### PR TITLE
fix: address code review feedback from PR #19

### DIFF
--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -345,6 +345,56 @@ describe("CalendarModule", () => {
     });
   });
 
+  describe("Edit Event Flow", () => {
+    it("opens edit modal from detail modal and updates event", async () => {
+      const event = createTestEvent({ title: "Original Title" });
+      seedMockEvents([event]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      // Wait for event to load
+      await waitFor(() => {
+        expect(screen.getByText("Original Title")).toBeInTheDocument();
+      });
+
+      // Click event to open detail modal
+      await user.click(screen.getByText("Original Title"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Click edit button
+      await user.click(screen.getByRole("button", { name: /edit/i }));
+
+      // Edit modal should open with form
+      await waitFor(() => {
+        expect(screen.getByLabelText(/event name/i)).toHaveValue(
+          "Original Title",
+        );
+      });
+
+      // Update the title
+      const titleInput = screen.getByLabelText(/event name/i);
+      await user.clear(titleInput);
+      await user.type(titleInput, "Updated Title");
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+      // Modal should close
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+
+      // Updated event should appear
+      await waitFor(() => {
+        expect(screen.getByText("Updated Title")).toBeInTheDocument();
+        expect(screen.queryByText("Original Title")).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe("View Switching", () => {
     it("renders weekly view with events", async () => {
       seedMockEvents(testEvents);

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -283,8 +283,67 @@ describe("CalendarModule", () => {
     });
   });
 
-  // Note: Edit and Delete flows with full modal interactions are tested in E2E tests (Playwright)
-  // These unit tests verify the API hooks and basic component rendering
+  describe("Event Detail Modal", () => {
+    it("opens detail modal when event is clicked", async () => {
+      const event = createTestEvent({
+        title: "Team Standup",
+        startTime: "9:00 AM",
+        endTime: "9:30 AM",
+        location: "Conference Room A",
+      });
+      seedMockEvents([event]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Team Standup")).toBeInTheDocument();
+      });
+
+      // Click the event
+      await user.click(screen.getByText("Team Standup"));
+
+      // Detail modal should open with event info
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Verify modal shows event details
+      expect(
+        screen.getByRole("heading", { name: "Team Standup" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("9:00 AM – 9:30 AM")).toBeInTheDocument();
+      expect(screen.getByText("Conference Room A")).toBeInTheDocument();
+      expect(screen.getByText(testMembers[0].name)).toBeInTheDocument();
+    });
+
+    it("closes detail modal when close button clicked", async () => {
+      const event = createTestEvent({ title: "Closeable Event" });
+      seedMockEvents([event]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Closeable Event")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("Closeable Event"));
+
+      await waitFor(() => {
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+      });
+
+      // Close the modal (dialog has a close button in header)
+      const dialog = screen.getByRole("dialog");
+      const closeButton = within(dialog).getByRole("button", {
+        name: /close/i,
+      });
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+    });
+  });
 
   describe("View Switching", () => {
     it("renders weekly view with events", async () => {

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -1,4 +1,4 @@
-import { waitFor } from "@testing-library/react";
+import { waitFor, within } from "@testing-library/react";
 import { HttpResponse, http } from "msw";
 import {
   afterAll,
@@ -201,9 +201,10 @@ describe("CalendarModule", () => {
 
       // Submit the form (find button within dialog)
       const dialog = screen.getByRole("dialog");
-      const submitButton = dialog.querySelector('button[type="submit"]');
-      expect(submitButton).toBeInTheDocument();
-      await user.click(submitButton!);
+      const submitButton = within(dialog).getByRole("button", {
+        name: /add event/i,
+      });
+      await user.click(submitButton);
 
       // Modal should close after successful submission
       await waitFor(() => {
@@ -253,8 +254,10 @@ describe("CalendarModule", () => {
       // Fill and submit
       await user.type(screen.getByLabelText(/event name/i), "Failing Event");
       const dialog = screen.getByRole("dialog");
-      const submitButton = dialog.querySelector('button[type="submit"]');
-      await user.click(submitButton!);
+      const submitButton = within(dialog).getByRole("button", {
+        name: /add event/i,
+      });
+      await user.click(submitButton);
 
       // Modal should stay open after failed request
       await waitFor(() => {

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -464,6 +464,91 @@ describe("CalendarModule", () => {
     });
   });
 
+  describe("Date Navigation", () => {
+    it("navigates to previous day when Previous button clicked", async () => {
+      seedMockEvents([]);
+      const today = new Date();
+      const yesterday = new Date(today);
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      // Click previous
+      await user.click(screen.getByRole("button", { name: /previous/i }));
+
+      // Date label should update to yesterday
+      const expectedLabel = yesterday.toLocaleDateString("en-US", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+      });
+    });
+
+    it("navigates to next day when Next button clicked", async () => {
+      seedMockEvents([]);
+      const today = new Date();
+      const tomorrow = new Date(today);
+      tomorrow.setDate(tomorrow.getDate() + 1);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      const expectedLabel = tomorrow.toLocaleDateString("en-US", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+      });
+    });
+
+    it("returns to today when Today button clicked", async () => {
+      seedMockEvents([]);
+
+      const { user } = renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      // Navigate away first
+      await user.click(screen.getByRole("button", { name: /next/i }));
+      await user.click(screen.getByRole("button", { name: /next/i }));
+
+      // Click today
+      await user.click(screen.getByRole("button", { name: /today/i }));
+
+      const today = new Date();
+      const expectedLabel = today.toLocaleDateString("en-US", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("View Switching", () => {
     it("renders weekly view with events", async () => {
       seedMockEvents(testEvents);

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -218,6 +218,25 @@ describe("EventForm", () => {
       expect(screen.getByText("Event name is required")).toBeInTheDocument();
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
+
+    it("shows error when end time is before start time", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{ startTime: "14:00", endTime: "13:00" }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.type(screen.getByLabelText(/event name/i), "Test Event");
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      expect(
+        screen.getByText("End time must be after start time"),
+      ).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
   });
 
   describe("Form Submission", () => {

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -202,7 +202,7 @@ describe("EventForm", () => {
       expect(mockOnSubmit).not.toHaveBeenCalled();
     });
 
-    it("allows whitespace-only title (documents current behavior)", async () => {
+    it("rejects whitespace-only title", async () => {
       const { user } = renderWithUser(
         <EventForm
           mode="add"
@@ -215,13 +215,8 @@ describe("EventForm", () => {
       await user.type(titleInput, "   ");
       await user.click(screen.getByRole("button", { name: /add event/i }));
 
-      // Note: Current validation allows whitespace-only titles.
-      // If validation is updated to reject whitespace, update this test.
-      expect(mockOnSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: "   ",
-        }),
-      );
+      expect(screen.getByText("Event name is required")).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -37,7 +37,12 @@ export function OnboardingFamilyName({
     <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
-        <Button variant="ghost" size="icon" onClick={onBack}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          aria-label="Go back"
+        >
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <span className="text-sm text-muted-foreground">Step 1 of 2</span>

--- a/src/components/onboarding/onboarding-flow.test.tsx
+++ b/src/components/onboarding/onboarding-flow.test.tsx
@@ -61,7 +61,7 @@ describe("OnboardingFlow", () => {
       expect(screen.getByText("What's your family name?")).toBeInTheDocument();
 
       // Click back
-      await user.click(screen.getByRole("button", { name: "" })); // Back button has no text, just icon
+      await user.click(screen.getByRole("button", { name: /go back/i }));
 
       expect(screen.getByText("Welcome to FamilyHub")).toBeInTheDocument();
     });
@@ -110,7 +110,7 @@ describe("OnboardingFlow", () => {
       await user.click(screen.getByRole("button", { name: /continue/i }));
 
       // Go back
-      await user.click(screen.getByRole("button", { name: "" }));
+      await user.click(screen.getByRole("button", { name: /go back/i }));
 
       expect(screen.getByRole("textbox")).toHaveValue("The Johnsons");
     });
@@ -231,7 +231,7 @@ describe("OnboardingFlow", () => {
       const { user } = renderWithUser(<OnboardingFlow />);
       await navigateToMembersStep(user);
 
-      await user.click(screen.getByRole("button", { name: "" })); // Back button
+      await user.click(screen.getByRole("button", { name: /go back/i }));
 
       expect(screen.getByText("What's your family name?")).toBeInTheDocument();
     });

--- a/src/components/onboarding/onboarding-members.tsx
+++ b/src/components/onboarding/onboarding-members.tsx
@@ -61,7 +61,12 @@ export function OnboardingMembers({
     <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
-        <Button variant="ghost" size="icon" onClick={onBack}>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          aria-label="Go back"
+        >
           <ArrowLeft className="h-5 w-5" />
         </Button>
         <span className="text-sm text-muted-foreground">Step 2 of 2</span>

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -21,8 +21,13 @@ export const eventFormSchema = z
   .object({
     title: z
       .string()
-      .min(1, "Event name is required")
-      .max(100, "Event name must be 100 characters or less"),
+      .transform((val) => val.trim())
+      .pipe(
+        z
+          .string()
+          .min(1, "Event name is required")
+          .max(100, "Event name must be 100 characters or less"),
+      ),
     date: z
       .string()
       .min(1, "Date is required")

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -138,6 +138,7 @@ export function resetFamilyStore(): void {
 
 /**
  * Seed calendar store with initial state for testing.
+ * Uses direct setState to avoid side effects from actions (like hasUserSetView).
  *
  * @example
  * seedCalendarStore({
@@ -151,38 +152,39 @@ export function seedCalendarStore(data: {
   calendarView?: CalendarViewType;
   filter?: Partial<FilterState>;
 }): void {
-  const store = useCalendarStore.getState();
+  const currentState = useCalendarStore.getState();
 
-  if (data.currentDate) {
-    store.setDate(data.currentDate);
-  }
-
-  if (data.calendarView) {
-    store.setCalendarView(data.calendarView);
-  }
-
-  if (data.filter) {
-    const currentFilter = useCalendarStore.getState().filter;
-    store.setFilter({
-      selectedMembers:
-        data.filter.selectedMembers ?? currentFilter.selectedMembers,
-      showAllDayEvents:
-        data.filter.showAllDayEvents ?? currentFilter.showAllDayEvents,
-    });
-  }
+  // Use direct setState to avoid triggering action side effects
+  useCalendarStore.setState({
+    ...(data.currentDate && { currentDate: data.currentDate }),
+    ...(data.calendarView && { calendarView: data.calendarView }),
+    ...(data.filter && {
+      filter: {
+        selectedMembers:
+          data.filter.selectedMembers ?? currentState.filter.selectedMembers,
+        showAllDayEvents:
+          data.filter.showAllDayEvents ?? currentState.filter.showAllDayEvents,
+      },
+    }),
+  });
 }
 
 /**
  * Reset the calendar store to its initial state.
+ * Uses direct setState to ensure clean state without side effects.
  */
 export function resetCalendarStore(): void {
-  const store = useCalendarStore.getState();
-  store.setDate(new Date());
-  store.setCalendarView("weekly");
-  store.setFilter({ selectedMembers: [], showAllDayEvents: true });
-  store.closeAddEventModal();
-  store.closeDetailModal();
-  store.closeEditModal();
+  useCalendarStore.setState({
+    currentDate: new Date(),
+    calendarView: "weekly",
+    hasUserSetView: false,
+    filter: { selectedMembers: [], showAllDayEvents: true },
+    isAddEventModalOpen: false,
+    selectedEvent: null,
+    isDetailModalOpen: false,
+    editingEvent: null,
+    isEditModalOpen: false,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Comprehensive follow-up fixes from code review of PR #19 (integration tests for calendar/onboarding):

### Accessibility
- Add `aria-label="Go back"` to onboarding back buttons for screen reader support

### Test Quality
- Replace brittle `querySelector` selectors with Testing Library accessible queries (`within()`, `getByRole`)
- Replace fragile empty-name back button selectors with proper aria-label queries
- Use scoped assertions (`within(dialog)`) to avoid duplicate text matching issues
- Improve test isolation with proper store reset utilities

### Validation
- Fix validation schema to reject whitespace-only event titles using Zod transform
- Add test coverage for end time before start time validation

### New Test Coverage
- Add event detail modal content verification tests
- Add full edit event integration flow tests
- Add full delete event integration flow tests (with confirmation)
- Add date navigation tests (previous/next/today)
- Add mobile smart defaults tests (schedule view on mobile for first-time users)

### Test Infrastructure
- Improve `seedCalendarStore` to use direct setState (avoid action side effects)
- Improve `resetCalendarStore` to fully reset all state including `hasUserSetView`
- Add controllable `useIsMobile` mock for mobile-specific tests

## Related
Addresses all issues identified in review of #19

## Test plan
- [x] All 392 tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)