### PR TITLE
feat: add Zod form validation for calendar events

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # FamilyHub Development Roadmap
 
-**Last Updated:** December 20, 2024
+**Last Updated:** December 20, 2025
 
 ## Current Status
 
@@ -23,7 +23,7 @@
 - [x] CalendarModule orchestrator component
 - [x] TanStack Query API layer with mock handlers
 - [x] Loading states and error handling
-- [ ] Form validation with Zod
+- [x] Form validation with Zod
 - [ ] Optimize event rendering performance
 
 **Sprint 5: PWA & Responsive**

--- a/src/components/ui/form-error.tsx
+++ b/src/components/ui/form-error.tsx
@@ -1,0 +1,13 @@
+interface FormErrorProps {
+  message?: string;
+}
+
+export function FormError({ message }: FormErrorProps) {
+  if (!message) return null;
+
+  return (
+    <p className="text-sm text-destructive mt-1" role="alert">
+      {message}
+    </p>
+  );
+}

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/**
+ * Schema for calendar event form validation
+ * Used by AddEventModal and future EditEventModal
+ */
+export const eventFormSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, "Event name is required")
+      .max(100, "Event name must be 100 characters or less"),
+    date: z.string().min(1, "Date is required"),
+    startTime: z.string().min(1, "Start time is required"),
+    endTime: z.string().min(1, "End time is required"),
+    memberId: z.string().min(1, "Please select a family member"),
+    location: z.string().optional(),
+    isAllDay: z.boolean().optional(),
+  })
+  .refine((data) => data.endTime > data.startTime, {
+    message: "End time must be after start time",
+    path: ["endTime"],
+  });
+
+/**
+ * TypeScript type inferred from the schema
+ * Use this for form data typing
+ */
+export type EventFormData = z.infer<typeof eventFormSchema>;

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -1,0 +1,1 @@
+export { type EventFormData, eventFormSchema } from "./calendar";


### PR DESCRIPTION
## Summary

- Add Zod schema validation for calendar event forms (`eventFormSchema`)
- Integrate react-hook-form with Zod resolver in AddEventModal
- Display field-level error messages with red borders on invalid inputs
- Add FormError component for consistent error styling

## Validation Rules

| Field | Rules |
|-------|-------|
| title | Required, max 100 chars |
| date | Required |
| startTime | Required |
| endTime | Required, must be after startTime |
| memberId | Required |

## Screenshots

### Before (no validation feedback)
<img width="2880" height="1564" alt="before-validation" src="https://github.com/user-attachments/assets/18133635-80da-43c7-83ed-2a45886ed59e" />

### After (with validation errors)
<img width="2880" height="1564" alt="after-validation" src="https://github.com/user-attachments/assets/4661c96c-080b-4733-b35a-5e3a41070aac" />


## Test plan

- [ ] Open Add Event modal and click "Add Event" without filling fields
- [ ] Verify all required field errors appear in red
- [ ] Fill start time as "10:00", end time as "09:00" - verify "End time must be after start time" error
- [ ] Fill all fields correctly - verify event creates successfully
- [ ] Verify form resets when modal closes