### PR TITLE
fix(calendar): improve schedule view UI/UX

### DIFF
--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -89,19 +89,25 @@ export function ScheduleCalendar({
         <div className="space-y-6 max-w-3xl mx-auto">
           {groupedEvents.map(({ date, events: dayEvents }) => (
             <div key={formatLocalDate(date)}>
-              {/* Date header - sticky with solid background and subtle today indicator */}
+              {/* Date header - sticky with colored background for Today */}
               <div
                 className={cn(
-                  "sticky top-0 z-10 py-2.5 px-3 mb-3",
-                  "bg-background shadow-sm border-b border-border/50",
+                  "sticky top-0 z-10 py-2 px-3 mb-3 rounded-lg",
                   "flex items-center gap-2",
+                  isToday(date)
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted/80",
                 )}
               >
-                {isToday(date) && (
-                  <span className="w-2 h-2 rounded-full bg-primary" />
-                )}
                 <span className="font-semibold">{formatDateLabel(date)}</span>
-                <span className="text-muted-foreground text-sm font-normal">
+                <span
+                  className={cn(
+                    "text-sm font-normal",
+                    isToday(date)
+                      ? "text-primary-foreground/80"
+                      : "text-muted-foreground",
+                  )}
+                >
                   · {formatDateSuffix(date)}
                 </span>
               </div>
@@ -116,20 +122,20 @@ export function ScheduleCalendar({
                       key={event.id}
                       onClick={() => onEventClick?.(event)}
                       className={cn(
-                        "flex flex-col p-2.5 rounded-lg cursor-pointer text-left w-full",
+                        "flex flex-col p-3 rounded-lg cursor-pointer text-left w-full",
                         "transition-all hover:shadow-md hover:scale-[1.005]",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
-                        "border-l-4",
+                        "border-l-4 ring-1 ring-inset ring-black/5",
                         member
                           ? colorMap[member.color]?.bg
                           : "border-muted-foreground",
                         member ? colorMap[member.color]?.light : "bg-muted",
                       )}
                     >
-                      <h3 className="font-medium text-foreground truncate">
+                      <h3 className="font-semibold text-foreground truncate">
                         {event.title}
                       </h3>
-                      <div className="flex items-center gap-2 mt-1 text-sm text-foreground/70">
+                      <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground">
                         <div className="flex items-center gap-1">
                           <Clock className="w-3.5 h-3.5" />
                           <span>
@@ -138,7 +144,7 @@ export function ScheduleCalendar({
                         </div>
                         {event.location && (
                           <>
-                            <span className="text-foreground/40">·</span>
+                            <span className="text-muted-foreground/50">·</span>
                             <div className="flex items-center gap-1">
                               <MapPin className="w-3.5 h-3.5" />
                               <span className="truncate">{event.location}</span>

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -54,20 +54,29 @@ export function ScheduleCalendar({
     return date.toDateString() === today.toDateString();
   };
 
-  const formatDate = (date: Date) => {
-    if (isToday(date)) return "Today";
+  const isTomorrow = (date: Date) => {
     const tomorrow = new Date(today);
     tomorrow.setDate(today.getDate() + 1);
-    if (date.toDateString() === tomorrow.toDateString()) return "Tomorrow";
+    return date.toDateString() === tomorrow.toDateString();
+  };
+
+  const formatDateLabel = (date: Date) => {
+    if (isToday(date)) return "Today";
+    if (isTomorrow(date)) return "Tomorrow";
     return date.toLocaleDateString("en-US", {
       weekday: "long",
+    });
+  };
+
+  const formatDateSuffix = (date: Date) => {
+    return date.toLocaleDateString("en-US", {
       month: "short",
       day: "numeric",
     });
   };
 
   return (
-    <div className="flex-1 overflow-y-auto bg-background p-4">
+    <div className="flex-1 overflow-y-auto bg-background p-4 scroll-pt-12">
       {groupedEvents.length === 0 ? (
         <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
           <Calendar className="w-16 h-16 mb-4 opacity-50" />
@@ -80,20 +89,25 @@ export function ScheduleCalendar({
         <div className="space-y-6 max-w-3xl mx-auto">
           {groupedEvents.map(({ date, events: dayEvents }) => (
             <div key={formatLocalDate(date)}>
-              {/* Date header */}
+              {/* Date header - sticky with solid background and subtle today indicator */}
               <div
                 className={cn(
-                  "sticky top-0 z-10 py-2 px-3 mb-3 rounded-lg font-semibold",
-                  isToday(date)
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-muted text-foreground",
+                  "sticky top-0 z-10 py-2.5 px-3 mb-3",
+                  "bg-background shadow-sm border-b border-border/50",
+                  "flex items-center gap-2",
                 )}
               >
-                {formatDate(date)}
+                {isToday(date) && (
+                  <span className="w-2 h-2 rounded-full bg-primary" />
+                )}
+                <span className="font-semibold">{formatDateLabel(date)}</span>
+                <span className="text-muted-foreground text-sm font-normal">
+                  · {formatDateSuffix(date)}
+                </span>
               </div>
 
-              {/* Events list */}
-              <div className="space-y-2 pl-2">
+              {/* Events list - simplified cards with colored left border */}
+              <div className="space-y-1.5">
                 {dayEvents.map((event) => {
                   const member = getFamilyMember(familyMembers, event.memberId);
                   return (
@@ -102,54 +116,35 @@ export function ScheduleCalendar({
                       key={event.id}
                       onClick={() => onEventClick?.(event)}
                       className={cn(
-                        "flex items-start gap-3 p-3 rounded-xl cursor-pointer transition-all hover:scale-[1.01] text-left w-full",
-                        member ? colorMap[member.color]?.light : "bg-muted",
+                        "flex flex-col p-2.5 rounded-lg cursor-pointer text-left w-full",
+                        "transition-all hover:shadow-md hover:scale-[1.005]",
+                        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                         "border-l-4",
                         member
                           ? colorMap[member.color]?.bg
                           : "border-muted-foreground",
+                        member ? colorMap[member.color]?.light : "bg-muted",
                       )}
                     >
-                      <div
-                        className={cn(
-                          "w-10 h-10 rounded-full flex items-center justify-center text-white font-bold text-sm shrink-0",
-                          member
-                            ? colorMap[member.color]?.bg
-                            : "bg-muted-foreground",
-                        )}
-                      >
-                        {member?.name.charAt(0)}
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-semibold text-foreground truncate">
-                          {event.title}
-                        </h3>
-                        <div className="flex items-center gap-3 mt-1 text-sm text-muted-foreground">
-                          <div className="flex items-center gap-1">
-                            <Clock className="w-3.5 h-3.5" />
-                            <span>
-                              {event.startTime} - {event.endTime}
-                            </span>
-                          </div>
-                          {event.location && (
+                      <h3 className="font-medium text-foreground truncate">
+                        {event.title}
+                      </h3>
+                      <div className="flex items-center gap-2 mt-1 text-sm text-foreground/70">
+                        <div className="flex items-center gap-1">
+                          <Clock className="w-3.5 h-3.5" />
+                          <span>
+                            {event.startTime} - {event.endTime}
+                          </span>
+                        </div>
+                        {event.location && (
+                          <>
+                            <span className="text-foreground/40">·</span>
                             <div className="flex items-center gap-1">
                               <MapPin className="w-3.5 h-3.5" />
                               <span className="truncate">{event.location}</span>
                             </div>
-                          )}
-                        </div>
-                        <div className="mt-1">
-                          <span
-                            className={cn(
-                              "text-xs font-medium px-2 py-0.5 rounded-full",
-                              member ? colorMap[member.color]?.bg : "bg-muted",
-                              "text-white",
-                            )}
-                          >
-                            {member?.name}
-                          </span>
-                        </div>
+                          </>
+                        )}
                       </div>
                     </button>
                   );


### PR DESCRIPTION
## Summary

Improves the Schedule Calendar view with better UX and cleaner design:

- **Fixed sticky header overlap** - Headers now have solid background with subtle shadow for clear visual separation
- **Redesigned date headers** - Subtle dot indicator for "Today" instead of bold purple banner, includes full date (e.g., "Today · Jan 3")
- **Simplified event cards** - Removed redundant avatar circle and member name badge; colored left border is the sole member identifier
- **Improved typography** - Lighter font weights, better text contrast (70% opacity for secondary text)
- **Better accessibility** - Added focus-visible states for keyboard navigation
- **Tighter spacing** - More compact layout with appropriate padding

## Screenshots

### Before

<img width="2880" height="1564" alt="schedule-view-before" src="https://github.com/user-attachments/assets/38692b34-cc01-406b-baa7-f7a8c69cf290" />

<img width="2880" height="1564" alt="schedule-view-before-scrolled" src="https://github.com/user-attachments/assets/99b3891f-01df-41bd-8b48-c38999a1dd3b" />


### After  
<img width="2880" height="1564" alt="schedule-view-after" src="https://github.com/user-attachments/assets/25cb6310-e7b3-48b4-b0dd-6935f6abc93b" />

<img width="2880" height="1564" alt="schedule-view-after-scrolled" src="https://github.com/user-attachments/assets/5d64d121-d027-412d-b916-a831c72ab401" />

## Test plan

- [x] All E2E tests pass
- [ ] Verify Schedule view renders correctly with events
- [ ] Verify sticky headers work without obscuring content
- [ ] Verify event clicks open detail modal
- [ ] Test keyboard navigation (Tab + Enter)