### PR TITLE
Fix mobile-chrome E2E test failures

### DIFF
--- a/e2e/calendar-navigation.spec.ts
+++ b/e2e/calendar-navigation.spec.ts
@@ -112,8 +112,11 @@ test.describe("Calendar View Navigation", () => {
     await expect(page.getByText("Alice's Task")).toBeVisible();
 
     // Find and click Alice's filter pill to toggle OFF
-    // The pill has Alice's name or initial
-    const alicePill = page.getByRole("button", { name: /Alice/i }).first();
+    // Use aria-label to target filter pills specifically (not event cards)
+    const filterPills = page.getByTestId("family-filter-pills");
+    const alicePill = filterPills.getByRole("button", {
+      name: /Filter by Alice/i,
+    });
     await alicePill.click();
 
     // Wait for filter to apply and verify event is hidden
@@ -125,8 +128,10 @@ test.describe("Calendar View Navigation", () => {
     // Verify event reappears
     await expect(page.getByText("Alice's Task")).toBeVisible();
 
-    // Test "All" toggle
-    const allToggle = page.getByRole("button", { name: /^(All|Some|None)$/i });
+    // Test "All" toggle (scoped to filter pills)
+    const allToggle = filterPills.getByRole("button", {
+      name: /^(All|Some|None)$/i,
+    });
     await allToggle.click();
 
     // If it was "All", now it's "None" - event should be hidden

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -42,7 +42,7 @@ export async function seedFamily(
   const familyData: FamilyStorageData = {
     state: {
       family: {
-        id: "test-family-" + Date.now(),
+        id: `test-family-${Date.now()}`,
         name: options.name,
         members: options.members,
         createdAt: new Date().toISOString(),

--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -31,7 +31,10 @@ export function FamilyFilterPills() {
   };
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div
+      className="flex items-center gap-1.5"
+      data-testid="family-filter-pills"
+    >
       <button
         onClick={handleToggleAll}
         className={cn(
@@ -77,6 +80,7 @@ export function FamilyFilterPills() {
                 : "bg-muted text-muted-foreground hover:bg-muted/80 opacity-50",
             )}
             title={member.name}
+            aria-label={`Filter by ${member.name}`}
           >
             <span
               className={cn(

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -97,11 +97,12 @@ export function ScheduleCalendar({
                 {dayEvents.map((event) => {
                   const member = getFamilyMember(familyMembers, event.memberId);
                   return (
-                    <div
+                    <button
+                      type="button"
                       key={event.id}
                       onClick={() => onEventClick?.(event)}
                       className={cn(
-                        "flex items-start gap-3 p-3 rounded-xl cursor-pointer transition-all hover:scale-[1.01]",
+                        "flex items-start gap-3 p-3 rounded-xl cursor-pointer transition-all hover:scale-[1.01] text-left w-full",
                         member ? colorMap[member.color]?.light : "bg-muted",
                         "border-l-4",
                         member
@@ -150,7 +151,7 @@ export function ScheduleCalendar({
                           </span>
                         </div>
                       </div>
-                    </div>
+                    </button>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Summary
- Fix E2E test failures on `mobile-chrome` and `webkit` browsers that only run on main branch (not on PR checks)
- Change schedule calendar events from `<div>` to `<button>` for semantic HTML and consistent test selectors
- Add `data-testid` and `aria-label` to filter pills for better accessibility and scoped test selectors

## Test plan
- [x] Verified all 16 E2E tests pass locally across all browsers (chromium, firefox, webkit, mobile-chrome)
- [x] Verified lint and unit tests pass