### PR TITLE
fix(family): add validation and accessibility improvements

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -8,24 +8,13 @@ This document tracks known technical debt, deferred improvements, and future enh
 
 ## High Priority (Address Soon)
 
-### 1. Data Validation on Rehydration
-**Source:** PR #10 Review (Sprint 5)
-**File:** `src/stores/family-store.ts`
-**Status:** Deferred
-
-**Problem:**
-Persisted data is not validated after loading from localStorage. If the data structure changes in a future release or gets corrupted, the app could crash.
-
-**Suggested Fix:**
-- Add Zod schema validation after hydration
-- Add `version` field to storage config for migrations
-- Clear invalid data and restart onboarding if validation fails
+_No high priority items at this time._
 
 ---
 
 ## Medium Priority (Future Sprint)
 
-### 2. Orphaned Events Warning
+### 1. Orphaned Events Warning
 **Source:** PR #10 Review (Sprint 5)
 **Files:** `src/stores/family-store.ts`, `src/components/settings/family-settings-modal.tsx`
 **Status:** Deferred to Backend Integration
@@ -43,37 +32,9 @@ When a member is deleted:
 
 ---
 
-### 3. Duplicate Member Name Validation
-**Source:** PR #10 Review (Sprint 5)
-**File:** `src/lib/validations/family.ts`
-**Status:** Deferred
-
-**Problem:**
-Users can add members with duplicate names (e.g., two "John"s).
-
-**Suggested Fix:**
-Add Zod refinement with context:
-```typescript
-memberFormSchema.refine(
-  (data, ctx) => {
-    const existingNames = ctx.existingMembers?.map(m => m.name.toLowerCase());
-    return !existingNames?.includes(data.name.toLowerCase());
-  },
-  { message: "A member with this name already exists" }
-);
-```
-
----
-
 ## Low Priority (Nice to Have)
 
-### 4. Form Accessibility (aria-describedby)
-**Source:** PR #10 Review (Sprint 5)
-**Files:** All form components
-**Status:** Enhancement
-
-**Problem:**
-Form error messages aren't linked to inputs via `aria-describedby`. Screen reader users won't hear validation errors when focused on inputs.
+_No low priority items at this time._
 
 ---
 
@@ -98,6 +59,9 @@ These items should be addressed when integrating with the backend API:
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| Data Validation on Rehydration (Zod schema) | Sprint 5 | - | Dec 27, 2025 |
+| Duplicate Member Name Validation | Sprint 5 | - | Dec 27, 2025 |
+| Form Accessibility (aria-describedby) | Sprint 5 | - | Dec 27, 2025 |
 | localStorage Error Handling | Sprint 5 | #10 | Dec 27, 2025 |
 | Remove Dead Code from AppStore | Sprint 5 | #10 | Dec 27, 2025 |
 | Color Picker Code Duplication | Sprint 5 | #10 | Dec 27, 2025 |

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -56,19 +56,26 @@ export function OnboardingFamilyName({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="familyName" className="sr-only">
+            <Label htmlFor="onboarding-family-name" className="sr-only">
               Family Name
             </Label>
             <Input
-              id="familyName"
+              id="onboarding-family-name"
               placeholder="The Smiths"
               className="text-center text-lg h-14"
               autoComplete="off"
               autoFocus
+              aria-describedby={
+                errors.name ? "onboarding-family-name-error" : undefined
+              }
+              aria-invalid={errors.name ? "true" : undefined}
               {...register("name")}
             />
             {errors.name && (
-              <p className="text-sm text-destructive text-center">
+              <p
+                id="onboarding-family-name-error"
+                className="text-sm text-destructive text-center"
+              >
                 {errors.name.message}
               </p>
             )}

--- a/src/components/onboarding/onboarding-members.tsx
+++ b/src/components/onboarding/onboarding-members.tsx
@@ -134,6 +134,7 @@ export function OnboardingMembers({
         mode={editingMember ? "edit" : "add"}
         member={editingMember ?? undefined}
         usedColors={usedColorsForForm as FamilyColor[]}
+        existingNames={members.map((m) => m.name)}
         onSubmit={handleFormSubmit}
       />
     </div>

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -132,9 +132,16 @@ export function FamilySettingsModal({
                     id="familyName"
                     placeholder="Enter family name"
                     {...register("name")}
+                    aria-describedby={
+                      errors.name ? "family-name-error" : undefined
+                    }
+                    aria-invalid={errors.name ? "true" : undefined}
                   />
                   {errors.name && (
-                    <p className="text-sm text-destructive">
+                    <p
+                      id="family-name-error"
+                      className="text-sm text-destructive"
+                    >
                       {errors.name.message}
                     </p>
                   )}
@@ -222,6 +229,7 @@ export function FamilySettingsModal({
         mode={editingMember ? "edit" : "add"}
         member={editingMember ?? undefined}
         usedColors={usedColorsForForm as FamilyColor[]}
+        existingNames={familyMembers.map((m) => m.name)}
         onSubmit={handleMemberFormSubmit}
       />
 

--- a/src/components/ui/color-picker.tsx
+++ b/src/components/ui/color-picker.tsx
@@ -7,6 +7,8 @@ interface ColorPickerProps {
   onChange: (color: FamilyColor) => void;
   usedColors?: FamilyColor[];
   error?: string;
+  /** ID for the error message element, used for aria-describedby */
+  errorId?: string;
 }
 
 export function ColorPicker({
@@ -14,10 +16,15 @@ export function ColorPicker({
   onChange,
   usedColors = [],
   error,
+  errorId = "color-picker-error",
 }: ColorPickerProps) {
   return (
-    <div className="space-y-2">
-      <div className="flex flex-wrap gap-3 justify-center">
+    <fieldset className="space-y-2 border-0 p-0 m-0">
+      <legend className="sr-only">Select a color</legend>
+      <div
+        aria-describedby={error ? errorId : undefined}
+        className="flex flex-wrap gap-3 justify-center"
+      >
         {familyColors.map((color) => {
           const colors = colorMap[color];
           const isSelected = value === color;
@@ -43,7 +50,11 @@ export function ColorPicker({
           );
         })}
       </div>
-      {error && <p className="text-sm text-destructive text-center">{error}</p>}
-    </div>
+      {error && (
+        <p id={errorId} className="text-sm text-destructive text-center">
+          {error}
+        </p>
+      )}
+    </fieldset>
   );
 }

--- a/src/stores/family-store.ts
+++ b/src/stores/family-store.ts
@@ -8,6 +8,7 @@ import {
   type FamilyMember,
   familyColors,
 } from "@/lib/types";
+import { validateFamilyData } from "@/lib/validations/family";
 
 interface FamilyState {
   // State
@@ -131,6 +132,14 @@ export const useFamilyStore = create<FamilyState>()(
           console.error("Failed to rehydrate family store:", error);
           // Clear corrupted data - will trigger onboarding
           localStorage.removeItem("family-hub-family");
+        } else if (state?.family) {
+          // Validate the structure of rehydrated data
+          const validatedData = validateFamilyData(state.family);
+          if (!validatedData) {
+            console.warn("Invalid family data structure, resetting store");
+            localStorage.removeItem("family-hub-family");
+            state.resetFamily();
+          }
         }
         state?.setHasHydrated(true);
       },


### PR DESCRIPTION
## Summary

- Add Zod schema validation during localStorage rehydration to catch corrupted data
- Add duplicate member name validation with case-insensitive check  
- Add `aria-describedby` and `aria-invalid` to form error messages for screen reader accessibility
- Use semantic `<fieldset>/<legend>` for color picker accessibility

## Changes

### Data Validation (`src/lib/validations/family.ts`)
- Added `familyDataSchema` and `familyMemberSchema` for validating stored data
- Added `createMemberFormSchema()` factory function for duplicate name validation
- Added `validateFamilyData()` function for rehydration validation

### Form Accessibility
- Added `aria-describedby` linking inputs to their error messages
- Added `aria-invalid` attribute when fields have validation errors
- Used `<fieldset>` with `<legend>` for color picker (semantic HTML)

### Store Updates (`src/stores/family-store.ts`)
- Integrated `validateFamilyData()` in `onRehydrateStorage` callback
- Invalid data triggers store reset and localStorage cleanup

## Test Plan

- [x] Try adding a member with a duplicate name (case-insensitive) - should show error
- [x] Manually corrupt localStorage and reload - should trigger onboarding
- [ ] Test with screen reader to verify error messages are announced
- [x] Verify all forms still work correctly