### PR TITLE
perf(calendar): optimize event rendering performance

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -56,6 +56,14 @@
     }
   },
   "files": {
-    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.json"]
+    "includes": [
+      "**/*.ts",
+      "**/*.tsx",
+      "**/*.js",
+      "**/*.json",
+      "!!dist",
+      "!!node_modules",
+      "!!.husky"
+    ]
   }
 }

--- a/docs/PERFORMANCE-BASELINE.md
+++ b/docs/PERFORMANCE-BASELINE.md
@@ -1,0 +1,98 @@
+# Calendar Performance Baseline
+
+**Date:** December 22, 2024
+**Branch:** `perf/calendar-rendering-optimization`
+
+## Test Environment
+
+- **Device:** [Your device]
+- **Browser:** Chrome [version]
+- **React Version:** 19.2.0
+- **React Compiler:** Not enabled (baseline)
+
+## Measurement Methodology
+
+1. **React DevTools Profiler** - Record interactions, measure render counts and durations
+2. **Chrome DevTools Performance** - Record 5-second traces
+3. **`<Profiler>` component** - Programmatic render timing
+
+## Baseline Metrics
+
+### Daily View
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Initial mount | ms | |
+| Navigation (prev/next) | ms | |
+| Filter toggle | ms | |
+| CalendarEventCard renders | count | Per navigation |
+
+### Weekly View
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Initial mount | ms | |
+| Navigation (prev/next) | ms | |
+| Filter toggle | ms | |
+| CalendarEventCard renders | count | Per navigation |
+| getEventsForDay() calls | 14 | Per render (7 headers + 7 columns) |
+
+### Monthly View
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Initial mount | ms | |
+| Navigation (prev/next) | ms | |
+| Filter toggle | ms | |
+| getEventsForDay() calls | ~70 | Per render (35 days × 2) |
+
+### Schedule View
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Initial mount | ms | |
+| Navigation (prev/next) | ms | |
+| Filter toggle | ms | |
+| getGroupedEvents() calls | 1 | But iterates 14 days internally |
+
+## Known Issues (Pre-optimization)
+
+1. **CalendarEventCard not memoized** - Re-renders on every parent update
+2. **O(n) family member lookups** - `familyMembers.find()` called per event
+3. **Duplicate parseTime()** - Regex compiled on every call in daily/weekly views
+4. **Multiple Zustand subscriptions** - 10 separate `useCalendarStore()` calls in CalendarModule
+5. **Redundant filtering** - getEventsForDay() called 14x (weekly) or 70x (monthly) per render
+
+---
+
+## Post-Optimization Metrics
+
+_To be filled in after optimizations are complete._
+
+### After React Compiler (Commit 1)
+
+| View | Mount | Navigation | Filter Toggle | Improvement |
+|------|-------|------------|---------------|-------------|
+| Daily | ms | ms | ms | % |
+| Weekly | ms | ms | ms | % |
+| Monthly | ms | ms | ms | % |
+| Schedule | ms | ms | ms | % |
+
+### After All Optimizations (Commit 6)
+
+| View | Mount | Navigation | Filter Toggle | Total Improvement |
+|------|-------|------------|---------------|-------------------|
+| Daily | ms | ms | ms | % |
+| Weekly | ms | ms | ms | % |
+| Monthly | ms | ms | ms | % |
+| Schedule | ms | ms | ms | % |
+
+## Summary
+
+| Optimization | Impact |
+|--------------|--------|
+| React Compiler | % improvement |
+| O(1) member lookups | % improvement |
+| Pre-computed eventsByDay | % improvement |
+| Zustand compound selectors | % improvement |
+| **Total** | **% improvement** |

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-query": "^5.90.12",
         "@tanstack/react-query-devtools": "^5.91.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -224,7 +225,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -233,7 +233,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -341,7 +340,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -3418,6 +3416,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
       }
     },
     "node_modules/baseline-browser-mapping": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^5.90.12",
     "@tanstack/react-query-devtools": "^5.91.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/calendar/CalendarModule.tsx
+++ b/src/components/calendar/CalendarModule.tsx
@@ -111,8 +111,7 @@ export function CalendarModule() {
     });
   }, [eventsResponse, filter]);
 
-  const handleEventClick = (event: CalendarEvent) => {
-    console.log("Event clicked:", event);
+  const handleEventClick = (_event: CalendarEvent) => {
     // Future: Open event detail modal
   };
 

--- a/src/components/calendar/CalendarModule.tsx
+++ b/src/components/calendar/CalendarModule.tsx
@@ -7,7 +7,7 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
-import { useMemo } from "react";
+import { Profiler, useMemo } from "react";
 import { useCalendarEvents, useCreateEvent } from "@/api";
 import {
   AddEventButton,
@@ -19,6 +19,7 @@ import {
   ScheduleCalendar,
   WeeklyCalendar,
 } from "@/components/calendar";
+import { logProfilerData } from "@/lib/perf-utils";
 import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import { useCalendarStore, useIsViewingToday } from "@/stores";
@@ -188,27 +189,29 @@ export function CalendarModule() {
   };
 
   return (
-    <div className="flex-1 flex flex-col overflow-hidden">
-      {/* Toolbar */}
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-4 py-3 bg-card border-b border-border">
-        <CalendarViewSwitcher />
-        <FamilyFilterPills />
+    <Profiler id="CalendarModule" onRender={logProfilerData}>
+      <div className="flex-1 flex flex-col overflow-hidden">
+        {/* Toolbar */}
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-4 py-3 bg-card border-b border-border">
+          <CalendarViewSwitcher />
+          <FamilyFilterPills />
+        </div>
+
+        {/* Calendar View */}
+        {renderCalendarView()}
+
+        {/* FAB */}
+        <AddEventButton onClick={openAddEventModal} />
+
+        {/* Modal */}
+        <EventFormModal
+          mode="add"
+          isOpen={isAddEventModalOpen}
+          onClose={closeAddEventModal}
+          onSubmit={handleAddEvent}
+          isPending={createEvent.isPending}
+        />
       </div>
-
-      {/* Calendar View */}
-      {renderCalendarView()}
-
-      {/* FAB */}
-      <AddEventButton onClick={openAddEventModal} />
-
-      {/* Modal */}
-      <EventFormModal
-        mode="add"
-        isOpen={isAddEventModalOpen}
-        onClose={closeAddEventModal}
-        onSubmit={handleAddEvent}
-        isPending={createEvent.isPending}
-      />
-    </div>
+    </Profiler>
   );
 }

--- a/src/components/calendar/CalendarModule.tsx
+++ b/src/components/calendar/CalendarModule.tsx
@@ -22,7 +22,11 @@ import {
 import { logProfilerData } from "@/lib/perf-utils";
 import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
-import { useCalendarStore, useIsViewingToday } from "@/stores";
+import {
+  useCalendarActions,
+  useCalendarState,
+  useIsViewingToday,
+} from "@/stores";
 
 // Helper to format time consistently (24h -> 12h AM/PM)
 function formatTime(time: string): string {
@@ -34,28 +38,20 @@ function formatTime(time: string): string {
 }
 
 export function CalendarModule() {
-  // Client state from Zustand
-  const currentDate = useCalendarStore((state) => state.currentDate);
-  const calendarView = useCalendarStore((state) => state.calendarView);
-  const filter = useCalendarStore((state) => state.filter);
-  const isAddEventModalOpen = useCalendarStore(
-    (state) => state.isAddEventModalOpen,
-  );
+  // Client state from Zustand (compound selector with shallow comparison)
+  const { currentDate, calendarView, filter, isAddEventModalOpen } =
+    useCalendarState();
   const isViewingToday = useIsViewingToday();
 
-  // Client actions from Zustand
-  const goToToday = useCalendarStore((state) => state.goToToday);
-  const goToPrevious = useCalendarStore((state) => state.goToPrevious);
-  const goToNext = useCalendarStore((state) => state.goToNext);
-  const selectDateAndSwitchToDaily = useCalendarStore(
-    (state) => state.selectDateAndSwitchToDaily,
-  );
-  const openAddEventModal = useCalendarStore(
-    (state) => state.openAddEventModal,
-  );
-  const closeAddEventModal = useCalendarStore(
-    (state) => state.closeAddEventModal,
-  );
+  // Client actions from Zustand (compound selector)
+  const {
+    goToToday,
+    goToPrevious,
+    goToNext,
+    selectDateAndSwitchToDaily,
+    openAddEventModal,
+    closeAddEventModal,
+  } = useCalendarActions();
 
   // Compute date range based on current view for API query
   const dateRange = useMemo(() => {

--- a/src/components/calendar/components/calendar-event.tsx
+++ b/src/components/calendar/components/calendar-event.tsx
@@ -1,4 +1,4 @@
-import { type CalendarEvent, colorMap, familyMembers } from "@/lib/types";
+import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface CalendarEventCardProps {
@@ -12,7 +12,7 @@ export function CalendarEventCard({
   onClick,
   variant = "default",
 }: CalendarEventCardProps) {
-  const member = familyMembers.find((m) => m.id === event.memberId);
+  const member = getFamilyMember(event.memberId);
   const colors = member ? colorMap[member.color] : colorMap["bg-coral"];
 
   if (variant === "large") {

--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -1,15 +1,12 @@
 import { Check } from "lucide-react";
 import { colorMap, familyMembers } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { useCalendarStore } from "@/stores";
+import { useFilterPillsState } from "@/stores";
 
 export function FamilyFilterPills() {
-  const filter = useCalendarStore((state) => state.filter);
-  const toggleMember = useCalendarStore((state) => state.toggleMember);
-  const toggleAllMembers = useCalendarStore((state) => state.toggleAllMembers);
-  const toggleAllDayEvents = useCalendarStore(
-    (state) => state.toggleAllDayEvents,
-  );
+  // Compound selector with shallow comparison (4 separate calls → 1)
+  const { filter, toggleMember, toggleAllMembers, toggleAllDayEvents } =
+    useFilterPillsState();
 
   const allSelected = filter.selectedMembers.length === familyMembers.length;
   const noneSelected = filter.selectedMembers.length === 0;

--- a/src/components/chores-view.tsx
+++ b/src/components/chores-view.tsx
@@ -1,7 +1,12 @@
 import { Check, RotateCcw, Star, Trophy } from "lucide-react";
 import { useState } from "react";
 import { generateSampleChores } from "@/lib/calendar-data";
-import { type ChoreItem, colorMap, familyMembers } from "@/lib/types";
+import {
+  type ChoreItem,
+  colorMap,
+  familyMembers,
+  getFamilyMember,
+} from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export function ChoresView() {
@@ -29,7 +34,7 @@ export function ChoresView() {
     {} as Record<string, ChoreItem[]>,
   );
 
-  const getMember = (id: string) => familyMembers.find((m) => m.id === id);
+  const getMember = (id: string) => getFamilyMember(id);
 
   return (
     <div className="flex-1 p-6 overflow-y-auto">

--- a/src/lib/perf-utils.ts
+++ b/src/lib/perf-utils.ts
@@ -1,0 +1,70 @@
+/**
+ * Performance measurement utilities for development.
+ * These helpers are no-ops in production builds.
+ */
+
+/**
+ * Wraps a function to measure and log its execution time.
+ * Only active in development mode.
+ */
+export function measurePerf<T>(name: string, fn: () => T): T {
+  if (import.meta.env.DEV) {
+    performance.mark(`${name}-start`);
+    const result = fn();
+    performance.mark(`${name}-end`);
+    performance.measure(name, `${name}-start`, `${name}-end`);
+    const measure = performance.getEntriesByName(name).pop();
+    console.log(`⏱️ ${name}: ${measure?.duration.toFixed(2)}ms`);
+    performance.clearMarks(`${name}-start`);
+    performance.clearMarks(`${name}-end`);
+    performance.clearMeasures(name);
+    return result;
+  }
+  return fn();
+}
+
+/**
+ * React Profiler onRender callback for logging render metrics.
+ * Use with React's <Profiler> component.
+ *
+ * @example
+ * <Profiler id="CalendarModule" onRender={logProfilerData}>
+ *   <CalendarModule />
+ * </Profiler>
+ */
+export function logProfilerData(
+  id: string,
+  phase: "mount" | "update" | "nested-update",
+  actualDuration: number,
+  baseDuration: number,
+  startTime: number,
+  commitTime: number,
+) {
+  if (import.meta.env.DEV) {
+    console.log(
+      `📊 [${id}] ${phase}: ${actualDuration.toFixed(2)}ms (base: ${baseDuration.toFixed(2)}ms)`,
+    );
+  }
+}
+
+/**
+ * Counter for tracking render counts.
+ * Useful for measuring how many times a component re-renders.
+ */
+const renderCounts = new Map<string, number>();
+
+export function countRender(componentName: string): void {
+  if (import.meta.env.DEV) {
+    const count = (renderCounts.get(componentName) ?? 0) + 1;
+    renderCounts.set(componentName, count);
+    console.log(`🔄 ${componentName} render #${count}`);
+  }
+}
+
+export function resetRenderCounts(): void {
+  renderCounts.clear();
+}
+
+export function getRenderCounts(): Map<string, number> {
+  return new Map(renderCounts);
+}

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared time parsing utilities for calendar components.
+ * Centralizes time parsing logic and compiles regex once for reuse.
+ */
+
+// Compile regex once, reuse across all calls
+const TIME_REGEX = /(\d+):(\d+)\s*(AM|PM)/i;
+
+export interface ParsedTime {
+  hours: number;
+  minutes: number;
+}
+
+/**
+ * Parse a time string like "9:30 AM" or "2:00 PM" into hours (24h) and minutes.
+ */
+export function parseTime(timeStr: string): ParsedTime {
+  const match = timeStr.match(TIME_REGEX);
+  if (!match) {
+    return { hours: 0, minutes: 0 };
+  }
+
+  let hours = Number.parseInt(match[1], 10);
+  const minutes = Number.parseInt(match[2], 10);
+  const period = match[3].toUpperCase();
+
+  // Convert to 24-hour format
+  if (period === "PM" && hours !== 12) {
+    hours += 12;
+  } else if (period === "AM" && hours === 12) {
+    hours = 0;
+  }
+
+  return { hours, minutes };
+}
+
+/**
+ * Convert a time string to total minutes since midnight.
+ * Useful for sorting and comparing events.
+ */
+export function getTimeInMinutes(timeStr: string): number {
+  const { hours, minutes } = parseTime(timeStr);
+  return hours * 60 + minutes;
+}
+
+/**
+ * Compare two events by their start time.
+ * Use as a comparator function for Array.sort().
+ */
+export function compareEventsByTime(
+  a: { startTime: string },
+  b: { startTime: string },
+): number {
+  return getTimeInMinutes(a.startTime) - getTimeInMinutes(b.startTime);
+}

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -14,6 +14,23 @@ export const familyMembers: FamilyMember[] = [
   { id: "6", name: "Family", color: "bg-yellow" },
 ];
 
+/**
+ * O(1) lookup map for family members by ID.
+ * Use getFamilyMember() instead of familyMembers.find() for better performance.
+ */
+export const familyMemberMap: Map<string, FamilyMember> = new Map(
+  familyMembers.map((m) => [m.id, m]),
+);
+
+/**
+ * Get a family member by ID with O(1) lookup.
+ * @param id - The family member ID
+ * @returns The family member or undefined if not found
+ */
+export function getFamilyMember(id: string): FamilyMember | undefined {
+  return familyMemberMap.get(id);
+}
+
 export const colorMap: Record<
   string,
   { bg: string; text: string; light: string }

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { useShallow } from "zustand/shallow";
 import type { CalendarViewType, FilterState } from "@/lib/types";
 import { familyMembers } from "@/lib/types";
 
@@ -171,3 +172,49 @@ export const useIsViewingToday = () =>
         return true;
     }
   });
+
+/**
+ * Compound selector for calendar state.
+ * Combines multiple state values into a single subscription with shallow comparison.
+ */
+export const useCalendarState = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      currentDate: state.currentDate,
+      calendarView: state.calendarView,
+      filter: state.filter,
+      isAddEventModalOpen: state.isAddEventModalOpen,
+    })),
+  );
+
+/**
+ * Compound selector for calendar actions.
+ * Combines multiple actions into a single subscription.
+ */
+export const useCalendarActions = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      goToToday: state.goToToday,
+      goToPrevious: state.goToPrevious,
+      goToNext: state.goToNext,
+      setDate: state.setDate,
+      selectDateAndSwitchToDaily: state.selectDateAndSwitchToDaily,
+      setCalendarView: state.setCalendarView,
+      openAddEventModal: state.openAddEventModal,
+      closeAddEventModal: state.closeAddEventModal,
+    })),
+  );
+
+/**
+ * Compound selector for filter pills component.
+ * Combines filter state and toggle actions.
+ */
+export const useFilterPillsState = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      filter: state.filter,
+      toggleMember: state.toggleMember,
+      toggleAllMembers: state.toggleAllMembers,
+      toggleAllDayEvents: state.toggleAllDayEvents,
+    })),
+  );

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,7 +2,13 @@
 export { type ModuleType, useAppStore } from "./app-store";
 
 // Calendar Store
-export { useCalendarStore, useIsViewingToday } from "./calendar-store";
+export {
+  useCalendarActions,
+  useCalendarState,
+  useCalendarStore,
+  useFilterPillsState,
+  useIsViewingToday,
+} from "./calendar-store";
 
 // Module Stores
 export { useChoresStore } from "./chores-store";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,13 @@ import { defineConfig } from "vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ["babel-plugin-react-compiler"],
+      },
+    }),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

- Enable React Compiler for automatic memoization
- Pre-compute calendar events by date (algorithmic optimization)
- Replace O(n) array lookups with O(1) Map lookups
- Optimize Zustand selectors with shallow comparison
- Consolidate duplicated time parsing utilities
- Fix buggy time sorting in schedule view (parseInt only reads first digit)

## Optimizations by Commit

1. **React Compiler** - Automatic memoization via `babel-plugin-react-compiler`
2. **Shared utilities** - `src/lib/time-utils.ts` with pre-compiled regex
3. **O(1) lookups** - `familyMemberMap` + `getFamilyMember()` function
4. **Zustand compound selectors** - `useCalendarState`, `useCalendarActions`, `useFilterPillsState`
5. **Pre-computed events** - Single-pass `useMemo` computation in all views:
   - Weekly: 14 calls → 1 Map computation
   - Monthly: 70 calls → 1 Map computation
   - Daily: Memoized O(n²) column layout
   - Schedule: Memoized grouped events + fixed sorting bug

---

## Performance Verification Results

### Monthly View Navigation (5 consecutive clicks)

| Click | Baseline | Optimized | Improvement |
|-------|----------|-----------|-------------|
| 1 | 12.10ms | 6.70ms | **45%** |
| 2 | 10.90ms | 4.20ms | **61%** |
| 3 | 8.00ms | 5.40ms | **33%** |
| 4 | 8.70ms | 4.90ms | **44%** |
| 5 | 8.90ms | 4.70ms | **47%** |
| **Average** | **9.72ms** | **5.18ms** | **47%** |

### View Switch Performance

| Metric | Baseline | Optimized | Improvement |
|--------|----------|-----------|-------------|
| Switch to Monthly | 14.60ms | 10.90ms | **25%** |

### Summary

| Optimization | Measured Impact |
|--------------|-----------------|
| Monthly navigation | **47% faster** (9.72ms → 5.18ms) |
| View switching | **25% faster** (14.60ms → 10.90ms) |

---

## How to Reproduce Performance Tests

### Option 1: Compare branches manually

```bash
# Baseline measurement (pre-optimization commit)
git checkout 73ef2ac
npm run dev
# Open http://localhost:5173, switch to Monthly view
# Click Next 5 times, watch console for 📊 profiler logs

# Optimized measurement
git checkout perf/calendar-rendering-optimization
npm run dev
# Repeat same interactions, compare profiler logs
```

### Option 2: Console Performance Script

Paste in DevTools Console while on calendar page (Monthly view):

```javascript
async function measureCalendarPerformance() {
  const results = { navigation: [] };

  // Measure 5 navigation clicks
  for (let i = 0; i < 5; i++) {
    const start = performance.now();
    document.querySelector('[aria-label="Next"]')?.click();
    await new Promise(r => setTimeout(r, 150));
    results.navigation.push(performance.now() - start);
  }

  console.table({
    'Avg Navigation (ms)': (results.navigation.reduce((a,b) => a+b) / results.navigation.length).toFixed(2)
  });
  return results;
}
measureCalendarPerformance();
```

### Option 3: React DevTools Profiler

1. Install React DevTools browser extension
2. Open DevTools → Profiler tab
3. Click Record (red circle)
4. Perform interactions (switch views, navigate, toggle filters)
5. Click Stop
6. Examine:
   - **Flamegraph**: See which components took longest
   - **Ranked**: Sort components by render time
   - **Commits**: Count how many re-renders occurred

---

## Files Changed

- `vite.config.ts` - Enable React Compiler
- `src/lib/time-utils.ts` - Shared time parsing utilities (new)
- `src/lib/perf-utils.ts` - Performance measurement utilities (new)
- `src/lib/types/family.ts` - O(1) member lookup Map
- `src/stores/calendar-store.ts` - Compound selectors
- `src/components/calendar/views/*.tsx` - Pre-computed events
- `src/components/calendar/components/calendar-event.tsx` - O(1) lookup
- `src/components/chores-view.tsx` - O(1) lookup
- `docs/PERFORMANCE-BASELINE.md` - Documentation

## Test plan

- [x] All 4 calendar views render correctly (Daily, Weekly, Monthly, Schedule)
- [x] React DevTools shows "Memo ✨" on optimized components
- [x] Event filtering by family member works
- [x] Navigation (prev/next/today) works
- [x] Filter pills toggle correctly
- [x] Performance verified: **47% improvement** in monthly navigation
- [x] `npm run build` passes
- [x] `npm run lint` passes