### PR TITLE
feat(calendar): add event detail view, edit, and delete functionality

### DIFF
--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -2,6 +2,7 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { calendarService } from "@/api/services";
+import { parseLocalDate } from "@/lib/time-utils";
 import type {
   ApiResponse,
   CalendarEvent,
@@ -104,7 +105,7 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
                     ...event,
                     ...updatedEvent,
                     date: updatedEvent.date
-                      ? new Date(updatedEvent.date)
+                      ? parseLocalDate(updatedEvent.date) // Parse as local date, not UTC
                       : event.date,
                   }
                 : event,

--- a/src/api/mocks/calendar.mock.ts
+++ b/src/api/mocks/calendar.mock.ts
@@ -1,5 +1,6 @@
 import { isWithinInterval, parseISO, startOfDay } from "date-fns";
 import { ApiErrorCode, ApiException } from "@/api/client";
+import { parseLocalDate } from "@/lib/time-utils";
 import type {
   ApiResponse,
   CalendarEvent,
@@ -237,7 +238,7 @@ export const calendarMockHandlers = {
       title: request.title,
       startTime: request.startTime,
       endTime: request.endTime,
-      date: new Date(request.date),
+      date: parseLocalDate(request.date), // Parse as local date, not UTC
       memberId: request.memberId,
       isAllDay: request.isAllDay,
       location: request.location,
@@ -268,7 +269,7 @@ export const calendarMockHandlers = {
       title: request.title ?? existingEvent.title,
       startTime: request.startTime ?? existingEvent.startTime,
       endTime: request.endTime ?? existingEvent.endTime,
-      date: request.date ? new Date(request.date) : existingEvent.date,
+      date: request.date ? parseLocalDate(request.date) : existingEvent.date, // Parse as local date, not UTC
       memberId: request.memberId ?? existingEvent.memberId,
       isAllDay: request.isAllDay ?? existingEvent.isAllDay,
       location: request.location ?? existingEvent.location,

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -3,7 +3,6 @@ import {
   endOfMonth,
   endOfWeek,
   format,
-  parseISO,
   startOfMonth,
   startOfWeek,
 } from "date-fns";
@@ -26,6 +25,7 @@ import {
   WeeklyCalendar,
 } from "@/components/calendar";
 import { logProfilerData } from "@/lib/perf-utils";
+import { format24hTo12h } from "@/lib/time-utils";
 import type {
   CalendarEvent,
   CreateEventRequest,
@@ -39,15 +39,6 @@ import {
   useEventDetailState,
   useIsViewingToday,
 } from "@/stores";
-
-// Helper to format time consistently (24h -> 12h AM/PM)
-function formatTime(time: string): string {
-  const [hours, minutes] = time.split(":");
-  const hour = Number.parseInt(hours, 10);
-  const ampm = hour >= 12 ? "PM" : "AM";
-  const hour12 = hour % 12 || 12;
-  return `${hour12}:${minutes} ${ampm}`;
-}
 
 export function CalendarModule() {
   // Client state from Zustand (compound selector with shallow comparison)
@@ -169,9 +160,9 @@ export function CalendarModule() {
     const request: UpdateEventRequest = {
       id: editingEvent.id,
       title: formData.title,
-      startTime: formatTime(formData.startTime),
-      endTime: formatTime(formData.endTime),
-      date: parseISO(formData.date).toISOString(),
+      startTime: format24hTo12h(formData.startTime),
+      endTime: format24hTo12h(formData.endTime),
+      date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
@@ -182,9 +173,9 @@ export function CalendarModule() {
   const handleAddEvent = (formData: EventFormData) => {
     const request: CreateEventRequest = {
       title: formData.title,
-      startTime: formatTime(formData.startTime),
-      endTime: formatTime(formData.endTime),
-      date: parseISO(formData.date).toISOString(),
+      startTime: format24hTo12h(formData.startTime),
+      endTime: format24hTo12h(formData.endTime),
+      date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -1,0 +1,129 @@
+import { format } from "date-fns";
+import { Calendar, Clock, MapPin, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { CalendarEvent } from "@/lib/types";
+import { colorMap, getFamilyMember } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface EventDetailModalProps {
+  event: CalendarEvent | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+  isDeleting?: boolean;
+  deleteError?: string | null;
+}
+
+function EventDetailModal({
+  event,
+  isOpen,
+  onClose,
+  onEdit,
+  onDelete,
+  isDeleting = false,
+  deleteError,
+}: EventDetailModalProps) {
+  if (!event) return null;
+
+  const member = getFamilyMember(event.memberId);
+  const colors = member ? colorMap[member.color] : null;
+
+  // Format date for display (e.g., "Monday, December 23, 2025")
+  const formattedDate = format(event.date, "EEEE, MMMM d, yyyy");
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <DialogHeader onClose={onClose}>
+          <DialogTitle className="pr-8 truncate">{event.title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Member badge */}
+          <div className="flex items-center gap-3">
+            <div
+              className={cn(
+                "w-10 h-10 rounded-full flex items-center justify-center text-white font-bold text-sm shrink-0",
+                colors?.bg ? `bg-[${colors.bg}]` : "bg-muted-foreground",
+              )}
+              style={{ backgroundColor: colors?.bg }}
+            >
+              {member?.name.charAt(0)}
+            </div>
+            <span className="font-medium text-foreground">{member?.name}</span>
+          </div>
+
+          {/* Event details */}
+          <div className="space-y-3 text-sm">
+            {/* Date */}
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <Calendar className="w-4 h-4 shrink-0" />
+              <span>{formattedDate}</span>
+            </div>
+
+            {/* Time */}
+            <div className="flex items-center gap-3 text-muted-foreground">
+              <Clock className="w-4 h-4 shrink-0" />
+              {event.isAllDay ? (
+                <span className="px-2 py-0.5 bg-muted rounded text-xs font-medium">
+                  All day
+                </span>
+              ) : (
+                <span>
+                  {event.startTime} – {event.endTime}
+                </span>
+              )}
+            </div>
+
+            {/* Location (conditional) */}
+            {event.location && (
+              <div className="flex items-center gap-3 text-muted-foreground">
+                <MapPin className="w-4 h-4 shrink-0" />
+                <span className="truncate">{event.location}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Error message */}
+          {deleteError && (
+            <div className="text-destructive text-sm text-center py-2">
+              Failed to delete event. Please try again.
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onEdit}
+            disabled={isDeleting}
+            className="flex-1 min-h-[48px]"
+          >
+            <Pencil className="w-4 h-4 mr-2" />
+            Edit
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={onDelete}
+            disabled={isDeleting}
+            className="flex-1 min-h-[48px]"
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            {isDeleting ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { EventDetailModal };
+export type { EventDetailModalProps };

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
-import { Calendar, Clock, MapPin, Pencil, Trash2 } from "lucide-react";
+import { Calendar, Clock, Loader2, MapPin, Pencil, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -31,10 +32,31 @@ function EventDetailModal({
   isDeleting = false,
   deleteError,
 }: EventDetailModalProps) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  // Reset confirmation state when modal closes or event changes
+  useEffect(() => {
+    if (!isOpen) {
+      setShowDeleteConfirm(false);
+    }
+  }, [isOpen]);
+
   if (!event) return null;
 
   const member = getFamilyMember(event.memberId);
   const colors = member ? colorMap[member.color] : null;
+
+  const handleDeleteClick = () => {
+    setShowDeleteConfirm(true);
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteConfirm(false);
+  };
+
+  const handleConfirmDelete = () => {
+    onDelete();
+  };
 
   // Format date for display (e.g., "Monday, December 23, 2025")
   const formattedDate = format(event.date, "EEEE, MMMM d, yyyy");
@@ -100,25 +122,60 @@ function EventDetailModal({
           )}
         </div>
 
-        <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={onEdit}
-            disabled={isDeleting}
-            className="flex-1 min-h-[48px]"
-          >
-            <Pencil className="w-4 h-4 mr-2" />
-            Edit
-          </Button>
-          <Button
-            variant="destructive"
-            onClick={onDelete}
-            disabled={isDeleting}
-            className="flex-1 min-h-[48px]"
-          >
-            <Trash2 className="w-4 h-4 mr-2" />
-            {isDeleting ? "Deleting..." : "Delete"}
-          </Button>
+        <DialogFooter className="flex-col gap-3">
+          {showDeleteConfirm ? (
+            <>
+              <p className="text-sm text-muted-foreground text-center w-full">
+                Are you sure you want to delete this event?
+              </p>
+              <div className="flex gap-3 w-full">
+                <Button
+                  variant="outline"
+                  onClick={handleCancelDelete}
+                  disabled={isDeleting}
+                  className="flex-1 min-h-[48px]"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={handleConfirmDelete}
+                  disabled={isDeleting}
+                  className="flex-1 min-h-[48px]"
+                >
+                  {isDeleting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                      Deleting...
+                    </>
+                  ) : (
+                    "Delete Event"
+                  )}
+                </Button>
+              </div>
+            </>
+          ) : (
+            <div className="flex gap-3 w-full">
+              <Button
+                variant="outline"
+                onClick={onEdit}
+                disabled={isDeleting}
+                className="flex-1 min-h-[48px]"
+              >
+                <Pencil className="w-4 h-4 mr-2" />
+                Edit
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDeleteClick}
+                disabled={isDeleting}
+                className="flex-1 min-h-[48px]"
+              >
+                <Trash2 className="w-4 h-4 mr-2" />
+                Delete
+              </Button>
+            </div>
+          )}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -74,9 +74,8 @@ function EventDetailModal({
             <div
               className={cn(
                 "w-10 h-10 rounded-full flex items-center justify-center text-white font-bold text-sm shrink-0",
-                colors?.bg ? `bg-[${colors.bg}]` : "bg-muted-foreground",
+                colors?.bg || "bg-muted-foreground",
               )}
-              style={{ backgroundColor: colors?.bg }}
             >
               {member?.name.charAt(0)}
             </div>

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { parseTime } from "@/lib/time-utils";
 import type { CalendarEvent } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import { EventForm } from "./event-form";
@@ -19,8 +20,17 @@ interface EventFormModalProps {
 }
 
 /**
+ * Convert 12h time (e.g., "4:00 PM") to 24h format (e.g., "16:00")
+ * The form/TimePicker uses 24h format internally
+ */
+function convertTo24hFormat(timeStr: string): string {
+  const { hours, minutes } = parseTime(timeStr);
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+}
+
+/**
  * Transform a CalendarEvent to EventFormData for the form
- * Handles date formatting and any field mapping
+ * Handles date formatting and time conversion (12h -> 24h)
  */
 function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
   // Format date as yyyy-MM-dd string
@@ -32,8 +42,8 @@ function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
   return {
     title: event.title,
     date: dateStr,
-    startTime: event.startTime,
-    endTime: event.endTime,
+    startTime: convertTo24hFormat(event.startTime),
+    endTime: convertTo24hFormat(event.endTime),
     memberId: event.memberId,
     location: event.location,
     isAllDay: event.isAllDay,

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -1,11 +1,10 @@
-import { format } from "date-fns";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { parseTime } from "@/lib/time-utils";
+import { format12hTo24h, formatLocalDate } from "@/lib/time-utils";
 import type { CalendarEvent } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import { EventForm } from "./event-form";
@@ -21,31 +20,21 @@ interface EventFormModalProps {
 }
 
 /**
- * Convert 12h time (e.g., "4:00 PM") to 24h format (e.g., "16:00")
- * The form/TimePicker uses 24h format internally
- */
-function convertTo24hFormat(timeStr: string): string {
-  const { hours, minutes } = parseTime(timeStr);
-  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
-}
-
-/**
  * Transform a CalendarEvent to EventFormData for the form
  * Handles date formatting and time conversion (12h -> 24h)
  */
 function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
   // Format date as yyyy-MM-dd string using local timezone (not UTC)
-  // toISOString() would convert to UTC and shift the date incorrectly
   const dateStr =
     event.date instanceof Date
-      ? format(event.date, "yyyy-MM-dd")
+      ? formatLocalDate(event.date)
       : String(event.date).split("T")[0];
 
   return {
     title: event.title,
     date: dateStr,
-    startTime: convertTo24hFormat(event.startTime),
-    endTime: convertTo24hFormat(event.endTime),
+    startTime: format12hTo24h(event.startTime),
+    endTime: format12hTo24h(event.endTime),
     memberId: event.memberId,
     location: event.location,
     isAllDay: event.isAllDay,

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import {
   Dialog,
   DialogContent,
@@ -33,10 +34,11 @@ function convertTo24hFormat(timeStr: string): string {
  * Handles date formatting and time conversion (12h -> 24h)
  */
 function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
-  // Format date as yyyy-MM-dd string
+  // Format date as yyyy-MM-dd string using local timezone (not UTC)
+  // toISOString() would convert to UTC and shift the date incorrectly
   const dateStr =
     event.date instanceof Date
-      ? event.date.toISOString().split("T")[0]
+      ? format(event.date, "yyyy-MM-dd")
       : String(event.date).split("T")[0];
 
   return {

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MemberSelector } from "@/components/ui/member-selector";
 import { TimePicker } from "@/components/ui/time-picker";
+import { parseLocalDate } from "@/lib/time-utils";
 import { familyMembers } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { type EventFormData, eventFormSchema } from "@/lib/validations";
@@ -97,8 +98,8 @@ function EventForm({
   };
 
   // Convert date string to Date object for DatePicker display
-  // Append T00:00:00 to parse as local midnight (not UTC)
-  const dateAsDate = dateValue ? new Date(dateValue + "T00:00:00") : undefined;
+  // Use parseLocalDate to ensure consistent local timezone handling
+  const dateAsDate = dateValue ? parseLocalDate(dateValue) : undefined;
 
   const isAdd = mode === "add";
   const submitText = isAdd ? "Add Event" : "Save Changes";

--- a/src/components/calendar/components/index.ts
+++ b/src/components/calendar/components/index.ts
@@ -6,6 +6,7 @@ export { CalendarFilter } from "./calendar-filter";
 export { CalendarNavigation } from "./calendar-navigation";
 export { CalendarViewSwitcher } from "./calendar-view-switcher";
 export { CurrentTimeIndicator } from "./current-time-indicator";
+export { EventDetailModal } from "./event-detail-modal";
 export { EventForm } from "./event-form";
 export { EventFormModal } from "./event-form-modal";
 export { FamilyFilterPills } from "./family-filter-pills";

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -1,7 +1,7 @@
 import { Clock, MapPin } from "lucide-react";
 import type React from "react";
 import { useMemo } from "react";
-import { compareEventsByTime } from "@/lib/time-utils";
+import { compareEventsByTime, formatLocalDate } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { FilterState } from "../components/calendar-filter";
@@ -77,7 +77,7 @@ export function ScheduleCalendar({
       ) : (
         <div className="space-y-6 max-w-3xl mx-auto">
           {groupedEvents.map(({ date, events: dayEvents }) => (
-            <div key={date.toISOString()}>
+            <div key={formatLocalDate(date)}>
               {/* Date header */}
               <div
                 className={cn(

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -3,6 +3,8 @@
  * Centralizes time parsing logic and compiles regex once for reuse.
  */
 
+import { format, parseISO, startOfDay } from "date-fns";
+
 // Compile regex once, reuse across all calls
 const TIME_REGEX = /(\d+):(\d+)\s*(AM|PM)/i;
 
@@ -52,4 +54,43 @@ export function compareEventsByTime(
   b: { startTime: string },
 ): number {
   return getTimeInMinutes(a.startTime) - getTimeInMinutes(b.startTime);
+}
+
+/**
+ * Convert 24-hour time format to 12-hour format with AM/PM.
+ * Example: "16:00" -> "4:00 PM", "09:30" -> "9:30 AM"
+ */
+export function format24hTo12h(time24h: string): string {
+  const [hours, minutes] = time24h.split(":");
+  const hour = Number.parseInt(hours, 10);
+  const ampm = hour >= 12 ? "PM" : "AM";
+  const hour12 = hour % 12 || 12;
+  return `${hour12}:${minutes} ${ampm}`;
+}
+
+/**
+ * Convert 12-hour time format to 24-hour format.
+ * Example: "4:00 PM" -> "16:00", "9:30 AM" -> "09:30"
+ */
+export function format12hTo24h(time12h: string): string {
+  const { hours, minutes } = parseTime(time12h);
+  return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Format a Date to a local date string (yyyy-MM-dd).
+ * Uses date-fns format() which respects local timezone,
+ * avoiding the timezone shift bug from toISOString().
+ */
+export function formatLocalDate(date: Date): string {
+  return format(date, "yyyy-MM-dd");
+}
+
+/**
+ * Parse a date string (yyyy-MM-dd) to a local Date at midnight.
+ * Uses date-fns to ensure consistent local timezone handling,
+ * avoiding the browser-specific quirk of appending "T00:00:00".
+ */
+export function parseLocalDate(dateStr: string): Date {
+  return startOfDay(parseISO(dateStr));
 }

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -1,5 +1,18 @@
 import { z } from "zod";
 
+// Time format validation patterns
+const DATE_FORMAT_REGEX = /^\d{4}-\d{2}-\d{2}$/; // yyyy-MM-dd
+const TIME_24H_FORMAT_REGEX = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/; // HH:mm (24h)
+
+/**
+ * Convert 24h time string (HH:mm) to minutes since midnight.
+ * Used for numeric comparison of times.
+ */
+function getTimeInMinutes(time: string): number {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
 /**
  * Schema for calendar event form validation
  * Used by AddEventModal and future EditEventModal
@@ -10,17 +23,29 @@ export const eventFormSchema = z
       .string()
       .min(1, "Event name is required")
       .max(100, "Event name must be 100 characters or less"),
-    date: z.string().min(1, "Date is required"),
-    startTime: z.string().min(1, "Start time is required"),
-    endTime: z.string().min(1, "End time is required"),
+    date: z
+      .string()
+      .min(1, "Date is required")
+      .regex(DATE_FORMAT_REGEX, "Invalid date format"),
+    startTime: z
+      .string()
+      .min(1, "Start time is required")
+      .regex(TIME_24H_FORMAT_REGEX, "Invalid time format"),
+    endTime: z
+      .string()
+      .min(1, "End time is required")
+      .regex(TIME_24H_FORMAT_REGEX, "Invalid time format"),
     memberId: z.string().min(1, "Please select a family member"),
     location: z.string().optional(),
     isAllDay: z.boolean().optional(),
   })
-  .refine((data) => data.endTime > data.startTime, {
-    message: "End time must be after start time",
-    path: ["endTime"],
-  });
+  .refine(
+    (data) => getTimeInMinutes(data.endTime) > getTimeInMinutes(data.startTime),
+    {
+      message: "End time must be after start time",
+      path: ["endTime"],
+    },
+  );
 
 /**
  * TypeScript type inferred from the schema

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
-import type { CalendarViewType, FilterState } from "@/lib/types";
+import type { CalendarEvent, CalendarViewType, FilterState } from "@/lib/types";
 import { familyMembers } from "@/lib/types";
 
 interface CalendarState {
@@ -10,6 +10,14 @@ interface CalendarState {
   calendarView: CalendarViewType;
   filter: FilterState;
   isAddEventModalOpen: boolean;
+
+  // Event detail modal state
+  selectedEvent: CalendarEvent | null;
+  isDetailModalOpen: boolean;
+
+  // Edit modal state (separate from add)
+  editingEvent: CalendarEvent | null;
+  isEditModalOpen: boolean;
 
   // Navigation actions
   goToToday: () => void;
@@ -30,6 +38,14 @@ interface CalendarState {
   // Modal actions
   openAddEventModal: () => void;
   closeAddEventModal: () => void;
+
+  // Detail modal actions
+  openDetailModal: (event: CalendarEvent) => void;
+  closeDetailModal: () => void;
+
+  // Edit modal actions
+  openEditModal: (event: CalendarEvent) => void;
+  closeEditModal: () => void;
 }
 
 export const useCalendarStore = create<CalendarState>()(
@@ -43,6 +59,14 @@ export const useCalendarStore = create<CalendarState>()(
         showAllDayEvents: true,
       },
       isAddEventModalOpen: false,
+
+      // Event detail modal state
+      selectedEvent: null,
+      isDetailModalOpen: false,
+
+      // Edit modal state
+      editingEvent: null,
+      isEditModalOpen: false,
 
       // Navigation actions
       goToToday: () => set({ currentDate: new Date() }),
@@ -134,6 +158,21 @@ export const useCalendarStore = create<CalendarState>()(
       // Modal actions
       openAddEventModal: () => set({ isAddEventModalOpen: true }),
       closeAddEventModal: () => set({ isAddEventModalOpen: false }),
+
+      // Detail modal actions
+      openDetailModal: (event) =>
+        set({ selectedEvent: event, isDetailModalOpen: true }),
+      closeDetailModal: () =>
+        set({ selectedEvent: null, isDetailModalOpen: false }),
+
+      // Edit modal actions
+      openEditModal: (event) =>
+        set({
+          editingEvent: event,
+          isEditModalOpen: true,
+          isDetailModalOpen: false, // Close detail when opening edit
+        }),
+      closeEditModal: () => set({ editingEvent: null, isEditModalOpen: false }),
     }),
     {
       name: "family-hub-calendar",
@@ -202,6 +241,35 @@ export const useCalendarActions = () =>
       setCalendarView: state.setCalendarView,
       openAddEventModal: state.openAddEventModal,
       closeAddEventModal: state.closeAddEventModal,
+      openEditModal: state.openEditModal,
+      closeEditModal: state.closeEditModal,
+    })),
+  );
+
+/**
+ * Compound selector for event detail modal.
+ * Combines detail modal state and actions.
+ */
+export const useEventDetailState = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      selectedEvent: state.selectedEvent,
+      isDetailModalOpen: state.isDetailModalOpen,
+      openDetailModal: state.openDetailModal,
+      closeDetailModal: state.closeDetailModal,
+    })),
+  );
+
+/**
+ * Compound selector for edit modal state.
+ */
+export const useEditModalState = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      editingEvent: state.editingEvent,
+      isEditModalOpen: state.isEditModalOpen,
+      openEditModal: state.openEditModal,
+      closeEditModal: state.closeEditModal,
     })),
   );
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -6,6 +6,8 @@ export {
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
+  useEditModalState,
+  useEventDetailState,
   useFilterPillsState,
   useIsViewingToday,
 } from "./calendar-store";


### PR DESCRIPTION
## Summary

Complete CRUD functionality for calendar events by making event pills clickable and enabling view, edit, and delete operations.

- Add `EventDetailModal` component showing event info with Edit/Delete buttons
- Implement inline delete confirmation (no separate dialog)
- Wire event click across all 4 calendar views (daily, weekly, monthly, schedule)
- Integrate edit mode with existing `EventFormModal`
- Add Zustand state management for detail and edit modals

## Changes

### New Files
- `src/components/calendar/components/event-detail-modal.tsx` - Detail view modal

### Modified Files
- `src/stores/calendar-store.ts` - Add selectedEvent, detail/edit modal state
- `src/stores/index.ts` - Export new selectors
- `src/components/calendar/calendar-module.tsx` - Wire handlers and render modals
- `src/components/calendar/components/index.ts` - Export EventDetailModal

## Screenshots

<!-- Upload screenshots via GitHub web interface -->
- Event detail modal (member info, date, time, location)
- Delete confirmation state
- Edit form pre-filled with event data

## Test Plan

- [x] Click event in Daily view → detail modal opens
- [x] Click event in Weekly view → detail modal opens
- [x] Click event in Monthly view (pill) → detail modal opens
- [x] Click event in Schedule view → detail modal opens
- [x] Edit button → form modal with pre-filled data
- [x] Save edit → event updates, modal closes
- [x] Delete button → inline confirmation appears
- [x] Cancel delete → returns to action buttons
- [x] Confirm delete → event removed (optimistic), modal closes
- [x] Escape key closes modals