### PR TITLE
feat: add mobile home dashboard with module cards

### DIFF
--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -76,8 +76,25 @@ export async function waitForHydration(page: Page): Promise<void> {
 /**
  * Wait for the calendar module to be fully loaded
  * The FAB (Add event button) is a reliable indicator
+ *
+ * On mobile (<640px), the app starts on home dashboard,
+ * so we need to navigate to calendar first.
  */
 export async function waitForCalendar(page: Page): Promise<void> {
+  // Check if we're on the mobile home dashboard by looking for the "Home" heading
+  const homeHeading = page.getByRole("heading", { name: "Home", level: 1 });
+  const isOnHomeDashboard = await homeHeading.isVisible().catch(() => false);
+
+  if (isOnHomeDashboard) {
+    // We're on mobile home dashboard - click Calendar card to navigate
+    // Use the button within main content area (not nav tabs)
+    await page
+      .locator("main")
+      .getByRole("button", { name: "Calendar" })
+      .click();
+  }
+
+  // Now wait for calendar to load
   await page
     .getByRole("button", { name: "Add event" })
     .waitFor({ state: "visible", timeout: 10000 });

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { clearStorage, waitForHydration } from "./helpers/test-helpers";
+import {
+  clearStorage,
+  waitForCalendar,
+  waitForHydration,
+} from "./helpers/test-helpers";
 
 test.describe("First-Time User Onboarding", () => {
   test.beforeEach(async ({ page }) => {
@@ -80,10 +84,9 @@ test.describe("First-Time User Onboarding", () => {
     await completeButton.click();
 
     // Verify main app is showing
-    // The FAB (Add event button) indicates calendar is loaded
-    await expect(page.getByRole("button", { name: "Add event" })).toBeVisible({
-      timeout: 10000,
-    });
+    // On mobile, this shows home dashboard first; on desktop, shows calendar
+    // waitForCalendar handles both cases by navigating from home if needed
+    await waitForCalendar(page);
 
     // Verify family name appears in header
     await expect(page.getByText("The Johnsons")).toBeVisible();
@@ -93,9 +96,8 @@ test.describe("First-Time User Onboarding", () => {
     await waitForHydration(page);
 
     // Should still be on main app (not onboarding)
-    await expect(page.getByRole("button", { name: "Add event" })).toBeVisible({
-      timeout: 10000,
-    });
+    // On mobile, this will be home dashboard; waitForCalendar handles it
+    await waitForCalendar(page);
 
     // Family name should still be visible
     await expect(page.getByText("The Johnsons")).toBeVisible();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { CalendarModule } from "@/components/calendar";
+import { HomeDashboard } from "@/components/home";
 import { AppHeader, NavigationTabs, SidebarMenu } from "@/components/shared";
+import { useIsMobile } from "@/hooks";
 import {
   type ModuleType,
   useAppStore,
@@ -35,7 +37,11 @@ function ModuleLoader() {
   );
 }
 
-function renderModule(activeModule: ModuleType) {
+function renderModule(activeModule: ModuleType | null) {
+  if (activeModule === null) {
+    return <HomeDashboard />;
+  }
+
   switch (activeModule) {
     case "calendar":
       return <CalendarModule />;
@@ -70,8 +76,17 @@ function renderModule(activeModule: ModuleType) {
 
 export default function FamilyHub() {
   const activeModule = useAppStore((state) => state.activeModule);
+  const setActiveModule = useAppStore((state) => state.setActiveModule);
   const hasHydrated = useHasHydrated();
   const setupComplete = useSetupComplete();
+  const isMobile = useIsMobile();
+
+  // On desktop, redirect null (home) to calendar since home is mobile-only
+  useEffect(() => {
+    if (!isMobile && activeModule === null) {
+      setActiveModule("calendar");
+    }
+  }, [isMobile, activeModule, setActiveModule]);
 
   // Wait for store to hydrate from localStorage
   if (!hasHydrated) {

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -1,0 +1,61 @@
+import {
+  Calendar,
+  CheckSquare,
+  ImageIcon,
+  ListTodo,
+  UtensilsCrossed,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { type ModuleType, useAppStore } from "@/stores";
+
+const modules: Array<{
+  id: ModuleType;
+  label: string;
+  icon: typeof Calendar;
+  color: string;
+}> = [
+  { id: "calendar", label: "Calendar", icon: Calendar, color: "bg-purple-500" },
+  { id: "lists", label: "Lists", icon: ListTodo, color: "bg-teal-500" },
+  { id: "chores", label: "Chores", icon: CheckSquare, color: "bg-green-500" },
+  {
+    id: "meals",
+    label: "Meals",
+    icon: UtensilsCrossed,
+    color: "bg-orange-500",
+  },
+  { id: "photos", label: "Photos", icon: ImageIcon, color: "bg-pink-500" },
+];
+
+export function HomeDashboard() {
+  const setActiveModule = useAppStore((state) => state.setActiveModule);
+
+  return (
+    <div className="flex-1 p-4 overflow-y-auto">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-foreground">Home</h1>
+        <p className="text-muted-foreground">What would you like to do?</p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        {modules.map((module) => {
+          const Icon = module.icon;
+          return (
+            <button
+              type="button"
+              key={module.id}
+              onClick={() => setActiveModule(module.id)}
+              className={cn(
+                "flex flex-col items-center justify-center gap-3 p-6 rounded-2xl",
+                "text-white shadow-md active:scale-95 transition-transform",
+                module.color,
+              )}
+            >
+              <Icon className="h-10 w-10" />
+              <span className="text-lg font-semibold">{module.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,0 +1,1 @@
+export { HomeDashboard } from "./home-dashboard";

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,5 +1,6 @@
-import { Cloud, Menu, Settings, Sun } from "lucide-react";
+import { Cloud, Home, Menu, Settings, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks";
 import { colorMap } from "@/lib/types";
 import {
   useAppStore,
@@ -17,7 +18,13 @@ export function AppHeader() {
   const familyMembers = useFamilyMembers();
 
   // From app-store
+  const activeModule = useAppStore((state) => state.activeModule);
+  const setActiveModule = useAppStore((state) => state.setActiveModule);
   const openSidebar = useAppStore((state) => state.openSidebar);
+
+  // Mobile detection
+  const isMobile = useIsMobile();
+  const showHomeButton = isMobile && activeModule !== null;
 
   const formatDate = (date: Date) => {
     return date.toLocaleDateString("en-US", {
@@ -38,6 +45,18 @@ export function AppHeader() {
   return (
     <header className="flex items-center justify-between px-6 py-4 bg-card border-b border-border">
       <div className="flex items-center gap-4">
+        {/* Home button - mobile only, when not on home dashboard */}
+        {showHomeButton && (
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Home"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={() => setActiveModule(null)}
+          >
+            <Home className="h-6 w-6" />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon"

--- a/src/components/shared/navigation-tabs.tsx
+++ b/src/components/shared/navigation-tabs.tsx
@@ -24,7 +24,7 @@ export function NavigationTabs() {
   const setActiveModule = useAppStore((state) => state.setActiveModule);
 
   return (
-    <nav className="w-20 flex flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
+    <nav className="hidden sm:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeModule === tab.id;

--- a/src/stores/app-store.test.ts
+++ b/src/stores/app-store.test.ts
@@ -5,8 +5,8 @@ describe("AppStore", () => {
   // Store reset handled globally by setup.ts afterEach via resetAllStores()
 
   describe("initial state", () => {
-    it("initializes with activeModule = 'calendar'", () => {
-      expect(useAppStore.getState().activeModule).toBe("calendar");
+    it("initializes with activeModule = null (home dashboard)", () => {
+      expect(useAppStore.getState().activeModule).toBe(null);
     });
 
     it("initializes with isSidebarOpen = false", () => {
@@ -27,6 +27,13 @@ describe("AppStore", () => {
       useAppStore.getState().setActiveModule(module);
 
       expect(useAppStore.getState().activeModule).toBe(module);
+    });
+
+    it("sets activeModule to null (home dashboard)", () => {
+      useAppStore.getState().setActiveModule("calendar");
+      useAppStore.getState().setActiveModule(null);
+
+      expect(useAppStore.getState().activeModule).toBe(null);
     });
 
     it("switching modules does not affect other state", () => {

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -4,19 +4,19 @@ export type ModuleType = "calendar" | "lists" | "chores" | "meals" | "photos";
 
 interface AppState {
   // State
-  activeModule: ModuleType;
+  activeModule: ModuleType | null; // null = home dashboard (mobile only)
   isSidebarOpen: boolean;
 
   // Actions
-  setActiveModule: (module: ModuleType) => void;
+  setActiveModule: (module: ModuleType | null) => void;
   openSidebar: () => void;
   closeSidebar: () => void;
   toggleSidebar: () => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
-  // Initial state
-  activeModule: "calendar",
+  // Initial state - null shows home dashboard on mobile, desktop redirects to calendar
+  activeModule: null,
   isSidebarOpen: false,
 
   // Actions


### PR DESCRIPTION
## Summary

- Add a mobile-only home dashboard that displays module cards as the landing page on mobile devices (<640px)
- Desktop experience remains unchanged with the existing sidebar navigation
- Users can tap module cards to navigate to Calendar, Lists, Chores, Meals, or Photos
- A Home button appears in the header when inside a module to return to the dashboard

## Changes

- **app-store.ts**: Updated `activeModule` type to `ModuleType | null` (null = home dashboard)
- **HomeDashboard component**: New 2-column grid of colored module cards
- **App.tsx**: Renders HomeDashboard when `activeModule` is null; redirects desktop to calendar
- **NavigationTabs**: Hidden on mobile with `hidden sm:flex`
- **AppHeader**: Added conditional Home button for mobile navigation

## Test plan

- [x] Mobile (<640px): Opens to home dashboard with 5 module cards
- [x] Mobile: Tapping a card navigates to that module
- [x] Mobile: Home icon appears in header when inside a module
- [x] Mobile: Tapping Home icon returns to dashboard
- [x] Desktop (>=640px): Sidebar navigation unchanged, no home dashboard
- [x] All tests pass (`npm run test`)
- [x] Build succeeds (`npm run build`)

## Screenshots

Screenshots taken with Playwright MCP - will upload manually:
<img width="2880" height="1564" alt="desktop-calendar-view" src="https://github.com/user-attachments/assets/eca391e5-aa23-4d38-b179-ff024543d16c" />
<img width="375" height="667" alt="mobile-home-dashboard" src="https://github.com/user-attachments/assets/0b8a3fe4-a62f-4771-8f0a-4e29ffe6839a" />
<img width="375" height="667" alt="mobile-calendar-with-home-button" src="https://github.com/user-attachments/assets/ad2dc934-4a47-40bf-8076-980cb7335a5a" />
