### PR TITLE
fix(e2e): improve CI stability for calendar CRUD test

### DIFF
--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -61,6 +61,9 @@ test.describe("Calendar Event CRUD", () => {
       .getByRole("button", { name: /Team Meeting/ })
       .first();
     await eventCard.waitFor({ state: "visible" });
+    // Brief wait for React to fully attach event handlers after render
+    // This helps prevent race conditions in slower CI environments
+    await page.waitForLoadState("domcontentloaded");
     await eventCard.click({ force: true });
 
     // Wait for dialog to fully open

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import type { FamilyColor, FamilyMember } from "../../src/lib/types/family";
 
 /**
@@ -74,8 +74,8 @@ export async function waitForHydration(page: Page): Promise<void> {
 }
 
 /**
- * Wait for the calendar module to be fully loaded
- * The FAB (Add event button) is a reliable indicator
+ * Wait for the calendar module to be fully loaded.
+ * The FAB (Add event button) is a reliable indicator.
  *
  * On mobile (<640px), the app starts on home dashboard,
  * so we need to navigate to calendar first.
@@ -94,10 +94,13 @@ export async function waitForCalendar(page: Page): Promise<void> {
       .click();
   }
 
-  // Now wait for calendar to load
+  // Wait for calendar UI to load
   await page
     .getByRole("button", { name: "Add event" })
     .waitFor({ state: "visible", timeout: 10000 });
+
+  // Wait for network to settle to ensure TanStack Query has completed initial fetches
+  await page.waitForLoadState("networkidle");
 }
 
 /**
@@ -138,12 +141,13 @@ export function getTodayDateString(): string {
 
 /**
  * Wait for a Radix dialog to fully open.
- * Uses data-state attribute which is deterministic.
+ * Uses expect() with auto-retry for more reliability in CI.
  * In CI with reducedMotion, animations are instant.
  */
 export async function waitForDialogOpen(page: Page): Promise<void> {
   const dialog = page.getByRole("dialog");
-  await dialog.waitFor({ state: "visible" });
+  // Use expect with auto-retry instead of waitFor for better CI stability
+  await expect(dialog).toBeVisible({ timeout: 10000 });
   // Ensure Radix has finished mounting by checking data-state
   await page.waitForSelector('[data-state="open"]', { state: "attached" });
 }


### PR DESCRIPTION
## Summary
Fixes the E2E test timeout failures in CI that started after the family API migration (Zustand → TanStack Query).

## Problem
The E2E test `creates, views, edits, and deletes an event` in `calendar-crud.spec.ts` was timing out in CI with a 60-second timeout when waiting for dialogs to open. The test passed locally on all 4 browsers but failed consistently in CI on all desktop browsers (chromium, firefox, webkit).

**Error location:** Line 67 - `waitForDialogOpen(page)` after clicking an event card to view details.

**Timeline:** CI started failing after commit `badf3c0` on main (post family API migration merge). Last passing CI was `c8cd9fb`.

## Root Cause Analysis
After investigation, the issue appears to be a timing/initialization race condition specific to CI environments:

1. The test passes locally on all browsers (macOS, Node 20)
2. The test fails in CI on all desktop browsers (Ubuntu, Node 22)
3. The event card IS visible and clickable, but the dialog never opens
4. This suggests the React event handlers may not be fully attached when the click occurs

**Environmental differences:**
| Factor | Local | CI |
|--------|-------|-----|
| Node.js | 20.12.2 | 22.21.1 |
| OS | macOS | Ubuntu |
| Server | `reuseExistingServer: true` | `false` |
| Motion | `no-preference` | `reduce` |

## Solution
Made three improvements to E2E test helpers for better CI stability:

1. **`waitForCalendar`**: Added `networkidle` wait to ensure TanStack Query has completed initial data fetches before proceeding
2. **`waitForDialogOpen`**: Changed from `waitFor` to `expect().toBeVisible()` with auto-retry for better handling of timing variations
3. **`calendar-crud.spec.ts`**: Added `domcontentloaded` wait before clicking event cards to ensure React has fully attached event handlers

## Debugging Guide (for future reference)

### How to investigate CI-only E2E failures:

1. **Check CI logs for exact error location:**
   ```bash
   gh run view <run-id> --log-failed | head -100
   ```

2. **Compare passing vs failing commits:**
   ```bash
   gh run list --limit 15 --json conclusion,headSha
   git log --oneline <last-passing>..<first-failing>
   ```

3. **Key indicators of timing issues:**
   - Test passes locally but fails in CI
   - Element IS visible but click doesn't trigger expected behavior
   - Failures across ALL browsers (not browser-specific)

4. **Common fixes for CI timing issues:**
   - Use `expect().toBeVisible()` instead of `waitFor()` (has auto-retry)
   - Add `waitForLoadState("networkidle")` after page changes
   - Add `waitForLoadState("domcontentloaded")` before clicking dynamic elements
   - Avoid `waitForTimeout()` - use state-based waits instead

### Playwright best practices applied:
- `expect()` assertions have built-in auto-retry (5 seconds default)
- `waitFor()` does NOT retry - it just polls
- `networkidle` ensures all XHR/fetch requests have completed
- `domcontentloaded` ensures DOM is ready (React hydration complete)

## Test Plan
- [x] All 12 desktop E2E tests pass locally (chromium, firefox, webkit)
- [x] CI passes on this PR
- [x] No regressions in other tests

## Notes
- Mobile-chrome tests have pre-existing flakiness on main (unrelated to this fix) due to sticky header element interception - tracked separately
- This fix focuses on the desktop browser failures that were blocking CI