### PR TITLE
fix: clean up mobile header for better UX

### DIFF
--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -70,26 +70,31 @@ export function AppHeader() {
           <h1 className="text-xl font-bold text-foreground">
             {familyName || "Family Hub"}
           </h1>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <span>{formatDate(currentDate)}</span>
-            <span>•</span>
-            <span>{formatTime(new Date())}</span>
-          </div>
+          {/* Date/time - hidden on mobile (device shows in status bar) */}
+          {!isMobile && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span>{formatDate(currentDate)}</span>
+              <span>•</span>
+              <span>{formatTime(new Date())}</span>
+            </div>
+          )}
         </div>
       </div>
 
       <div className="flex items-center gap-6">
-        {/* Weather */}
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <div className="relative">
-            <Sun className="h-5 w-5 text-yellow-500" />
-            <Cloud className="h-4 w-4 text-gray-400 absolute -bottom-1 -right-1" />
+        {/* Weather - hidden on mobile (future: widget on desktop) */}
+        {!isMobile && (
+          <div className="flex items-center gap-2 text-muted-foreground">
+            <div className="relative">
+              <Sun className="h-5 w-5 text-yellow-500" />
+              <Cloud className="h-4 w-4 text-gray-400 absolute -bottom-1 -right-1" />
+            </div>
+            <span className="text-sm font-medium">72°</span>
           </div>
-          <span className="text-sm font-medium">72°</span>
-        </div>
+        )}
 
-        {/* Family member indicators */}
-        {familyMembers.length > 0 && (
+        {/* Family member indicators - hidden on mobile (used for calendar filtering) */}
+        {!isMobile && familyMembers.length > 0 && (
           <div className="flex items-center gap-1.5">
             {familyMembers.slice(0, 6).map((member) => (
               <div


### PR DESCRIPTION
## Summary

Simplifies the mobile header by hiding elements that are either redundant or not useful on small screens:

- **Date/time**: Removed on mobile - device status bar already shows this
- **Weather**: Removed on mobile - will be a desktop widget in future (fits "at a glance" vision better)
- **Family member dots**: Removed on mobile - only useful for calendar filtering, adds visual noise elsewhere

## Before / After

**Before (cluttered):**
- Menu, family name, date (wrapping awkwardly), time, weather, 4 family dots, settings
- Everything competing for ~375px of width

**After (clean):**
- Menu, family name, settings
- Clear visual hierarchy, room to breathe

## Desktop Unchanged

Desktop header retains all elements: date/time, weather, family member indicators.

## Screenshots

Will upload manually:
<img width="375" height="667" alt="mobile-header-after-cleanup" src="https://github.com/user-attachments/assets/bc65e30a-ba93-4e85-8b4a-954e448a7a28" />
<img width="375" height="667" alt="mobile-calendar-header-after-cleanup" src="https://github.com/user-attachments/assets/aa98701e-c304-4850-b27a-cc4d97334b03" />
<img width="1280" height="800" alt="desktop-header-unchanged" src="https://github.com/user-attachments/assets/92d7016b-aaa7-42fe-a815-96a3605c1971" />

## Test plan

- [x] All 16 E2E tests pass
- [x] Mobile header shows only: Menu, family name, Settings
- [x] Mobile header in module shows: Home, Menu, family name, Settings  
- [x] Desktop header unchanged with all elements