### PR TITLE
fix(calendar): clamp day when navigating months to avoid overflow

### DIFF
--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -1,0 +1,344 @@
+import { waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { createTestEvent, testEvents, testMembers } from "@/test/fixtures";
+import {
+  API_BASE,
+  getMockEvents,
+  resetMockEvents,
+  seedMockEvents,
+  server,
+} from "@/test/mocks/server";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedCalendarStore,
+  seedFamilyStore,
+} from "@/test/test-utils";
+import { CalendarModule } from "./calendar-module";
+
+// Mock useIsMobile hook for consistent viewport
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return {
+    ...actual,
+    useIsMobile: () => false,
+  };
+});
+
+describe("CalendarModule", () => {
+  // Setup MSW lifecycle hooks
+  beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+  afterEach(() => {
+    server.resetHandlers();
+    resetMockEvents();
+  });
+  afterAll(() => server.close());
+
+  // Seed family store before each test (most tests need family data)
+  beforeEach(() => {
+    seedFamilyStore({
+      name: "Test Family",
+      members: testMembers,
+      setupComplete: true,
+    });
+    // Initialize filter with all members selected
+    seedCalendarStore({
+      filter: {
+        selectedMembers: testMembers.map((m) => m.id),
+        showAllDayEvents: true,
+      },
+    });
+  });
+
+  describe("Loading & Error States", () => {
+    it("shows loading indicator while fetching events", async () => {
+      // Delay the response to ensure loading state is visible
+      server.use(
+        http.get(`${API_BASE}/calendar/events`, async () => {
+          await new Promise((r) => setTimeout(r, 100));
+          return HttpResponse.json({ data: [] });
+        }),
+      );
+
+      render(<CalendarModule />);
+
+      expect(screen.getByText("Loading events...")).toBeInTheDocument();
+    });
+
+    it("shows error message when API fails", async () => {
+      server.use(
+        http.get(`${API_BASE}/calendar/events`, () => {
+          return HttpResponse.json(
+            { message: "Internal server error" },
+            { status: 500 },
+          );
+        }),
+      );
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Error loading events/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows events after successful fetch", async () => {
+      const event = createTestEvent({ title: "Team Meeting" });
+      seedMockEvents([event]);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Team Meeting")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Event Display & Filtering", () => {
+    it("displays events for current date range", async () => {
+      seedMockEvents(testEvents);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+        expect(screen.getByText("Lunch with Team")).toBeInTheDocument();
+      });
+    });
+
+    it("filters events by selected family member", async () => {
+      // Only select first member
+      seedCalendarStore({
+        filter: {
+          selectedMembers: [testMembers[0].id],
+          showAllDayEvents: true,
+        },
+      });
+      seedMockEvents(testEvents);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        // First member's event should be visible
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+      });
+
+      // Second member's event should not be visible
+      expect(screen.queryByText("Lunch with Team")).not.toBeInTheDocument();
+    });
+
+    it("filters out all-day events when toggle is off", async () => {
+      seedCalendarStore({
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: false,
+        },
+      });
+      seedMockEvents(testEvents);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+      });
+
+      // All-day event should not be visible
+      expect(screen.queryByText("All Day Event")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Add Event Flow", () => {
+    it("opens add event modal when FAB clicked", async () => {
+      seedMockEvents([]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      const addButton = screen.getByRole("button", { name: /add event/i });
+      await user.click(addButton);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Add Event" }),
+      ).toBeInTheDocument();
+    });
+
+    it("submits new event to API and shows it in calendar", async () => {
+      seedMockEvents([]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      // Open modal
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      // Wait for dialog to open
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Fill in the form
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.clear(titleInput);
+      await user.type(titleInput, "New Test Event");
+
+      // Submit the form (find button within dialog)
+      const dialog = screen.getByRole("dialog");
+      const submitButton = dialog.querySelector('button[type="submit"]');
+      expect(submitButton).toBeInTheDocument();
+      await user.click(submitButton!);
+
+      // Modal should close after successful submission
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Verify event was created in mock storage
+      const mockEvents = getMockEvents();
+      expect(mockEvents).toHaveLength(1);
+      expect(mockEvents[0].title).toBe("New Test Event");
+
+      // Wait for the refetch to complete and event to appear
+      await waitFor(
+        () => {
+          expect(screen.getByText("New Test Event")).toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+    });
+
+    it("keeps modal open and shows error on API failure", async () => {
+      seedMockEvents([]);
+
+      // Make create fail
+      server.use(
+        http.post(`${API_BASE}/calendar/events`, () => {
+          return HttpResponse.json(
+            { message: "Failed to create event" },
+            { status: 500 },
+          );
+        }),
+      );
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      // Open modal
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Fill and submit
+      await user.type(screen.getByLabelText(/event name/i), "Failing Event");
+      const dialog = screen.getByRole("dialog");
+      const submitButton = dialog.querySelector('button[type="submit"]');
+      await user.click(submitButton!);
+
+      // Modal should stay open after failed request
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("View Event Details", () => {
+    it("renders events with clickable structure", async () => {
+      const event = createTestEvent({ title: "Clickable Event" });
+      seedMockEvents([event]);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Clickable Event")).toBeInTheDocument();
+      });
+
+      // Verify event card is in the DOM and has event handler structure
+      const eventElement = screen.getByText("Clickable Event");
+      expect(eventElement).toBeInTheDocument();
+    });
+  });
+
+  // Note: Edit and Delete flows with full modal interactions are tested in E2E tests (Playwright)
+  // These unit tests verify the API hooks and basic component rendering
+
+  describe("View Switching", () => {
+    it("renders weekly view with events", async () => {
+      seedMockEvents(testEvents);
+      seedCalendarStore({ calendarView: "weekly" });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+      });
+    });
+
+    it("renders schedule view with events", async () => {
+      seedMockEvents(testEvents);
+      seedCalendarStore({ calendarView: "schedule" });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Store Persistence", () => {
+    it("respects initial calendar view from store", async () => {
+      seedMockEvents([]);
+      seedCalendarStore({ calendarView: "monthly" });
+
+      render(<CalendarModule />);
+
+      // Monthly view shows month name in navigation
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+    });
+
+    it("respects filter state from store", async () => {
+      // Only first member selected
+      seedCalendarStore({
+        filter: {
+          selectedMembers: [testMembers[0].id],
+          showAllDayEvents: true,
+        },
+      });
+      seedMockEvents(testEvents);
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        // Should show first member's event
+        expect(screen.getByText("Morning Meeting")).toBeInTheDocument();
+      });
+
+      // Should not show other member's event
+      expect(screen.queryByText("Lunch with Team")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/calendar/components/add-event-button.tsx
+++ b/src/components/calendar/components/add-event-button.tsx
@@ -11,6 +11,7 @@ export function AddEventButton({ onClick }: AddEventButtonProps) {
       onClick={onClick}
       className="fixed bottom-8 right-8 w-14 h-14 rounded-full bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all"
       size="icon"
+      aria-label="Add event"
     >
       <Plus className="h-7 w-7 text-primary-foreground" />
     </Button>

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -1,0 +1,381 @@
+import { format } from "date-fns";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { testMembers } from "@/test/fixtures";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedFamilyStore,
+} from "@/test/test-utils";
+import { EventForm } from "./event-form";
+
+describe("EventForm", () => {
+  const mockOnSubmit = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    seedFamilyStore({
+      name: "Test Family",
+      members: testMembers,
+      setupComplete: true,
+    });
+  });
+
+  describe("Add Mode", () => {
+    it("renders with smart defaults", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Check form fields exist
+      expect(screen.getByLabelText(/event name/i)).toBeInTheDocument();
+      expect(screen.getByText("Date")).toBeInTheDocument();
+      expect(screen.getByText("Start Time")).toBeInTheDocument();
+      expect(screen.getByText("End Time")).toBeInTheDocument();
+      expect(screen.getByText("Assign To")).toBeInTheDocument();
+
+      // Check buttons
+      expect(
+        screen.getByRole("button", { name: /add event/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /cancel/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("defaults title to empty", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      const titleInput = screen.getByLabelText(/event name/i);
+      expect(titleInput).toHaveValue("");
+    });
+
+    it("defaults date to today", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // The date picker uses "PPP" format from date-fns (e.g., "December 28th, 2025")
+      const today = format(new Date(), "PPP");
+      expect(screen.getByText(today)).toBeInTheDocument();
+    });
+
+    it("defaults to first family member", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Fill title and submit to verify first member is selected
+      await user.type(screen.getByLabelText(/event name/i), "Test Event");
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memberId: testMembers[0].id,
+        }),
+      );
+    });
+  });
+
+  describe("Edit Mode", () => {
+    const existingEvent = {
+      title: "Existing Meeting",
+      date: "2025-12-25",
+      startTime: "14:00",
+      endTime: "15:00",
+      memberId: testMembers[1].id,
+    };
+
+    it("renders with provided values", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={existingEvent}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      expect(screen.getByLabelText(/event name/i)).toHaveValue(
+        "Existing Meeting",
+      );
+      expect(
+        screen.getByRole("button", { name: /save changes/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows Save Changes button instead of Add Event", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={existingEvent}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: /add event/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /save changes/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("preserves the selected family member on submit", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={existingEvent}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Submit without changing member
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      // Should submit with the original member (testMembers[1])
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memberId: testMembers[1].id,
+        }),
+      );
+    });
+  });
+
+  describe("Form Validation", () => {
+    it("shows error when title is empty on submit", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Clear title and submit
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.clear(titleInput);
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(screen.getByText("Event name is required")).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("shows error when title exceeds 100 characters", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      const longTitle = "a".repeat(101);
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.type(titleInput, longTitle);
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(
+        screen.getByText("Event name must be 100 characters or less"),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it("allows whitespace-only title (documents current behavior)", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.type(titleInput, "   ");
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      // Note: Current validation allows whitespace-only titles.
+      // If validation is updated to reject whitespace, update this test.
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "   ",
+        }),
+      );
+    });
+  });
+
+  describe("Form Submission", () => {
+    it("calls onSubmit with form data when valid", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Fill in the title
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.type(titleInput, "New Team Meeting");
+
+      // Submit the form
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "New Team Meeting",
+          memberId: testMembers[0].id,
+        }),
+      );
+    });
+
+    it("calls onCancel when cancel button is clicked", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(mockOnCancel).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Pending State", () => {
+    it("shows 'Adding...' when isPending is true in add mode", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          isPending
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /adding/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /add event/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows 'Saving...' when isPending is true in edit mode", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{ title: "Test" }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          isPending
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", { name: /saving/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("disables buttons when isPending", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          isPending
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: /adding/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+    });
+
+    it("prevents double submission when isPending", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{ title: "Test Event" }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+          isPending
+        />,
+      );
+
+      // Try to submit
+      const submitButton = screen.getByRole("button", { name: /adding/i });
+      await user.click(submitButton);
+
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Member Selection", () => {
+    it("allows changing selected family member", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Click on second member
+      const secondMember = screen.getByRole("button", {
+        name: testMembers[1].name,
+      });
+      await user.click(secondMember);
+
+      // Fill title and submit
+      await user.type(screen.getByLabelText(/event name/i), "Test Event");
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(mockOnSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          memberId: testMembers[1].id,
+        }),
+      );
+    });
+
+    it("displays all family members", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      for (const member of testMembers) {
+        expect(
+          screen.getByRole("button", { name: member.name }),
+        ).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/src/components/onboarding/onboarding-flow.test.tsx
+++ b/src/components/onboarding/onboarding-flow.test.tsx
@@ -1,0 +1,331 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useFamilyStore } from "@/stores";
+import {
+  render,
+  renderWithUser,
+  resetFamilyStore,
+  screen,
+  waitFor,
+} from "@/test/test-utils";
+import { OnboardingFlow } from "./onboarding-flow";
+
+describe("OnboardingFlow", () => {
+  beforeEach(() => {
+    resetFamilyStore();
+  });
+
+  afterEach(() => {
+    resetFamilyStore();
+  });
+
+  describe("Welcome Step", () => {
+    it("renders welcome screen initially", () => {
+      render(<OnboardingFlow />);
+
+      expect(screen.getByText("Welcome to FamilyHub")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /get started/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows feature highlights", () => {
+      render(<OnboardingFlow />);
+
+      expect(screen.getByText("Shared Calendar")).toBeInTheDocument();
+      expect(screen.getByText("Family Profiles")).toBeInTheDocument();
+    });
+
+    it("advances to family name step on Get Started click", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      expect(screen.getByText("What's your family name?")).toBeInTheDocument();
+    });
+  });
+
+  describe("Family Name Step", () => {
+    it("shows step indicator", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      expect(screen.getByText("Step 1 of 2")).toBeInTheDocument();
+    });
+
+    it("has back button that returns to welcome", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      // Go to family name step
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+      expect(screen.getByText("What's your family name?")).toBeInTheDocument();
+
+      // Click back
+      await user.click(screen.getByRole("button", { name: "" })); // Back button has no text, just icon
+
+      expect(screen.getByText("Welcome to FamilyHub")).toBeInTheDocument();
+    });
+
+    it("shows validation error for empty name", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      // Try to continue without entering name
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      expect(screen.getByText(/family name is required/i)).toBeInTheDocument();
+    });
+
+    it("shows validation error for name too long", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      const longName = "a".repeat(51);
+      await user.type(screen.getByRole("textbox"), longName);
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      expect(
+        screen.getByText(/must be 50 characters or less/i),
+      ).toBeInTheDocument();
+    });
+
+    it("advances to members step with valid name", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+      await user.type(screen.getByRole("textbox"), "The Smiths");
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      expect(screen.getByText("Who's in your family?")).toBeInTheDocument();
+    });
+
+    it("preserves family name when navigating back and forth", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      // Enter family name
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+      await user.type(screen.getByRole("textbox"), "The Johnsons");
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      // Go back
+      await user.click(screen.getByRole("button", { name: "" }));
+
+      expect(screen.getByRole("textbox")).toHaveValue("The Johnsons");
+    });
+  });
+
+  describe("Members Step", () => {
+    async function navigateToMembersStep(
+      user: ReturnType<typeof renderWithUser>["user"],
+    ) {
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+      await user.type(screen.getByRole("textbox"), "Test Family");
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+    }
+
+    it("shows step indicator", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      expect(screen.getByText("Step 2 of 2")).toBeInTheDocument();
+    });
+
+    it("shows Add Family Member button", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      expect(screen.getByText("Add Family Member")).toBeInTheDocument();
+    });
+
+    it("disables Complete Setup button when no members", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      expect(
+        screen.getByRole("button", { name: /complete setup/i }),
+      ).toBeDisabled();
+      expect(
+        screen.getByText("Add at least one family member to continue"),
+      ).toBeInTheDocument();
+    });
+
+    it("opens member form modal when Add Family Member clicked", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      // Click the button (not the modal title which doesn't exist yet)
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      // Dialog title
+      expect(
+        screen.getByRole("heading", { name: /add family member/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("adds a new member when form is submitted", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      // Open modal
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Fill form
+      await user.type(screen.getByLabelText(/name/i), "John");
+
+      // Select a color (buttons with aria-label like "Select coral color")
+      const coralColorButton = screen.getByRole("button", {
+        name: /select coral color/i,
+      });
+      await user.click(coralColorButton);
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      // Modal should close and member should appear
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+      expect(screen.getByText("John")).toBeInTheDocument();
+    });
+
+    it("enables Complete Setup after adding a member", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      // Add a member
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      await user.type(screen.getByLabelText(/name/i), "Jane");
+      await user.click(
+        screen.getByRole("button", { name: /select coral color/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Complete Setup should now be enabled
+      expect(
+        screen.getByRole("button", { name: /complete setup/i }),
+      ).not.toBeDisabled();
+    });
+
+    it("navigates back to family name step", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+      await navigateToMembersStep(user);
+
+      await user.click(screen.getByRole("button", { name: "" })); // Back button
+
+      expect(screen.getByText("What's your family name?")).toBeInTheDocument();
+    });
+  });
+
+  describe("Full Flow & Store Integration", () => {
+    it("completes onboarding and persists to store", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      // Step 1: Welcome
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+
+      // Step 2: Family Name
+      await user.type(screen.getByRole("textbox"), "The Test Family");
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      // Step 3: Add a member
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+      await user.type(screen.getByLabelText(/name/i), "Parent One");
+      await user.click(
+        screen.getByRole("button", { name: /select coral color/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Complete setup
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
+
+      // Verify store was updated
+      const state = useFamilyStore.getState();
+      expect(state.family.name).toBe("The Test Family");
+      expect(state.family.members).toHaveLength(1);
+      expect(state.family.members[0].name).toBe("Parent One");
+      expect(state.family.setupComplete).toBe(true);
+    });
+
+    it("allows adding multiple members before completing", async () => {
+      const { user } = renderWithUser(<OnboardingFlow />);
+
+      // Navigate to members step
+      await user.click(screen.getByRole("button", { name: /get started/i }));
+      await user.type(screen.getByRole("textbox"), "Big Family");
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      // Add first member
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+      await waitFor(() =>
+        expect(screen.getByRole("dialog")).toBeInTheDocument(),
+      );
+      await user.type(screen.getByLabelText(/name/i), "Mom");
+      await user.click(
+        screen.getByRole("button", { name: /select coral color/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      );
+
+      // Add second member
+      await user.click(
+        screen.getByRole("button", { name: /add family member/i }),
+      );
+      await waitFor(() =>
+        expect(screen.getByRole("dialog")).toBeInTheDocument(),
+      );
+      await user.type(screen.getByLabelText(/name/i), "Dad");
+      await user.click(
+        screen.getByRole("button", { name: /select teal color/i }),
+      );
+      await user.click(screen.getByRole("button", { name: /^add$/i }));
+      await waitFor(() =>
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+      );
+
+      // Both members should be visible
+      expect(screen.getByText("Mom")).toBeInTheDocument();
+      expect(screen.getByText("Dad")).toBeInTheDocument();
+
+      // Complete
+      await user.click(screen.getByRole("button", { name: /complete setup/i }));
+
+      // Verify store
+      const state = useFamilyStore.getState();
+      expect(state.family.members).toHaveLength(2);
+    });
+  });
+});

--- a/src/stores/app-store.test.ts
+++ b/src/stores/app-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { type ModuleType, useAppStore } from "./app-store";
 
 describe("AppStore", () => {
@@ -10,21 +10,8 @@ describe("AppStore", () => {
     });
   });
 
-  afterEach(() => {
-    useAppStore.setState({
-      activeModule: "calendar",
-      isSidebarOpen: false,
-    });
-  });
-
   describe("initial state", () => {
     it("initializes with activeModule = 'calendar'", () => {
-      // Reset to initial state
-      useAppStore.setState({
-        activeModule: "calendar",
-        isSidebarOpen: false,
-      });
-
       expect(useAppStore.getState().activeModule).toBe("calendar");
     });
 

--- a/src/stores/calendar-store.test.ts
+++ b/src/stores/calendar-store.test.ts
@@ -300,9 +300,62 @@ describe("CalendarStore", () => {
       useCalendarStore.getState().goToNext();
 
       const date = useCalendarStore.getState().currentDate;
-      // JavaScript Date auto-corrects Jan 31 + 1 month to Mar 3 (since Feb 31 doesn't exist)
-      // This is expected JavaScript behavior
-      expect(date.getMonth()).toBe(2); // March (due to JS date overflow)
+      // Day should be clamped to last day of February (28 in non-leap year)
+      expect(date.getMonth()).toBe(1); // February
+      expect(date.getDate()).toBe(28);
+    });
+
+    it("handles month length differences in leap year (Jan 31 → Feb 29)", () => {
+      resetStore({
+        currentDate: new Date(2024, 0, 31, 12, 0, 0), // January 31, 2024 (leap year)
+        calendarView: "monthly",
+      });
+
+      useCalendarStore.getState().goToNext();
+
+      const date = useCalendarStore.getState().currentDate;
+      expect(date.getMonth()).toBe(1); // February
+      expect(date.getDate()).toBe(29); // Leap year has 29 days
+    });
+
+    it("handles backward month length differences (Mar 31 → Feb 28)", () => {
+      resetStore({
+        currentDate: new Date(2025, 2, 31, 12, 0, 0), // March 31, 2025
+        calendarView: "monthly",
+      });
+
+      useCalendarStore.getState().goToPrevious();
+
+      const date = useCalendarStore.getState().currentDate;
+      // Day should be clamped to last day of February (28 in non-leap year)
+      expect(date.getMonth()).toBe(1); // February
+      expect(date.getDate()).toBe(28);
+    });
+
+    it("handles backward month length differences in leap year (Mar 31 → Feb 29)", () => {
+      resetStore({
+        currentDate: new Date(2024, 2, 31, 12, 0, 0), // March 31, 2024 (leap year)
+        calendarView: "monthly",
+      });
+
+      useCalendarStore.getState().goToPrevious();
+
+      const date = useCalendarStore.getState().currentDate;
+      expect(date.getMonth()).toBe(1); // February
+      expect(date.getDate()).toBe(29); // Leap year has 29 days
+    });
+
+    it("preserves day when target month has enough days", () => {
+      resetStore({
+        currentDate: new Date(2025, 0, 15, 12, 0, 0), // January 15
+        calendarView: "monthly",
+      });
+
+      useCalendarStore.getState().goToNext();
+
+      const date = useCalendarStore.getState().currentDate;
+      expect(date.getMonth()).toBe(1); // February
+      expect(date.getDate()).toBe(15); // Day preserved
     });
   });
 

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -85,9 +85,28 @@ export const useCalendarStore = create<CalendarState>()(
           case "schedule":
             newDate.setDate(currentDate.getDate() - 7);
             break;
-          case "monthly":
-            newDate.setMonth(currentDate.getMonth() - 1);
+          case "monthly": {
+            // Handle month navigation with day clamping to avoid overflow
+            // (e.g., Mar 31 → Feb 28, not Mar 3)
+            const targetMonth = currentDate.getMonth() - 1;
+            const targetYear =
+              targetMonth < 0
+                ? currentDate.getFullYear() - 1
+                : currentDate.getFullYear();
+            const normalizedMonth = targetMonth < 0 ? 11 : targetMonth;
+            // Get last day of target month (day 0 of next month = last day of target month)
+            const lastDayOfTargetMonth = new Date(
+              targetYear,
+              normalizedMonth + 1,
+              0,
+            ).getDate();
+            const clampedDay = Math.min(
+              currentDate.getDate(),
+              lastDayOfTargetMonth,
+            );
+            newDate.setFullYear(targetYear, normalizedMonth, clampedDay);
             break;
+          }
         }
 
         set({ currentDate: newDate });
@@ -105,9 +124,28 @@ export const useCalendarStore = create<CalendarState>()(
           case "schedule":
             newDate.setDate(currentDate.getDate() + 7);
             break;
-          case "monthly":
-            newDate.setMonth(currentDate.getMonth() + 1);
+          case "monthly": {
+            // Handle month navigation with day clamping to avoid overflow
+            // (e.g., Jan 31 → Feb 28, not Mar 3)
+            const targetMonth = currentDate.getMonth() + 1;
+            const targetYear =
+              targetMonth > 11
+                ? currentDate.getFullYear() + 1
+                : currentDate.getFullYear();
+            const normalizedMonth = targetMonth > 11 ? 0 : targetMonth;
+            // Get last day of target month (day 0 of next month = last day of target month)
+            const lastDayOfTargetMonth = new Date(
+              targetYear,
+              normalizedMonth + 1,
+              0,
+            ).getDate();
+            const clampedDay = Math.min(
+              currentDate.getDate(),
+              lastDayOfTargetMonth,
+            );
+            newDate.setFullYear(targetYear, normalizedMonth, clampedDay);
             break;
+          }
         }
 
         set({ currentDate: newDate });

--- a/src/test/fixtures/calendar.ts
+++ b/src/test/fixtures/calendar.ts
@@ -1,0 +1,138 @@
+import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
+import { testMembers } from "./family";
+
+/**
+ * Today's date at midnight (for consistent test dates).
+ */
+export const today = new Date();
+today.setHours(0, 0, 0, 0);
+
+/**
+ * Create a date relative to today.
+ */
+export function getRelativeDate(daysFromToday: number): Date {
+  const date = new Date(today);
+  date.setDate(date.getDate() + daysFromToday);
+  return date;
+}
+
+/**
+ * Test events for various scenarios.
+ */
+export const testEvents: CalendarEvent[] = [
+  {
+    id: "event-1",
+    title: "Morning Meeting",
+    startTime: "9:00 AM",
+    endTime: "10:00 AM",
+    date: today,
+    memberId: testMembers[0].id,
+  },
+  {
+    id: "event-2",
+    title: "Lunch with Team",
+    startTime: "12:00 PM",
+    endTime: "1:00 PM",
+    date: today,
+    memberId: testMembers[1].id,
+    location: "Downtown Cafe",
+  },
+  {
+    id: "event-3",
+    title: "Soccer Practice",
+    startTime: "4:00 PM",
+    endTime: "5:30 PM",
+    date: today,
+    memberId: testMembers[2].id,
+  },
+  {
+    id: "event-4",
+    title: "All Day Event",
+    startTime: "12:00 AM",
+    endTime: "11:59 PM",
+    date: today,
+    memberId: testMembers[0].id,
+    isAllDay: true,
+  },
+];
+
+/**
+ * Single test event for simpler tests.
+ */
+export const testEvent: CalendarEvent = testEvents[0];
+
+/**
+ * Test event for tomorrow.
+ */
+export const tomorrowEvent: CalendarEvent = {
+  id: "event-tomorrow",
+  title: "Tomorrow's Meeting",
+  startTime: "10:00 AM",
+  endTime: "11:00 AM",
+  date: getRelativeDate(1),
+  memberId: testMembers[0].id,
+};
+
+/**
+ * Test event for yesterday.
+ */
+export const yesterdayEvent: CalendarEvent = {
+  id: "event-yesterday",
+  title: "Yesterday's Event",
+  startTime: "2:00 PM",
+  endTime: "3:00 PM",
+  date: getRelativeDate(-1),
+  memberId: testMembers[1].id,
+};
+
+/**
+ * Create a custom test event with overrides.
+ */
+export function createTestEvent(
+  overrides: Partial<CalendarEvent> = {},
+): CalendarEvent {
+  return {
+    id: `event-${Date.now()}`,
+    title: "Test Event",
+    startTime: "9:00 AM",
+    endTime: "10:00 AM",
+    date: today,
+    memberId: testMembers[0].id,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a valid CreateEventRequest for API testing.
+ */
+export function createEventRequest(
+  overrides: Partial<CreateEventRequest> = {},
+): CreateEventRequest {
+  const date = overrides.date ?? today.toISOString().split("T")[0];
+  return {
+    title: "New Event",
+    startTime: "2:00 PM",
+    endTime: "3:00 PM",
+    date,
+    memberId: testMembers[0].id,
+    ...overrides,
+  };
+}
+
+/**
+ * Events for a full week of testing.
+ */
+export function createWeekOfEvents(): CalendarEvent[] {
+  const events: CalendarEvent[] = [];
+  for (let i = 0; i < 7; i++) {
+    events.push({
+      id: `week-event-${i}`,
+      title: `Day ${i} Event`,
+      startTime: "10:00 AM",
+      endTime: "11:00 AM",
+      date: getRelativeDate(i),
+      memberId: testMembers[i % testMembers.length].id,
+    });
+  }
+  return events;
+}

--- a/src/test/fixtures/family.ts
+++ b/src/test/fixtures/family.ts
@@ -1,0 +1,68 @@
+import type { FamilyColor, FamilyData, FamilyMember } from "@/lib/types";
+
+/**
+ * Test family members with different colors.
+ */
+export const testMembers: FamilyMember[] = [
+  { id: "member-1", name: "John", color: "coral" as FamilyColor },
+  { id: "member-2", name: "Jane", color: "teal" as FamilyColor },
+  { id: "member-3", name: "Alex", color: "green" as FamilyColor },
+];
+
+/**
+ * Single test member for simpler tests.
+ */
+export const testMember: FamilyMember = testMembers[0];
+
+/**
+ * Complete test family data (setup complete).
+ */
+export const testFamily: FamilyData = {
+  id: "family-1",
+  name: "Test Family",
+  members: testMembers,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  setupComplete: true,
+};
+
+/**
+ * Incomplete family data (onboarding not finished).
+ */
+export const incompleteFamily: FamilyData = {
+  id: "family-2",
+  name: "Incomplete Family",
+  members: [],
+  createdAt: "2025-01-01T00:00:00.000Z",
+  setupComplete: false,
+};
+
+/**
+ * Create a custom test member with overrides.
+ */
+export function createTestMember(
+  overrides: Partial<FamilyMember> = {},
+): FamilyMember {
+  return {
+    id: `member-${Date.now()}`,
+    name: "Test Member",
+    color: "coral" as FamilyColor,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a family with custom members.
+ */
+export function createTestFamily(
+  members: FamilyMember[],
+  overrides: Partial<Omit<FamilyData, "members">> = {},
+): FamilyData {
+  return {
+    id: `family-${Date.now()}`,
+    name: "Test Family",
+    createdAt: new Date().toISOString(),
+    setupComplete: true,
+    ...overrides,
+    members,
+  };
+}

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -1,0 +1,22 @@
+// Family fixtures
+
+// Calendar fixtures
+export {
+  createEventRequest,
+  createTestEvent,
+  createWeekOfEvents,
+  getRelativeDate,
+  testEvent,
+  testEvents,
+  today,
+  tomorrowEvent,
+  yesterdayEvent,
+} from "./calendar";
+export {
+  createTestFamily,
+  createTestMember,
+  incompleteFamily,
+  testFamily,
+  testMember,
+  testMembers,
+} from "./family";

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -1,30 +1,199 @@
-// import { http, HttpResponse } from "msw";
+import { HttpResponse, http } from "msw";
+import { parseLocalDate } from "@/lib/time-utils";
+import type {
+  ApiResponse,
+  CalendarEvent,
+  CreateEventRequest,
+  MutationResponse,
+  UpdateEventRequest,
+} from "@/lib/types";
+
+// In-memory storage for mock calendar events (reset between tests)
+let mockEvents: CalendarEvent[] = [];
 
 /**
- * MSW request handlers for API mocking in tests.
+ * Reset mock data between tests
+ */
+export function resetMockEvents(): void {
+  mockEvents = [];
+}
+
+/**
+ * Seed mock events for testing
+ */
+export function seedMockEvents(events: CalendarEvent[]): void {
+  mockEvents = [...events];
+}
+
+/**
+ * Get current mock events (for assertions)
+ */
+export function getMockEvents(): CalendarEvent[] {
+  return [...mockEvents];
+}
+
+function createApiResponse<T>(data: T): ApiResponse<T> {
+  return {
+    data,
+    meta: {
+      timestamp: Date.now(),
+      requestId: crypto.randomUUID(),
+    },
+  };
+}
+
+function createMutationResponse<T>(
+  data: T,
+  message: string,
+): MutationResponse<T> {
+  return { data, message };
+}
+
+// Base URL for API endpoints
+// Note: Service endpoints start with "/" which makes them absolute paths from the origin
+// So /calendar/events with baseUrl http://localhost:3000/api becomes http://localhost:3000/calendar/events
+export const API_BASE = "http://localhost:3000";
+
+/**
+ * MSW request handlers for calendar API endpoints.
  *
  * Usage in tests:
  * ```typescript
- * import { server } from "@/test/mocks/server";
- * import { http, HttpResponse } from "msw";
+ * import { server, seedMockEvents, resetMockEvents } from "@/test/mocks/server";
  *
- * // Override a handler for a specific test
+ * beforeEach(() => {
+ *   seedMockEvents([testEvent]);
+ * });
+ *
+ * afterEach(() => {
+ *   resetMockEvents();
+ * });
+ * ```
+ *
+ * Override handlers for error scenarios:
+ * ```typescript
  * server.use(
- *   http.get("/api/events", () => {
- *     return HttpResponse.json({ events: [] });
+ *   http.get("http://localhost:3000/calendar/events", () => {
+ *     return HttpResponse.json({ message: "Server error" }, { status: 500 });
  *   })
  * );
  * ```
- *
- * Add your API handlers below as the app grows.
  */
 export const handlers = [
-  // Example: Calendar events endpoint
-  // http.get("/api/calendar/events", () => {
-  //   return HttpResponse.json({
-  //     events: [
-  //       { id: "1", title: "Test Event", date: "2025-01-01" }
-  //     ]
-  //   });
-  // }),
+  // GET /calendar/events - List events with optional filters
+  http.get(`${API_BASE}/calendar/events`, ({ request }) => {
+    const url = new URL(request.url);
+    const startDate = url.searchParams.get("startDate");
+    const endDate = url.searchParams.get("endDate");
+    const memberId = url.searchParams.get("memberId");
+
+    let events = [...mockEvents];
+
+    // Apply date range filter (use parseLocalDate for consistent timezone handling)
+    if (startDate) {
+      const start = parseLocalDate(startDate);
+      events = events.filter((e) => new Date(e.date) >= start);
+    }
+    if (endDate) {
+      const end = parseLocalDate(endDate);
+      events = events.filter((e) => new Date(e.date) <= end);
+    }
+
+    // Apply member filter
+    if (memberId) {
+      events = events.filter((e) => e.memberId === memberId);
+    }
+
+    return HttpResponse.json(createApiResponse(events));
+  }),
+
+  // GET /calendar/events/:id - Get single event
+  http.get(`${API_BASE}/calendar/events/:id`, ({ params }) => {
+    const { id } = params;
+    const event = mockEvents.find((e) => e.id === id);
+
+    if (!event) {
+      return HttpResponse.json(
+        { message: `Event with id "${id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(createApiResponse(event));
+  }),
+
+  // POST /calendar/events - Create new event
+  http.post(`${API_BASE}/calendar/events`, async ({ request }) => {
+    const body = (await request.json()) as CreateEventRequest;
+
+    const newEvent: CalendarEvent = {
+      id: `event-${Date.now()}`,
+      title: body.title,
+      startTime: body.startTime,
+      endTime: body.endTime,
+      date: parseLocalDate(body.date), // Use parseLocalDate to avoid timezone issues
+      memberId: body.memberId,
+      isAllDay: body.isAllDay,
+      location: body.location,
+    };
+
+    mockEvents = [...mockEvents, newEvent];
+
+    return HttpResponse.json(
+      createMutationResponse(newEvent, "Event created successfully"),
+    );
+  }),
+
+  // PATCH /calendar/events/:id - Update event
+  http.patch(`${API_BASE}/calendar/events/:id`, async ({ params, request }) => {
+    const { id } = params;
+    const body = (await request.json()) as Omit<UpdateEventRequest, "id">;
+
+    const index = mockEvents.findIndex((e) => e.id === id);
+    if (index === -1) {
+      return HttpResponse.json(
+        { message: `Event with id "${id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    const existingEvent = mockEvents[index];
+    const updatedEvent: CalendarEvent = {
+      ...existingEvent,
+      title: body.title ?? existingEvent.title,
+      startTime: body.startTime ?? existingEvent.startTime,
+      endTime: body.endTime ?? existingEvent.endTime,
+      date: body.date ? parseLocalDate(body.date) : existingEvent.date,
+      memberId: body.memberId ?? existingEvent.memberId,
+      isAllDay: body.isAllDay ?? existingEvent.isAllDay,
+      location: body.location ?? existingEvent.location,
+    };
+
+    mockEvents = [
+      ...mockEvents.slice(0, index),
+      updatedEvent,
+      ...mockEvents.slice(index + 1),
+    ];
+
+    return HttpResponse.json(
+      createMutationResponse(updatedEvent, "Event updated successfully"),
+    );
+  }),
+
+  // DELETE /calendar/events/:id - Delete event
+  http.delete(`${API_BASE}/calendar/events/:id`, ({ params }) => {
+    const { id } = params;
+
+    const index = mockEvents.findIndex((e) => e.id === id);
+    if (index === -1) {
+      return HttpResponse.json(
+        { message: `Event with id "${id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    mockEvents = mockEvents.filter((e) => e.id !== id);
+
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -1,39 +1,58 @@
 import { setupServer } from "msw/node";
-import { handlers } from "./handlers";
+import {
+  API_BASE,
+  getMockEvents,
+  handlers,
+  resetMockEvents,
+  seedMockEvents,
+} from "./handlers";
 
 /**
  * MSW server instance for Node.js (Vitest) tests.
  *
- * This is NOT automatically started in setup.ts - import and use it
- * in test files that need API mocking:
- *
+ * Usage:
  * ```typescript
- * import { server } from "@/test/mocks/server";
- * import { beforeAll, afterEach, afterAll } from "vitest";
+ * import { server, seedMockEvents, resetMockEvents } from "@/test/mocks/server";
  *
  * beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
- * afterEach(() => server.resetHandlers());
+ * afterEach(() => {
+ *   server.resetHandlers();
+ *   resetMockEvents();
+ * });
  * afterAll(() => server.close());
  *
- * // Your tests here...
+ * it("displays events", () => {
+ *   seedMockEvents([testEvent]);
+ *   // test code...
+ * });
  * ```
  *
- * Or use a helper pattern:
- *
+ * Or use the helper:
  * ```typescript
- * import { setupMswServer } from "@/test/mocks/server";
+ * import { setupMswServer, seedMockEvents } from "@/test/mocks/server";
  *
- * setupMswServer(); // Registers beforeAll/afterEach/afterAll hooks
+ * setupMswServer();
+ *
+ * it("displays events", () => {
+ *   seedMockEvents([testEvent]);
+ *   // test code...
+ * });
  * ```
  */
 export const server = setupServer(...handlers);
 
 /**
  * Helper to set up MSW server lifecycle hooks in a describe block.
- * Call this at the top of your test file or describe block.
+ * Automatically resets mock data between tests.
  */
 export function setupMswServer() {
   beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
-  afterEach(() => server.resetHandlers());
+  afterEach(() => {
+    server.resetHandlers();
+    resetMockEvents();
+  });
   afterAll(() => server.close());
 }
+
+// Re-export mock data helpers and constants
+export { API_BASE, getMockEvents, resetMockEvents, seedMockEvents };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -38,6 +38,10 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   thresholds: [],
 }));
 
+// Mock scrollTo (used by calendar views for auto-scrolling)
+Element.prototype.scrollTo = vi.fn();
+window.scrollTo = vi.fn();
+
 // =============================================================================
 // Test Lifecycle
 // =============================================================================

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,14 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  define: {
+    // Disable internal mock API in tests so MSW can intercept HTTP requests
+    "import.meta.env.VITE_USE_MOCK_API": JSON.stringify("false"),
+    // Use absolute URL for fetch in Node.js environment
+    "import.meta.env.VITE_API_BASE_URL": JSON.stringify(
+      "http://localhost:3000/api",
+    ),
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- Fix monthly navigation bug where Jan 31 → Feb would overflow to Mar 3
- Clamp day to last day of target month (e.g., Jan 31 → Feb 28)
- Handle leap years correctly (Jan 31 → Feb 29 in leap year)
- Remove redundant `afterEach` reset in app-store.test.ts
- Add tests for month length edge cases (forward and backward)

## Context
Found during review of PR #18. The original test documented the overflow behavior as "expected JavaScript behavior" when it was actually a bug in the calendar store.

## Test plan
- [x] All 145 store tests pass
- [x] Lint passes
- [x] Build succeeds