### PR TITLE
feat(sidebar): add member profile modal and cleanup

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,10 +1,10 @@
 # FamilyHub Development Roadmap
 
-**Last Updated:** December 28, 2025
+**Last Updated:** December 29, 2025
 
 ## Current Status
 
-**Phase 1B: Calendar Frontend Polish** - Sprint 5 Complete
+**Phase 1B: Calendar Frontend Polish** - Sprint 6 In Progress
 
 > **Note:** See [TECHNICAL-DEBT.md](./TECHNICAL-DEBT.md) for known issues and deferred improvements.
 
@@ -58,11 +58,21 @@ PWA Basics: ✅ PR #13
 - [x] Static asset caching (JS, CSS, images, fonts via Workbox)
 - [x] (Deferred: Offline calendar viewing → Phase 2 with real backend)
 
-**Sprint 6: Testing & Polish**
+**Sprint 6: Testing & Polish** 🚧 CURRENT
 
-- [ ] Component tests (Vitest + Testing Library)
-- [ ] E2E tests (Playwright)
-- [ ] Performance optimization
+Component Tests: ✅ COMPLETED (December 29, 2025)
+- [x] Store tests: calendar-store (97%), family-store (85%), app-store (100%)
+- [x] Validation tests: 100% coverage for all Zod schemas
+- [x] Time utility tests: 100% coverage
+- [x] Integration tests: CalendarModule, EventForm, OnboardingFlow
+- [x] Total: 391 tests across 10 test files
+
+E2E Tests:
+- [ ] Playwright test suites (config ready, tests not written)
+
+Performance Optimization:
+- [ ] Bundle analysis and optimization
+- [ ] Performance profiling
 
 ## Phase 2: Backend Development ⏳ NEXT
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # FamilyHub Development Roadmap
 
-**Last Updated:** December 29, 2025
+**Last Updated:** December 30, 2025
 
 ## Current Status
 
@@ -66,6 +66,12 @@ Component Tests: ✅ COMPLETED (December 29, 2025)
 - [x] Time utility tests: 100% coverage
 - [x] Integration tests: CalendarModule, EventForm, OnboardingFlow
 - [x] Total: 391 tests across 10 test files
+
+Sidebar Polish: ✅ COMPLETED (December 30, 2025)
+- [x] Remove non-functional menu items (Home, Notifications, Customize, Settings, Help, Sign Out)
+- [x] Add MemberProfileModal (avatar upload, name, color, email fields)
+- [x] Wire sidebar member buttons to open profile modal
+- [x] Avatar display in sidebar (show uploaded image or initials fallback)
 
 E2E Tests:
 - [ ] Playwright test suites (config ready, tests not written)

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,1 +1,2 @@
 export { FamilySettingsModal } from "./family-settings-modal";
+export { MemberProfileModal } from "./member-profile-modal";

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -1,0 +1,299 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Camera, Trash2, X } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { ColorPicker } from "@/components/ui/color-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { colorMap, type FamilyColor } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import {
+  useFamilyActions,
+  useFamilyMemberById,
+  useFamilyMembers,
+} from "@/stores";
+
+/**
+ * Schema for member profile form.
+ */
+const createProfileSchema = (existingNames: string[], currentName?: string) => {
+  const lowerNames = existingNames
+    .filter((n) => n.toLowerCase() !== currentName?.toLowerCase())
+    .map((n) => n.toLowerCase());
+
+  return z.object({
+    name: z
+      .string()
+      .transform((val) => val.trim())
+      .pipe(
+        z
+          .string()
+          .min(1, "Name is required")
+          .max(30, "Name must be 30 characters or less")
+          .refine((val) => !lowerNames.includes(val.toLowerCase()), {
+            message: "A member with this name already exists",
+          }),
+      ),
+    color: z.enum([
+      "coral",
+      "teal",
+      "green",
+      "purple",
+      "yellow",
+      "pink",
+      "orange",
+    ]),
+    email: z
+      .string()
+      .transform((val) => val.trim())
+      .pipe(
+        z
+          .string()
+          .email("Please enter a valid email")
+          .optional()
+          .or(z.literal("")),
+      ),
+  });
+};
+
+type ProfileFormData = z.infer<ReturnType<typeof createProfileSchema>>;
+
+interface MemberProfileModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memberId: string;
+}
+
+export function MemberProfileModal({
+  open,
+  onOpenChange,
+  memberId,
+}: MemberProfileModalProps) {
+  const member = useFamilyMemberById(memberId);
+  const familyMembers = useFamilyMembers();
+  const { updateMember } = useFamilyActions();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const existingNames = familyMembers.map((m) => m.name);
+  const usedColors = familyMembers
+    .filter((m) => m.id !== memberId)
+    .map((m) => m.color);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<ProfileFormData>({
+    resolver: zodResolver(createProfileSchema(existingNames, member?.name)),
+    defaultValues: {
+      name: member?.name ?? "",
+      color: member?.color ?? "coral",
+      email: member?.email ?? "",
+    },
+  });
+
+  const selectedColor = watch("color");
+
+  // Reset form when member changes
+  useEffect(() => {
+    if (member) {
+      reset({
+        name: member.name,
+        color: member.color,
+        email: member.email ?? "",
+      });
+    }
+  }, [member, reset]);
+
+  if (!member) return null;
+
+  const onSubmit = (data: ProfileFormData) => {
+    updateMember(memberId, {
+      name: data.name,
+      color: data.color,
+      email: data.email || undefined,
+    });
+    onOpenChange(false);
+  };
+
+  const handleAvatarUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    // Validate file type
+    if (!file.type.startsWith("image/")) {
+      return;
+    }
+
+    // Validate file size (max 500KB for localStorage)
+    if (file.size > 500 * 1024) {
+      return;
+    }
+
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const base64 = e.target?.result as string;
+      updateMember(memberId, { avatarUrl: base64 });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleRemoveAvatar = () => {
+    updateMember(memberId, { avatarUrl: undefined });
+  };
+
+  const colors = colorMap[member.color];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-xl">Member Profile</DialogTitle>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => onOpenChange(false)}
+              className="h-8 w-8"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 py-4">
+          {/* Avatar Section */}
+          <div className="flex flex-col items-center gap-3">
+            <div className="relative">
+              {member.avatarUrl ? (
+                <img
+                  src={member.avatarUrl}
+                  alt={member.name}
+                  className="w-20 h-20 rounded-full object-cover"
+                />
+              ) : (
+                <div
+                  className={cn(
+                    "w-20 h-20 rounded-full flex items-center justify-center text-white text-2xl font-bold",
+                    colors?.bg,
+                  )}
+                >
+                  {member.name.charAt(0).toUpperCase()}
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="absolute bottom-0 right-0 w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-md hover:bg-primary/90 transition-colors"
+                aria-label="Upload avatar"
+              >
+                <Camera className="h-4 w-4" />
+              </button>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={handleAvatarUpload}
+              className="hidden"
+              aria-label="Upload avatar image"
+            />
+            {member.avatarUrl && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleRemoveAvatar}
+                className="text-muted-foreground gap-1"
+              >
+                <Trash2 className="h-3 w-3" />
+                Remove photo
+              </Button>
+            )}
+          </div>
+
+          {/* Name Field */}
+          <div className="space-y-2">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              {...register("name")}
+              aria-describedby={errors.name ? "name-error" : undefined}
+              aria-invalid={errors.name ? "true" : undefined}
+            />
+            {errors.name && (
+              <p id="name-error" className="text-sm text-destructive">
+                {errors.name.message}
+              </p>
+            )}
+          </div>
+
+          {/* Color Picker */}
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <ColorPicker
+              value={selectedColor}
+              onChange={(color) =>
+                setValue("color", color, { shouldDirty: true })
+              }
+              usedColors={usedColors as FamilyColor[]}
+              error={errors.color?.message}
+            />
+          </div>
+
+          {/* Email Field */}
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="email@example.com"
+              {...register("email")}
+              aria-describedby={
+                errors.email ? "email-error" : "email-description"
+              }
+              aria-invalid={errors.email ? "true" : undefined}
+            />
+            {errors.email ? (
+              <p id="email-error" className="text-sm text-destructive">
+                {errors.email.message}
+              </p>
+            ) : (
+              <p
+                id="email-description"
+                className="text-xs text-muted-foreground"
+              >
+                Used for Google Calendar sync (coming soon)
+              </p>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isDirty}>
+              Save Changes
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -54,12 +54,9 @@ const createProfileSchema = (existingNames: string[], currentName?: string) => {
     email: z
       .string()
       .transform((val) => val.trim())
-      .pipe(
-        z
-          .string()
-          .email("Please enter a valid email")
-          .optional()
-          .or(z.literal("")),
+      .refine(
+        (val) => val === "" || z.string().email().safeParse(val).success,
+        { message: "Please enter a valid email" },
       ),
   });
 };

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,6 +1,6 @@
 import { Users, X } from "lucide-react";
 import { useState } from "react";
-import { FamilySettingsModal } from "@/components/settings";
+import { FamilySettingsModal, MemberProfileModal } from "@/components/settings";
 import { Button } from "@/components/ui/button";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -14,10 +14,15 @@ export function SidebarMenu() {
   const familyName = useFamilyName();
   const familyMembers = useFamilyMembers();
 
-  // Family settings modal state
+  // Modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
 
   if (!isOpen) return null;
+
+  const handleOpenMemberProfile = (memberId: string) => {
+    setSelectedMemberId(memberId);
+  };
 
   const handleOpenSettings = () => {
     setIsSettingsOpen(true);
@@ -62,16 +67,25 @@ export function SidebarMenu() {
                 return (
                   <button
                     key={member.id}
+                    onClick={() => handleOpenMemberProfile(member.id)}
                     className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted transition-colors"
                   >
-                    <div
-                      className={cn(
-                        "w-8 h-8 rounded-full flex items-center justify-center text-card text-sm font-bold",
-                        colors?.bg,
-                      )}
-                    >
-                      {member.name.charAt(0)}
-                    </div>
+                    {member.avatarUrl ? (
+                      <img
+                        src={member.avatarUrl}
+                        alt={member.name}
+                        className="w-8 h-8 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div
+                        className={cn(
+                          "w-8 h-8 rounded-full flex items-center justify-center text-card text-sm font-bold",
+                          colors?.bg,
+                        )}
+                      >
+                        {member.name.charAt(0)}
+                      </div>
+                    )}
                     <span className="text-sm font-medium text-foreground">
                       {member.name}
                     </span>
@@ -111,6 +125,15 @@ export function SidebarMenu() {
         open={isSettingsOpen}
         onOpenChange={setIsSettingsOpen}
       />
+
+      {/* Member Profile Modal */}
+      {selectedMemberId && (
+        <MemberProfileModal
+          open={!!selectedMemberId}
+          onOpenChange={(open) => !open && setSelectedMemberId(null)}
+          memberId={selectedMemberId}
+        />
+      )}
     </>
   );
 }

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,13 +1,4 @@
-import {
-  Bell,
-  HelpCircle,
-  Home,
-  LogOut,
-  Palette,
-  Settings,
-  Users,
-  X,
-} from "lucide-react";
+import { Users, X } from "lucide-react";
 import { useState } from "react";
 import { FamilySettingsModal } from "@/components/settings";
 import { Button } from "@/components/ui/button";
@@ -33,12 +24,7 @@ export function SidebarMenu() {
   };
 
   const menuItems = [
-    { icon: Home, label: "Home", active: true },
     { icon: Users, label: "Family Settings", action: handleOpenSettings },
-    { icon: Bell, label: "Notifications" },
-    { icon: Palette, label: "Customize" },
-    { icon: Settings, label: "Settings" },
-    { icon: HelpCircle, label: "Help & Support" },
   ];
 
   return (
@@ -109,12 +95,7 @@ export function SidebarMenu() {
                 <button
                   key={index}
                   onClick={item.action}
-                  className={cn(
-                    "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
-                    item.active
-                      ? "bg-primary text-primary-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   <Icon className="h-5 w-5" />
                   {item.label}
@@ -123,14 +104,6 @@ export function SidebarMenu() {
             })}
           </div>
         </nav>
-
-        {/* Footer */}
-        <div className="p-4 border-t border-border">
-          <button className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium text-destructive hover:bg-destructive/10 transition-colors">
-            <LogOut className="h-5 w-5" />
-            Sign Out
-          </button>
-        </div>
       </aside>
 
       {/* Family Settings Modal */}

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -85,6 +85,48 @@ export const createMemberFormSchema = (
 };
 
 /**
+ * Creates a member profile schema with duplicate name and email validation.
+ * Used in MemberProfileModal for editing member profiles.
+ * @param existingNames - Array of existing member names to check against
+ * @param currentName - Current member name (for edit mode, to exclude self)
+ */
+export const createMemberProfileSchema = (
+  existingNames: string[],
+  currentName?: string,
+) => {
+  const lowerNames = existingNames
+    .filter((n) => n.toLowerCase() !== currentName?.toLowerCase())
+    .map((n) => n.toLowerCase());
+
+  return z.object({
+    name: z
+      .string()
+      .transform((val) => val.trim())
+      .pipe(
+        z
+          .string()
+          .min(1, "Name is required")
+          .max(30, "Name must be 30 characters or less")
+          .refine((val) => !lowerNames.includes(val.toLowerCase()), {
+            message: "A member with this name already exists",
+          }),
+      ),
+    color: familyColorSchema,
+    email: z
+      .string()
+      .transform((val) => val.trim())
+      .refine(
+        (val) => val === "" || z.string().email().safeParse(val).success,
+        { message: "Please enter a valid email" },
+      ),
+  });
+};
+
+export type MemberProfileFormData = z.infer<
+  ReturnType<typeof createMemberProfileSchema>
+>;
+
+/**
  * Schema for validating a single family member from localStorage.
  */
 export const familyMemberSchema = z.object({


### PR DESCRIPTION
## Summary

- Clean up sidebar menu by removing non-functional items
- Add MemberProfileModal for editing family member profiles
- Wire sidebar member buttons to open profile modal

### Changes

**Sidebar Cleanup:**
- Remove: Home, Notifications, Customize, Settings, Help & Support, Sign Out
- Keep: Family Settings (functional) and Family Members section

**MemberProfileModal (new):**
- Avatar upload (base64 stored in localStorage, max 500KB)
- Avatar remove functionality
- Name field with duplicate name validation
- Color picker (reuses existing ColorPicker component)
- Email field with validation (prep for Google Calendar sync)

**Sidebar Enhancements:**
- Member buttons now show avatar image when uploaded (or initials fallback)
- Clicking a member opens their profile modal

### Files Changed

| File | Change |
|------|--------|
| `src/components/shared/sidebar-menu.tsx` | Cleanup + wire modal |
| `src/components/settings/member-profile-modal.tsx` | New component |
| `src/components/settings/index.ts` | Export new component |
| `docs/ROADMAP.md` | Add sidebar polish to Sprint 6 |

## Test plan

- [x] All 391 tests pass (`npm run test`)
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Manual testing: avatar upload, name/color/email editing, modal open/close