### PR TITLE
feat: add JWT authentication for family login

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -1,6 +1,6 @@
 # Technical Debt & Deferred Improvements
 
-**Last Updated:** January 7, 2026
+**Last Updated:** January 14, 2026
 
 This document tracks known technical debt, deferred improvements, and future enhancements identified during code reviews. Items are prioritized and linked to relevant sprints.
 
@@ -51,7 +51,35 @@ Add mutation tests covering:
 
 ## Medium Priority (Future Sprint)
 
-### 1. Orphaned Events Warning
+### 1. Mobile-Chrome E2E Test Flakiness
+**Source:** PR #34, PR #35
+**Files:** `e2e/*.spec.ts`, `playwright.config.ts`
+**Status:** Tracked - intermittent failures
+
+**Problem:**
+Mobile-chrome E2E tests are flaky in CI, particularly around:
+- Sticky header element interception during clicks
+- Timing issues with dialog transitions
+- App state transitions after registration
+
+**Symptoms:**
+- Tests pass on desktop browsers (chromium, firefox, webkit) but fail intermittently on mobile-chrome
+- Element is visible but click doesn't trigger expected behavior
+- Timeouts waiting for elements that should be present
+
+**Mitigations Applied:**
+- Added `force: true` for event card clicks (PR#34)
+- Added explicit waits for state transitions (PR#35)
+- Using `expect().toBeVisible()` with auto-retry instead of `waitFor()`
+
+**Potential Fixes (not yet implemented):**
+- Investigate sticky header z-index issues on mobile viewport
+- Consider skipping mobile-chrome for specific flaky tests
+- Add mobile-specific wait strategies
+
+---
+
+### 2. Orphaned Events Warning
 **Source:** PR #10 Review (Sprint 5)
 **Files:** `src/stores/family-store.ts`, `src/components/settings/family-settings-modal.tsx`
 **Status:** Deferred to Backend Integration
@@ -131,10 +159,12 @@ See `.env.example` for environment variable documentation.
 - [ ] Implement calendar endpoints
 - [ ] Implement family endpoints
 
-**Phase 3: Authentication**
-- [ ] Add auth system (JWT recommended for API)
-- [ ] `httpClient` has `onUnauthorized` hook ready (`src/api/client/http-client.ts:13`)
-- [ ] Add protected routes / redirect to login
+**Phase 3: Authentication** ✅ COMPLETED (PR #35)
+- [x] Add auth system (JWT-based with mock API)
+- [x] `httpClient` injects auth headers (`src/api/client/http-client.ts`)
+- [x] Login screen gates unauthenticated users
+- [x] Onboarding includes credentials step (username + password)
+- [x] Logout clears auth state and redirects to login
 
 ### API Contracts
 
@@ -188,6 +218,8 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| Auth Store Test Isolation (unit + E2E test fixes) | Sprint 7 | #35 | Jan 14, 2026 |
+| E2E CI Stability Improvements (timing/hydration) | Sprint 7 | #34 | Jan 8, 2026 |
 | Family API Service Layer (TanStack Query migration) | Sprint 6.5 | #32 | Jan 7, 2026 |
 | Test Pattern Standardization | Sprint 6 | #25 | Jan 3, 2026 |
 | Data Validation on Rehydration (Zod schema) | Sprint 5 | - | Dec 27, 2025 |

--- a/docs/backend/00-QUICK-START.md
+++ b/docs/backend/00-QUICK-START.md
@@ -1,0 +1,322 @@
+# FamilyHub Backend - Quick Start Guide
+
+> **Start here.** This guide gets you from zero to running backend in under 30 minutes.
+
+---
+
+## What You're Building
+
+You have a beautiful React frontend that currently runs entirely in the browser with mock data. You're about to give it a real backend, which means:
+
+- **Real persistence** - Data survives browser refreshes, device changes
+- **Multi-user support** - Your whole family can access the same data
+- **Security** - Proper authentication, no data leaks
+- **Scalability** - From demo to production-ready
+
+---
+
+## The Documents
+
+I've created four detailed documents. Here's what each covers and when to read them:
+
+| Document | Purpose | When to Read |
+|----------|---------|--------------|
+| [01-PRD.md](./01-PRD.md) | Product vision, requirements, success criteria | **Now** - understand what you're building |
+| [02-API-CONTRACT.md](./02-API-CONTRACT.md) | Exact API specifications your backend must implement | **During development** - your source of truth |
+| [03-ARCHITECTURE.md](./03-ARCHITECTURE.md) | Code structure, patterns, technical decisions | **Before coding** - understand the why |
+| [04-ROADMAP.md](./04-ROADMAP.md) | Step-by-step implementation phases | **During development** - your checklist |
+
+---
+
+## The 30-Minute Setup
+
+### Prerequisites Check
+```bash
+# Java 21
+java -version  # Should show 21.x
+
+# Maven
+mvn -version  # Should show 3.9+
+
+# Docker
+docker --version  # Any recent version
+```
+
+### Step 1: Create the Project (5 min)
+
+Option A - Spring Initializr CLI:
+```bash
+curl https://start.spring.io/starter.tgz \
+  -d type=maven-project \
+  -d language=java \
+  -d bootVersion=3.2.0 \
+  -d baseDir=family-hub-backend \
+  -d groupId=com.familyhub \
+  -d artifactId=api \
+  -d name=FamilyHubApi \
+  -d javaVersion=21 \
+  -d dependencies=web,data-jpa,postgresql,security,validation,flyway,lombok,actuator \
+  | tar -xzf -
+```
+
+Option B - [start.spring.io](https://start.spring.io):
+1. Set Java version to 21
+2. Add dependencies: Spring Web, Spring Data JPA, PostgreSQL Driver, Spring Security, Validation, Flyway Migration, Lombok, Actuator
+3. Generate and extract
+
+### Step 2: Start Database (2 min)
+
+Create `docker/docker-compose.yml`:
+```yaml
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: familyhub
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: familyhub
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:
+```
+
+Start it:
+```bash
+cd family-hub-backend
+docker compose -f docker/docker-compose.yml up -d
+```
+
+### Step 3: Configure Application (5 min)
+
+Update `src/main/resources/application.yml`:
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/familyhub
+    username: familyhub
+    password: localdev
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+jwt:
+  secret: your-256-bit-secret-key-change-in-production-please
+  access-token-expiry: 24h
+  refresh-token-expiry: 30d
+
+server:
+  port: 8080
+```
+
+### Step 4: Add Health Endpoint (5 min)
+
+Create `src/main/java/com/familyhub/api/HealthController.java`:
+```java
+package com.familyhub.api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.time.Instant;
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/api/health")
+    public Map<String, Object> health() {
+        return Map.of(
+            "status", "healthy",
+            "timestamp", Instant.now().toString(),
+            "version", "0.1.0"
+        );
+    }
+}
+```
+
+### Step 5: Disable Security Temporarily (2 min)
+
+Create `src/main/java/com/familyhub/config/SecurityConfig.java`:
+```java
+package com.familyhub.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .build();
+    }
+}
+```
+
+### Step 6: Create First Migration (5 min)
+
+Create `src/main/resources/db/migration/V1__initial_schema.sql`:
+```sql
+-- Just a placeholder to verify Flyway works
+CREATE TABLE schema_info (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+INSERT INTO schema_info (description) VALUES ('Initial schema setup');
+```
+
+### Step 7: Run It! (2 min)
+
+```bash
+./mvnw spring-boot:run
+```
+
+Test it:
+```bash
+curl http://localhost:8080/api/health
+```
+
+You should see:
+```json
+{"status":"healthy","timestamp":"2026-01-08T12:00:00Z","version":"0.1.0"}
+```
+
+---
+
+## What's Next?
+
+Now that you have a running skeleton, follow the roadmap:
+
+1. **Read the PRD** (`01-PRD.md`) to understand the full scope
+2. **Study the Architecture** (`03-ARCHITECTURE.md`) before writing more code
+3. **Keep the API Contract** (`02-API-CONTRACT.md`) open as you implement
+4. **Follow the Roadmap** (`04-ROADMAP.md`) phase by phase
+
+### Immediate Next Steps
+
+1. **Phase 1: Authentication** - This is foundational. You can't do anything without it.
+   - Add JWT dependencies to pom.xml
+   - Create User entity and migration
+   - Implement register/login endpoints
+
+2. **Phase 2: Family Module** - This unlocks the frontend
+   - The frontend literally can't work without this
+   - Follow the API contract exactly
+
+3. **Phase 3: Calendar Module** - The main feature
+   - Most complex module
+   - Pay attention to time format handling
+
+---
+
+## Key Reminders
+
+### The API Contract is LAW
+
+Your frontend already expects specific request/response formats. The mock handlers show exactly what the backend needs to do. Don't deviate from the contract.
+
+Example - This is what the frontend expects:
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "The Johnsons",
+    "members": [...],
+    "setupComplete": true
+  },
+  "meta": {
+    "timestamp": 1735689600000,
+    "requestId": "uuid"
+  }
+}
+```
+
+### Time Formats Matter
+
+The frontend uses 12-hour time strings: `"9:00 AM"`, `"2:30 PM"`
+
+Your backend should:
+- Accept these strings in requests
+- Return these strings in responses
+- Store as `LocalTime` internally
+- Use the `TimeUtils` helper for conversion
+
+### Test Against the Frontend
+
+The best test is: does the frontend work?
+
+1. Start your backend
+2. Update frontend's `VITE_API_BASE_URL`
+3. Set `USE_MOCK_API = false`
+4. Try creating a family
+5. Try adding events
+
+If something breaks, check:
+- Response format matches contract?
+- Field names exact match (camelCase)?
+- Error responses match expected format?
+
+---
+
+## Common Gotchas
+
+### 1. CORS Errors
+Frontend on `:5173`, backend on `:8080` = CORS needed.
+
+```java
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("*")
+            .allowedHeaders("*");
+    }
+}
+```
+
+### 2. UUID Handling
+Frontend generates UUIDs for optimistic updates. Your backend should:
+- Generate new UUIDs for new entities (ignore client-provided IDs)
+- Accept UUIDs for lookups/updates
+
+### 3. Null vs Missing Fields
+
+In PATCH requests, the frontend distinguishes between:
+- Field not sent = don't change it
+- Field sent as null = clear it
+
+Your DTO should handle this (use `Optional<T>` or custom deserializer).
+
+### 4. Date Timezone Issues
+
+Store dates as `LocalDate` (no timezone). The frontend sends `"2026-01-15"`, store exactly that. Don't convert to timestamps.
+
+---
+
+## Need Help?
+
+1. **Re-read the documents** - Most answers are there
+2. **Check the mock handlers** - They show expected behavior
+3. **Look at frontend types** - They define the contract
+4. **Test incrementally** - One endpoint at a time
+
+---
+
+Good luck! You've got this. The hard part (building a polished frontend) is done. Now you're just implementing a well-defined API contract. That's the fun part.

--- a/docs/backend/01-PRD.md
+++ b/docs/backend/01-PRD.md
@@ -1,0 +1,356 @@
+# FamilyHub Backend - Product Requirements Document
+
+> **Version:** 1.0
+> **Last Updated:** January 2026
+> **Status:** Planning Phase
+
+---
+
+## Executive Summary
+
+FamilyHub is a family organization application that helps households coordinate their daily lives through shared calendars, chore management, meal planning, shopping lists, and photo sharing. This document outlines the requirements for building a robust Spring Boot backend to replace the current mock API layer.
+
+### The Vision
+
+Every family struggles with coordination. Whose turn is it to pick up groceries? Did anyone schedule the vet appointment? What's for dinner Tuesday? FamilyHub becomes the central nervous system of your household—a single place where everyone can see what's happening, who's responsible, and what's coming up.
+
+---
+
+## Problem Statement
+
+### Current State
+The frontend exists as a functional demo with:
+- Mock API handlers simulating backend behavior
+- localStorage for data persistence
+- Full CRUD operations for Calendar and Family modules
+- Type-safe API contracts already defined
+
+### Why This Matters
+Without a real backend:
+- Data is trapped in individual browsers
+- No synchronization between family members' devices
+- No data durability (clearing browser data = losing everything)
+- No authentication or security
+- Can't scale beyond a single-user demo
+
+### Success Criteria
+1. **Data Persistence**: All family data survives browser/device changes
+2. **Multi-User Access**: All family members access the same data
+3. **Real-Time Sync**: Changes appear across devices within seconds
+4. **Zero Data Loss**: 99.9% durability guarantee
+5. **Performance**: API responses under 200ms p95
+
+---
+
+## Product Scope
+
+### Phase 1: Foundation (MVP)
+**Goal**: Replace mock APIs with real backend, enable multi-device access
+
+| Module | Priority | Description |
+|--------|----------|-------------|
+| **Family** | P0 | Core entity - must exist before anything else |
+| **Calendar** | P0 | Primary feature, already fully built on frontend |
+| **Authentication** | P0 | Secure access, family membership |
+
+### Phase 2: Feature Expansion
+**Goal**: Build out remaining modules
+
+| Module | Priority | Description |
+|--------|----------|-------------|
+| **Chores** | P1 | Task assignment and tracking |
+| **Meals** | P1 | Meal planning and recipes |
+| **Lists** | P2 | Shared shopping/todo lists |
+| **Photos** | P2 | Family photo sharing |
+
+### Phase 3: Enhanced Experience
+**Goal**: Delight users with advanced features
+
+| Feature | Priority | Description |
+|---------|----------|-------------|
+| **Notifications** | P1 | Push notifications for events/reminders |
+| **Recurring Events** | P1 | Daily/weekly/monthly repeat patterns |
+| **External Calendar Sync** | P2 | Google Calendar, iCal integration |
+| **Mobile Apps** | P2 | Native iOS/Android experiences |
+
+---
+
+## User Stories
+
+### Family Management
+
+```
+As a user, I want to create a family so that I can start organizing our household.
+
+Acceptance Criteria:
+- I can set a family name
+- I can add initial family members with names and colors
+- Each member gets a unique identifier
+- The family is immediately usable after creation
+```
+
+```
+As a family admin, I want to invite new members so they can join our family.
+
+Acceptance Criteria:
+- I can generate an invite link/code
+- New members can join via the link
+- New members appear in the family member list
+- New members can immediately view/create events
+```
+
+```
+As a family member, I want to update my profile so my information stays current.
+
+Acceptance Criteria:
+- I can change my display name
+- I can change my assigned color (if not taken)
+- I can upload/change my avatar
+- Changes reflect immediately for all family members
+```
+
+### Calendar Management
+
+```
+As a family member, I want to create events so everyone knows my schedule.
+
+Acceptance Criteria:
+- I can set title, date, start/end times
+- I can optionally add a location
+- I can mark events as all-day
+- Events are associated with my member profile
+- Events appear immediately on all family devices
+```
+
+```
+As a family member, I want to filter the calendar by person so I can focus on specific schedules.
+
+Acceptance Criteria:
+- I can select one or more family members to view
+- Only selected members' events are shown
+- Filter state persists during my session
+```
+
+```
+As a family member, I want to edit/delete my events so I can keep my schedule accurate.
+
+Acceptance Criteria:
+- I can modify any event I created
+- I can delete events I created
+- Family admins can modify/delete any event
+- Changes sync immediately to all devices
+```
+
+---
+
+## Functional Requirements
+
+### FR-1: Family Entity Management
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-1.1 | System shall support creating a new family with name and initial members | P0 |
+| FR-1.2 | System shall generate unique IDs for families and members | P0 |
+| FR-1.3 | System shall enforce maximum of 7 members per family (color constraint) | P0 |
+| FR-1.4 | System shall prevent duplicate colors within a family | P0 |
+| FR-1.5 | System shall prevent removing the last family member | P0 |
+| FR-1.6 | System shall support updating family name | P0 |
+| FR-1.7 | System shall support soft-delete of families | P1 |
+
+### FR-2: Calendar Event Management
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-2.1 | System shall support CRUD operations for calendar events | P0 |
+| FR-2.2 | System shall associate each event with exactly one family member | P0 |
+| FR-2.3 | System shall support filtering events by date range | P0 |
+| FR-2.4 | System shall support filtering events by family member | P0 |
+| FR-2.5 | System shall support all-day events | P0 |
+| FR-2.6 | System shall support event locations | P0 |
+| FR-2.7 | System shall validate time ranges (end > start) | P0 |
+| FR-2.8 | System shall support recurring events | P1 |
+
+### FR-3: Authentication & Authorization
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| FR-3.1 | System shall authenticate users via email/password or OAuth | P0 |
+| FR-3.2 | System shall authorize users to access only their family's data | P0 |
+| FR-3.3 | System shall support role-based access (admin, member) | P1 |
+| FR-3.4 | System shall support password reset flow | P0 |
+| FR-3.5 | System shall issue JWT tokens for API authentication | P0 |
+
+---
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-1.1 | API response time (p50) | < 100ms |
+| NFR-1.2 | API response time (p95) | < 200ms |
+| NFR-1.3 | API response time (p99) | < 500ms |
+| NFR-1.4 | Concurrent users per family | 10 |
+| NFR-1.5 | Events per family | 10,000+ |
+
+### NFR-2: Reliability
+
+| ID | Requirement | Target |
+|----|-------------|--------|
+| NFR-2.1 | Service availability | 99.9% |
+| NFR-2.2 | Data durability | 99.999% |
+| NFR-2.3 | Backup frequency | Daily |
+| NFR-2.4 | Recovery time objective (RTO) | < 1 hour |
+| NFR-2.5 | Recovery point objective (RPO) | < 1 hour |
+
+### NFR-3: Security
+
+| ID | Requirement | Description |
+|----|-------------|-------------|
+| NFR-3.1 | All API endpoints secured with authentication | Except health checks |
+| NFR-3.2 | Passwords hashed with bcrypt (cost factor 12+) | |
+| NFR-3.3 | HTTPS required for all communications | |
+| NFR-3.4 | JWT tokens expire after 24 hours | Refresh tokens: 30 days |
+| NFR-3.5 | Rate limiting on authentication endpoints | 5 attempts/minute |
+| NFR-3.6 | SQL injection prevention via parameterized queries | |
+| NFR-3.7 | CORS configured for frontend origin only | |
+
+### NFR-4: Scalability
+
+| ID | Requirement | Description |
+|----|-------------|-------------|
+| NFR-4.1 | Horizontal scaling support | Stateless API design |
+| NFR-4.2 | Database connection pooling | HikariCP |
+| NFR-4.3 | Caching strategy | Redis for hot data |
+
+---
+
+## Data Model Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                           FAMILY HUB                                │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌──────────┐         ┌──────────────┐         ┌──────────────┐    │
+│  │   USER   │────────▶│    FAMILY    │◀────────│    MEMBER    │    │
+│  └──────────┘         └──────────────┘         └──────────────┘    │
+│       │                      │                        │             │
+│       │                      │                        │             │
+│       ▼                      ▼                        ▼             │
+│  ┌──────────┐         ┌──────────────┐         ┌──────────────┐    │
+│  │  AUTH    │         │    EVENT     │         │    CHORE     │    │
+│  │ TOKENS   │         │  (Calendar)  │         │    (P1)      │    │
+│  └──────────┘         └──────────────┘         └──────────────┘    │
+│                              │                        │             │
+│                              │                        │             │
+│                              ▼                        ▼             │
+│                       ┌──────────────┐         ┌──────────────┐    │
+│                       │  RECURRENCE  │         │    MEAL      │    │
+│                       │    (P1)      │         │    (P1)      │    │
+│                       └──────────────┘         └──────────────┘    │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Relationships
+
+1. **User → Family**: A user can belong to one family (MVP), many-to-many later
+2. **Family → Members**: A family has 1-7 members, each with unique colors
+3. **Member → Events**: Each event belongs to exactly one member
+4. **Event → Recurrence**: Optional pattern for recurring events
+
+---
+
+## API Contract Summary
+
+The frontend already defines these contracts. Backend must implement them exactly.
+
+### Family Endpoints
+```
+GET    /api/family              → Get current user's family
+POST   /api/family              → Create family (onboarding)
+PATCH  /api/family              → Update family properties
+DELETE /api/family              → Delete/reset family
+
+POST   /api/family/members      → Add member to family
+PATCH  /api/family/members/:id  → Update member
+DELETE /api/family/members/:id  → Remove member
+```
+
+### Calendar Endpoints
+```
+GET    /api/calendar/events     → List events (with filters)
+GET    /api/calendar/events/:id → Get single event
+POST   /api/calendar/events     → Create event
+PATCH  /api/calendar/events/:id → Update event
+DELETE /api/calendar/events/:id → Delete event
+```
+
+See `02-API-CONTRACT.md` for complete OpenAPI specification.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Complex auth flows delay MVP | High | Medium | Start with simple email/password, add OAuth later |
+| Real-time sync complexity | Medium | High | Start with polling, add WebSockets in P2 |
+| Data migration from localStorage | Medium | Medium | Provide one-click import on first authenticated login |
+| Performance at scale | High | Low | Design for scale from start, load test early |
+
+---
+
+## Success Metrics
+
+### MVP Launch (Phase 1)
+- [ ] All existing frontend features work with real backend
+- [ ] Multiple family members can access same data
+- [ ] Data persists across browser sessions
+- [ ] Response times meet NFR-1 targets
+- [ ] Zero critical security vulnerabilities
+
+### Growth Phase (3 months post-launch)
+- [ ] 100 active families
+- [ ] < 1% error rate
+- [ ] User satisfaction > 4.0/5.0
+- [ ] Average session length > 5 minutes
+
+---
+
+## Open Questions
+
+1. **Multi-family support**: Should users be able to belong to multiple families? (e.g., co-parenting situations)
+
+2. **Offline support**: How important is offline-first? This significantly impacts architecture.
+
+3. **Data ownership**: When a member leaves, what happens to their events?
+
+4. **Notification preferences**: Email? Push? In-app? All configurable?
+
+5. **External integrations**: Which calendar services are highest priority?
+
+---
+
+## Appendix: Technology Decisions
+
+### Chosen Stack
+- **Framework**: Spring Boot 3.x (Java 21)
+- **Database**: PostgreSQL 16
+- **Caching**: Redis
+- **Auth**: Spring Security + JWT
+- **API Docs**: SpringDoc OpenAPI
+- **Testing**: JUnit 5 + Testcontainers
+
+### Why Spring Boot?
+1. **Mature ecosystem** - Battle-tested in production at scale
+2. **Strong typing** - Java catches errors at compile time
+3. **Spring Security** - Comprehensive auth/authz out of the box
+4. **Great tooling** - IDE support, debugging, profiling
+5. **Team familiarity** - Already committed to this choice
+
+---
+
+*This document should be treated as a living specification. Update it as requirements evolve.*

--- a/docs/backend/02-API-CONTRACT.md
+++ b/docs/backend/02-API-CONTRACT.md
@@ -1,0 +1,865 @@
+# FamilyHub API Contract
+
+> **Version:** 1.0.0
+> **Base URL:** `/api`
+> **Content-Type:** `application/json`
+
+---
+
+## Overview
+
+This document defines the API contract between the FamilyHub frontend and backend. The frontend already implements these interfaces through mock handlers. The backend must implement them **exactly** to ensure seamless integration.
+
+### Design Principles
+
+1. **RESTful**: Resources as nouns, HTTP verbs for actions
+2. **Consistent**: Same response envelope across all endpoints
+3. **Predictable**: Standardized error responses
+4. **Idempotent**: Safe retry behavior for mutations
+
+---
+
+## Authentication
+
+All endpoints (except `/api/auth/*` and `/api/health`) require authentication.
+
+### Headers
+```http
+Authorization: Bearer <jwt_token>
+```
+
+### Token Payload
+```json
+{
+  "sub": "user-uuid",
+  "familyId": "family-uuid",
+  "memberId": "member-uuid",
+  "role": "admin|member",
+  "exp": 1735689600,
+  "iat": 1735603200
+}
+```
+
+---
+
+## Response Envelopes
+
+### Success Response
+```typescript
+interface ApiResponse<T> {
+  data: T;
+  meta?: {
+    timestamp: number;    // Unix timestamp (milliseconds)
+    requestId: string;    // UUID for tracing
+  };
+}
+```
+
+### Mutation Response
+```typescript
+interface MutationResponse<T> {
+  data: T;
+  message?: string;       // Human-readable success message
+}
+```
+
+### Error Response
+```typescript
+interface ErrorResponse {
+  code: ApiErrorCode;     // Machine-readable error code
+  message: string;        // Human-readable message
+  status: number;         // HTTP status code
+  details?: Record<string, unknown>;  // Additional context
+  field?: string;         // For validation errors
+}
+```
+
+### Error Codes
+```typescript
+const ApiErrorCode = {
+  NETWORK_ERROR: "NETWORK_ERROR",
+  UNAUTHORIZED: "UNAUTHORIZED",
+  FORBIDDEN: "FORBIDDEN",
+  NOT_FOUND: "NOT_FOUND",
+  VALIDATION_ERROR: "VALIDATION_ERROR",
+  CONFLICT: "CONFLICT",
+  SERVER_ERROR: "SERVER_ERROR",
+  TIMEOUT: "TIMEOUT",
+}
+```
+
+---
+
+## Family API
+
+### Data Types
+
+```typescript
+type FamilyColor = "coral" | "teal" | "green" | "purple" | "yellow" | "pink" | "orange";
+
+interface FamilyMember {
+  id: string;             // UUID
+  name: string;           // Display name (1-50 chars)
+  color: FamilyColor;     // Unique within family
+  avatarUrl?: string;     // URL to avatar image
+  email?: string;         // For notifications
+}
+
+interface FamilyData {
+  id: string;             // UUID
+  name: string;           // Family name (1-100 chars)
+  members: FamilyMember[];
+  createdAt: string;      // ISO 8601 datetime
+  setupComplete: boolean; // True after onboarding
+}
+```
+
+---
+
+### GET /api/family
+
+Get the current user's family data.
+
+**Response (200 OK)** - Family exists:
+```json
+{
+  "data": {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "name": "The Johnsons",
+    "members": [
+      {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "name": "Sarah",
+        "color": "coral",
+        "avatarUrl": null,
+        "email": "sarah@example.com"
+      },
+      {
+        "id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        "name": "Mike",
+        "color": "teal",
+        "avatarUrl": null,
+        "email": null
+      }
+    ],
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "setupComplete": true
+  },
+  "meta": {
+    "timestamp": 1735689600000,
+    "requestId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  }
+}
+```
+
+**Response (200 OK)** - No family (triggers onboarding):
+```json
+{
+  "data": null,
+  "meta": {
+    "timestamp": 1735689600000,
+    "requestId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  }
+}
+```
+
+---
+
+### POST /api/family
+
+Create a new family (during onboarding).
+
+**Request:**
+```typescript
+interface CreateFamilyRequest {
+  name: string;                           // 1-100 chars
+  members: Array<Omit<FamilyMember, "id">>; // 1-7 members
+}
+```
+
+**Example:**
+```json
+{
+  "name": "The Johnsons",
+  "members": [
+    { "name": "Sarah", "color": "coral", "email": "sarah@example.com" },
+    { "name": "Mike", "color": "teal" },
+    { "name": "Emma", "color": "purple" }
+  ]
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "data": {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "name": "The Johnsons",
+    "members": [
+      { "id": "uuid-1", "name": "Sarah", "color": "coral", "email": "sarah@example.com" },
+      { "id": "uuid-2", "name": "Mike", "color": "teal" },
+      { "id": "uuid-3", "name": "Emma", "color": "purple" }
+    ],
+    "createdAt": "2026-01-08T12:00:00.000Z",
+    "setupComplete": true
+  },
+  "message": "Family created successfully"
+}
+```
+
+**Error (409 Conflict)** - Family already exists:
+```json
+{
+  "code": "CONFLICT",
+  "message": "Family already exists. Use updateFamily to modify.",
+  "status": 409
+}
+```
+
+**Validation Rules:**
+- `name`: Required, 1-100 characters
+- `members`: Required, 1-7 items
+- `members[].name`: Required, 1-50 characters
+- `members[].color`: Required, must be valid FamilyColor
+- `members[].color`: Must be unique within request
+
+---
+
+### PATCH /api/family
+
+Update family properties.
+
+**Request:**
+```typescript
+interface UpdateFamilyRequest {
+  name?: string;  // 1-100 chars
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "name": "The Johnson-Smiths",
+    "members": [...],
+    "createdAt": "2026-01-01T00:00:00.000Z",
+    "setupComplete": true
+  },
+  "message": "Family updated successfully"
+}
+```
+
+**Error (404 Not Found):**
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "No family exists. Create one first.",
+  "status": 404
+}
+```
+
+---
+
+### DELETE /api/family
+
+Delete/reset the family (dangerous operation).
+
+**Response (204 No Content)**
+
+---
+
+### POST /api/family/members
+
+Add a new member to the family.
+
+**Request:**
+```typescript
+interface AddMemberRequest {
+  name: string;         // 1-50 chars
+  color: FamilyColor;   // Must not be in use
+  avatarUrl?: string;
+  email?: string;
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "data": {
+    "id": "new-member-uuid",
+    "name": "Baby Jake",
+    "color": "yellow",
+    "avatarUrl": null,
+    "email": null
+  },
+  "message": "Member added successfully"
+}
+```
+
+**Error (409 Conflict)** - Color taken:
+```json
+{
+  "code": "CONFLICT",
+  "message": "Color \"coral\" is already assigned to another member",
+  "status": 409
+}
+```
+
+**Error (400 Validation)** - Max members:
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Maximum of 7 family members allowed",
+  "status": 400
+}
+```
+
+---
+
+### PATCH /api/family/members/:id
+
+Update an existing family member.
+
+**Request:**
+```typescript
+interface UpdateMemberRequest {
+  name?: string;
+  color?: FamilyColor;
+  avatarUrl?: string;
+  email?: string;
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "id": "member-uuid",
+    "name": "Sarah J.",
+    "color": "coral",
+    "avatarUrl": "https://example.com/avatar.jpg",
+    "email": "sarah.j@example.com"
+  },
+  "message": "Member updated successfully"
+}
+```
+
+---
+
+### DELETE /api/family/members/:id
+
+Remove a member from the family.
+
+**Response (204 No Content)**
+
+**Error (400 Validation)** - Last member:
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "Cannot remove the last family member",
+  "status": 400
+}
+```
+
+---
+
+## Calendar API
+
+### Data Types
+
+```typescript
+interface CalendarEvent {
+  id: string;           // UUID
+  title: string;        // 1-200 chars
+  startTime: string;    // "9:00 AM" format (12-hour)
+  endTime: string;      // "10:00 AM" format (12-hour)
+  date: string;         // ISO date "2026-01-15" (in responses)
+  memberId: string;     // UUID of family member
+  isAllDay?: boolean;   // Default: false
+  location?: string;    // Optional, max 500 chars
+}
+```
+
+**Important Time Format Notes:**
+- Times are in 12-hour format with AM/PM: `"9:00 AM"`, `"2:30 PM"`
+- Dates are ISO format without time component: `"2026-01-15"`
+- Backend should store times in 24-hour format internally and convert for API
+
+---
+
+### GET /api/calendar/events
+
+List events with optional filters.
+
+**Query Parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startDate | string | ISO date (inclusive), e.g., `2026-01-01` |
+| endDate | string | ISO date (inclusive), e.g., `2026-01-31` |
+| memberId | string | UUID to filter by member |
+
+**Response (200 OK):**
+```json
+{
+  "data": [
+    {
+      "id": "event-uuid-1",
+      "title": "Soccer Practice",
+      "startTime": "4:00 PM",
+      "endTime": "5:30 PM",
+      "date": "2026-01-15",
+      "memberId": "member-uuid-1",
+      "isAllDay": false,
+      "location": "City Park Field 3"
+    },
+    {
+      "id": "event-uuid-2",
+      "title": "Emma's Birthday",
+      "startTime": "12:00 AM",
+      "endTime": "11:59 PM",
+      "date": "2026-01-20",
+      "memberId": "member-uuid-2",
+      "isAllDay": true,
+      "location": null
+    }
+  ],
+  "meta": {
+    "timestamp": 1735689600000,
+    "requestId": "request-uuid"
+  }
+}
+```
+
+**Behavior Notes:**
+- If no date filters provided, return all events (frontend caches aggressively)
+- Results should be sorted by date, then by start time
+- Empty array for no matching events (not an error)
+
+---
+
+### GET /api/calendar/events/:id
+
+Get a single event by ID.
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "id": "event-uuid",
+    "title": "Soccer Practice",
+    "startTime": "4:00 PM",
+    "endTime": "5:30 PM",
+    "date": "2026-01-15",
+    "memberId": "member-uuid",
+    "isAllDay": false,
+    "location": "City Park Field 3"
+  },
+  "meta": {
+    "timestamp": 1735689600000,
+    "requestId": "request-uuid"
+  }
+}
+```
+
+**Error (404 Not Found):**
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Event with id \"invalid-uuid\" not found",
+  "status": 404
+}
+```
+
+---
+
+### POST /api/calendar/events
+
+Create a new calendar event.
+
+**Request:**
+```typescript
+interface CreateEventRequest {
+  title: string;        // 1-200 chars
+  startTime: string;    // "9:00 AM" format
+  endTime: string;      // "10:00 AM" format
+  date: string;         // ISO date "2026-01-15"
+  memberId: string;     // UUID
+  isAllDay?: boolean;
+  location?: string;
+}
+```
+
+**Example:**
+```json
+{
+  "title": "Team Meeting",
+  "startTime": "9:00 AM",
+  "endTime": "10:00 AM",
+  "date": "2026-01-15",
+  "memberId": "550e8400-e29b-41d4-a716-446655440000",
+  "location": "Conference Room A"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "data": {
+    "id": "new-event-uuid",
+    "title": "Team Meeting",
+    "startTime": "9:00 AM",
+    "endTime": "10:00 AM",
+    "date": "2026-01-15",
+    "memberId": "550e8400-e29b-41d4-a716-446655440000",
+    "isAllDay": false,
+    "location": "Conference Room A"
+  },
+  "message": "Event created successfully"
+}
+```
+
+**Validation Rules:**
+- `title`: Required, 1-200 characters
+- `startTime`: Required, valid 12-hour time format
+- `endTime`: Required, valid 12-hour time format, must be after startTime
+- `date`: Required, valid ISO date
+- `memberId`: Required, must exist in family
+
+---
+
+### PATCH /api/calendar/events/:id
+
+Update an existing event.
+
+**Request:**
+```typescript
+interface UpdateEventRequest {
+  title?: string;
+  startTime?: string;
+  endTime?: string;
+  date?: string;
+  memberId?: string;
+  isAllDay?: boolean;
+  location?: string;
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "id": "event-uuid",
+    "title": "Team Meeting (Updated)",
+    "startTime": "9:30 AM",
+    "endTime": "10:30 AM",
+    "date": "2026-01-15",
+    "memberId": "member-uuid",
+    "isAllDay": false,
+    "location": "Conference Room B"
+  },
+  "message": "Event updated successfully"
+}
+```
+
+---
+
+### DELETE /api/calendar/events/:id
+
+Delete an event.
+
+**Response (204 No Content)**
+
+**Error (404 Not Found):**
+```json
+{
+  "code": "NOT_FOUND",
+  "message": "Event with id \"invalid-uuid\" not found",
+  "status": 404
+}
+```
+
+---
+
+## Authentication API (New for Backend)
+
+These endpoints are new and don't exist in the mock layer.
+
+### POST /api/auth/register
+
+Register a new user account.
+
+**Request:**
+```json
+{
+  "email": "sarah@example.com",
+  "password": "securePassword123!",
+  "name": "Sarah"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "data": {
+    "user": {
+      "id": "user-uuid",
+      "email": "sarah@example.com",
+      "name": "Sarah"
+    },
+    "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+    "refreshToken": "dGhpcyBpcyBhIHJlZnJl...",
+    "expiresIn": 86400
+  },
+  "message": "Registration successful"
+}
+```
+
+---
+
+### POST /api/auth/login
+
+Authenticate and get tokens.
+
+**Request:**
+```json
+{
+  "email": "sarah@example.com",
+  "password": "securePassword123!"
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "user": {
+      "id": "user-uuid",
+      "email": "sarah@example.com",
+      "name": "Sarah",
+      "familyId": "family-uuid",
+      "memberId": "member-uuid"
+    },
+    "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+    "refreshToken": "dGhpcyBpcyBhIHJlZnJl...",
+    "expiresIn": 86400
+  }
+}
+```
+
+---
+
+### POST /api/auth/refresh
+
+Refresh access token.
+
+**Request:**
+```json
+{
+  "refreshToken": "dGhpcyBpcyBhIHJlZnJl..."
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "data": {
+    "accessToken": "eyJhbGciOiJIUzI1NiIs...",
+    "expiresIn": 86400
+  }
+}
+```
+
+---
+
+### POST /api/auth/logout
+
+Invalidate refresh token.
+
+**Request:**
+```json
+{
+  "refreshToken": "dGhpcyBpcyBhIHJlZnJl..."
+}
+```
+
+**Response (204 No Content)**
+
+---
+
+## Health Check
+
+### GET /api/health
+
+System health check (no auth required).
+
+**Response (200 OK):**
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-01-08T12:00:00.000Z",
+  "version": "1.0.0",
+  "checks": {
+    "database": "healthy",
+    "redis": "healthy"
+  }
+}
+```
+
+---
+
+## OpenAPI Specification
+
+```yaml
+openapi: 3.1.0
+info:
+  title: FamilyHub API
+  version: 1.0.0
+  description: Family organization application API
+
+servers:
+  - url: http://localhost:8080/api
+    description: Local development
+  - url: https://api.familyhub.app/api
+    description: Production
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    FamilyColor:
+      type: string
+      enum: [coral, teal, green, purple, yellow, pink, orange]
+
+    FamilyMember:
+      type: object
+      required: [id, name, color]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 50
+        color:
+          $ref: '#/components/schemas/FamilyColor'
+        avatarUrl:
+          type: string
+          format: uri
+        email:
+          type: string
+          format: email
+
+    FamilyData:
+      type: object
+      required: [id, name, members, createdAt, setupComplete]
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/FamilyMember'
+          minItems: 1
+          maxItems: 7
+        createdAt:
+          type: string
+          format: date-time
+        setupComplete:
+          type: boolean
+
+    CalendarEvent:
+      type: object
+      required: [id, title, startTime, endTime, date, memberId]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+          minLength: 1
+          maxLength: 200
+        startTime:
+          type: string
+          pattern: '^(1[0-2]|0?[1-9]):[0-5][0-9] (AM|PM)$'
+          example: "9:00 AM"
+        endTime:
+          type: string
+          pattern: '^(1[0-2]|0?[1-9]):[0-5][0-9] (AM|PM)$'
+          example: "10:00 AM"
+        date:
+          type: string
+          format: date
+          example: "2026-01-15"
+        memberId:
+          type: string
+          format: uuid
+        isAllDay:
+          type: boolean
+          default: false
+        location:
+          type: string
+          maxLength: 500
+
+    ApiError:
+      type: object
+      required: [code, message, status]
+      properties:
+        code:
+          type: string
+          enum: [NETWORK_ERROR, UNAUTHORIZED, FORBIDDEN, NOT_FOUND, VALIDATION_ERROR, CONFLICT, SERVER_ERROR, TIMEOUT]
+        message:
+          type: string
+        status:
+          type: integer
+        details:
+          type: object
+        field:
+          type: string
+
+security:
+  - bearerAuth: []
+```
+
+---
+
+## Implementation Checklist
+
+### Phase 1 - MVP
+- [ ] `GET /api/health` - Health check
+- [ ] `POST /api/auth/register` - User registration
+- [ ] `POST /api/auth/login` - User authentication
+- [ ] `POST /api/auth/refresh` - Token refresh
+- [ ] `POST /api/auth/logout` - Token invalidation
+- [ ] `GET /api/family` - Get family
+- [ ] `POST /api/family` - Create family
+- [ ] `PATCH /api/family` - Update family
+- [ ] `DELETE /api/family` - Delete family
+- [ ] `POST /api/family/members` - Add member
+- [ ] `PATCH /api/family/members/:id` - Update member
+- [ ] `DELETE /api/family/members/:id` - Remove member
+- [ ] `GET /api/calendar/events` - List events
+- [ ] `GET /api/calendar/events/:id` - Get event
+- [ ] `POST /api/calendar/events` - Create event
+- [ ] `PATCH /api/calendar/events/:id` - Update event
+- [ ] `DELETE /api/calendar/events/:id` - Delete event
+
+### Phase 2 - Enhanced
+- [ ] `GET /api/family/invite` - Generate invite
+- [ ] `POST /api/family/join` - Join via invite
+- [ ] Recurring events support
+- [ ] WebSocket for real-time updates
+
+---
+
+*This contract is the source of truth for API integration. Any changes must be coordinated between frontend and backend teams.*

--- a/docs/backend/03-ARCHITECTURE.md
+++ b/docs/backend/03-ARCHITECTURE.md
@@ -1,0 +1,843 @@
+# FamilyHub Backend Architecture Guide
+
+> **Target Stack:** Spring Boot 3.x, Java 21, PostgreSQL, Redis
+> **Architecture Style:** Layered Architecture with Domain-Driven Design influences
+
+---
+
+## Why This Architecture?
+
+Before diving into structure, let's understand the *why* behind each decision. Architecture isn't about following patterns blindly—it's about making explicit tradeoffs.
+
+### Our Constraints
+1. **Small team** - Need simplicity over sophistication
+2. **Fast iteration** - Frontend already exists, backend needs to catch up
+3. **Scale later** - Design for 100 families now, architect for 10,000 later
+4. **Security first** - Family data is sensitive, mistakes are unforgivable
+
+### Our Decisions
+
+| Decision | Alternative Considered | Why We Chose This |
+|----------|----------------------|-------------------|
+| Layered Architecture | Hexagonal/Clean Architecture | Simpler for small team, sufficient isolation |
+| JPA/Hibernate | jOOQ, MyBatis | Spring ecosystem integration, familiarity |
+| PostgreSQL | MySQL, MongoDB | JSON support, better standards compliance, robust |
+| JWT + Refresh Tokens | Session cookies | Stateless API, mobile-ready |
+| Single module | Multi-module Maven | YAGNI - split when needed, not before |
+
+---
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              CLIENT LAYER                                    │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
+│  │   React     │  │   Mobile    │  │   Public    │  │   Admin     │        │
+│  │   Frontend  │  │   Apps      │  │   API       │  │   Dashboard │        │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘        │
+└─────────┼────────────────┼────────────────┼────────────────┼────────────────┘
+          │                │                │                │
+          └────────────────┴────────────────┴────────────────┘
+                                    │
+                              HTTPS / JWT
+                                    │
+┌───────────────────────────────────┴─────────────────────────────────────────┐
+│                           API GATEWAY / LOAD BALANCER                        │
+│                        (nginx / AWS ALB / Cloud Run)                         │
+└───────────────────────────────────┬─────────────────────────────────────────┘
+                                    │
+┌───────────────────────────────────┴─────────────────────────────────────────┐
+│                           SPRING BOOT APPLICATION                            │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │                        CONTROLLER LAYER                              │    │
+│  │   AuthController  │  FamilyController  │  CalendarController        │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                    │                                         │
+│  ┌─────────────────────────────────┴───────────────────────────────────┐    │
+│  │                        SERVICE LAYER                                 │    │
+│  │   AuthService  │  FamilyService  │  CalendarService  │  ...         │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                    │                                         │
+│  ┌─────────────────────────────────┴───────────────────────────────────┐    │
+│  │                       REPOSITORY LAYER                               │    │
+│  │   UserRepository  │  FamilyRepository  │  EventRepository  │  ...   │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                    │                                         │
+└────────────────────────────────────┼────────────────────────────────────────┘
+                                     │
+          ┌──────────────────────────┼──────────────────────────┐
+          │                          │                          │
+   ┌──────┴──────┐           ┌───────┴───────┐          ┌───────┴───────┐
+   │ PostgreSQL  │           │    Redis      │          │     S3        │
+   │  (Primary)  │           │   (Cache)     │          │  (Files)      │
+   └─────────────┘           └───────────────┘          └───────────────┘
+```
+
+---
+
+## Project Structure
+
+```
+family-hub-backend/
+├── src/
+│   ├── main/
+│   │   ├── java/com/familyhub/
+│   │   │   ├── FamilyHubApplication.java          # Entry point
+│   │   │   │
+│   │   │   ├── config/                            # Configuration
+│   │   │   │   ├── SecurityConfig.java            # Spring Security setup
+│   │   │   │   ├── JwtConfig.java                 # JWT settings
+│   │   │   │   ├── CorsConfig.java                # CORS policy
+│   │   │   │   ├── CacheConfig.java               # Redis cache config
+│   │   │   │   └── OpenApiConfig.java             # Swagger/OpenAPI
+│   │   │   │
+│   │   │   ├── domain/                            # Domain entities
+│   │   │   │   ├── user/
+│   │   │   │   │   ├── User.java                  # JPA entity
+│   │   │   │   │   ├── UserRepository.java        # Data access
+│   │   │   │   │   └── RefreshToken.java          # Token entity
+│   │   │   │   │
+│   │   │   │   ├── family/
+│   │   │   │   │   ├── Family.java
+│   │   │   │   │   ├── FamilyMember.java
+│   │   │   │   │   ├── FamilyColor.java           # Enum
+│   │   │   │   │   ├── FamilyRepository.java
+│   │   │   │   │   └── FamilyMemberRepository.java
+│   │   │   │   │
+│   │   │   │   └── calendar/
+│   │   │   │       ├── CalendarEvent.java
+│   │   │   │       └── CalendarEventRepository.java
+│   │   │   │
+│   │   │   ├── service/                           # Business logic
+│   │   │   │   ├── auth/
+│   │   │   │   │   ├── AuthService.java
+│   │   │   │   │   ├── JwtService.java
+│   │   │   │   │   └── RefreshTokenService.java
+│   │   │   │   │
+│   │   │   │   ├── family/
+│   │   │   │   │   ├── FamilyService.java
+│   │   │   │   │   └── FamilyMemberService.java
+│   │   │   │   │
+│   │   │   │   └── calendar/
+│   │   │   │       └── CalendarEventService.java
+│   │   │   │
+│   │   │   ├── api/                               # REST controllers
+│   │   │   │   ├── auth/
+│   │   │   │   │   ├── AuthController.java
+│   │   │   │   │   ├── dto/
+│   │   │   │   │   │   ├── LoginRequest.java
+│   │   │   │   │   │   ├── RegisterRequest.java
+│   │   │   │   │   │   └── AuthResponse.java
+│   │   │   │   │
+│   │   │   │   ├── family/
+│   │   │   │   │   ├── FamilyController.java
+│   │   │   │   │   ├── FamilyMemberController.java
+│   │   │   │   │   ├── dto/
+│   │   │   │   │   │   ├── CreateFamilyRequest.java
+│   │   │   │   │   │   ├── UpdateFamilyRequest.java
+│   │   │   │   │   │   ├── FamilyResponse.java
+│   │   │   │   │   │   └── ...
+│   │   │   │   │
+│   │   │   │   ├── calendar/
+│   │   │   │   │   ├── CalendarController.java
+│   │   │   │   │   ├── dto/
+│   │   │   │   │   │   ├── CreateEventRequest.java
+│   │   │   │   │   │   ├── UpdateEventRequest.java
+│   │   │   │   │   │   ├── EventResponse.java
+│   │   │   │   │   │   └── ...
+│   │   │   │   │
+│   │   │   │   └── common/
+│   │   │   │       ├── ApiResponse.java           # Response wrapper
+│   │   │   │       ├── ErrorResponse.java         # Error format
+│   │   │   │       └── HealthController.java
+│   │   │   │
+│   │   │   ├── exception/                         # Exception handling
+│   │   │   │   ├── GlobalExceptionHandler.java    # @ControllerAdvice
+│   │   │   │   ├── ResourceNotFoundException.java
+│   │   │   │   ├── ConflictException.java
+│   │   │   │   ├── ValidationException.java
+│   │   │   │   └── UnauthorizedException.java
+│   │   │   │
+│   │   │   ├── security/                          # Security components
+│   │   │   │   ├── JwtAuthenticationFilter.java
+│   │   │   │   ├── UserPrincipal.java             # Custom UserDetails
+│   │   │   │   └── CurrentUser.java               # @Annotation for injection
+│   │   │   │
+│   │   │   └── util/                              # Utilities
+│   │   │       ├── TimeUtils.java                 # Time format conversions
+│   │   │       └── IdGenerator.java               # UUID generation
+│   │   │
+│   │   └── resources/
+│   │       ├── application.yml                    # Main config
+│   │       ├── application-dev.yml                # Dev overrides
+│   │       ├── application-prod.yml               # Prod overrides
+│   │       └── db/migration/                      # Flyway migrations
+│   │           ├── V1__create_users_table.sql
+│   │           ├── V2__create_families_table.sql
+│   │           ├── V3__create_events_table.sql
+│   │           └── ...
+│   │
+│   └── test/
+│       └── java/com/familyhub/
+│           ├── integration/                       # Integration tests
+│           │   ├── FamilyApiTests.java
+│           │   └── CalendarApiTests.java
+│           │
+│           ├── service/                           # Unit tests
+│           │   ├── FamilyServiceTests.java
+│           │   └── ...
+│           │
+│           └── TestContainersConfig.java          # Testcontainers setup
+│
+├── docker/
+│   ├── Dockerfile
+│   └── docker-compose.yml                         # Local dev environment
+│
+├── pom.xml                                        # Maven config
+└── README.md
+```
+
+---
+
+## Layer Responsibilities
+
+### Controller Layer (API)
+**Purpose:** HTTP request/response handling, input validation, authentication context
+
+```java
+@RestController
+@RequestMapping("/api/family")
+@RequiredArgsConstructor
+public class FamilyController {
+
+    private final FamilyService familyService;
+
+    @GetMapping
+    public ApiResponse<FamilyResponse> getFamily(@CurrentUser UserPrincipal user) {
+        // Controllers should be thin - delegate to service
+        return ApiResponse.of(familyService.getFamilyForUser(user.getFamilyId()));
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MutationResponse<FamilyResponse> createFamily(
+            @Valid @RequestBody CreateFamilyRequest request,
+            @CurrentUser UserPrincipal user) {
+        // Validation handled by @Valid + Bean Validation
+        FamilyResponse family = familyService.createFamily(user.getId(), request);
+        return MutationResponse.of(family, "Family created successfully");
+    }
+}
+```
+
+**Rules:**
+- NO business logic - only orchestration
+- Always use DTOs for request/response (never expose entities)
+- Use `@Valid` for input validation
+- Return appropriate HTTP status codes
+
+### Service Layer
+**Purpose:** Business logic, transaction boundaries, authorization rules
+
+```java
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FamilyService {
+
+    private final FamilyRepository familyRepository;
+    private final FamilyMemberRepository memberRepository;
+    private final FamilyMapper mapper;
+
+    public FamilyResponse getFamilyForUser(UUID familyId) {
+        if (familyId == null) {
+            return null; // No family yet - triggers onboarding
+        }
+
+        Family family = familyRepository.findById(familyId)
+            .orElseThrow(() -> new ResourceNotFoundException("Family", familyId));
+
+        return mapper.toResponse(family);
+    }
+
+    @Transactional
+    public FamilyResponse createFamily(UUID userId, CreateFamilyRequest request) {
+        // Business rule: user can only have one family
+        if (familyRepository.existsByCreatorId(userId)) {
+            throw new ConflictException("Family already exists");
+        }
+
+        // Business rule: validate colors are unique
+        validateUniqueColors(request.getMembers());
+
+        Family family = mapper.toEntity(request);
+        family.setCreatorId(userId);
+
+        familyRepository.save(family);
+
+        return mapper.toResponse(family);
+    }
+
+    private void validateUniqueColors(List<MemberRequest> members) {
+        Set<FamilyColor> colors = new HashSet<>();
+        for (MemberRequest member : members) {
+            if (!colors.add(member.getColor())) {
+                throw new ValidationException("color",
+                    "Color " + member.getColor() + " is used multiple times");
+            }
+        }
+    }
+}
+```
+
+**Rules:**
+- All business logic lives here
+- Transaction boundaries are explicit
+- Use domain exceptions, not generic ones
+- Services can call other services (but avoid circular dependencies)
+
+### Repository Layer
+**Purpose:** Data access abstraction
+
+```java
+public interface FamilyRepository extends JpaRepository<Family, UUID> {
+
+    Optional<Family> findByCreatorId(UUID creatorId);
+
+    boolean existsByCreatorId(UUID creatorId);
+
+    @Query("SELECT f FROM Family f JOIN FETCH f.members WHERE f.id = :id")
+    Optional<Family> findByIdWithMembers(@Param("id") UUID id);
+}
+```
+
+**Rules:**
+- Extend Spring Data interfaces
+- Custom queries only when needed
+- Use `@Query` for complex queries, avoid raw SQL
+
+### Domain Layer (Entities)
+**Purpose:** Data structure, JPA mappings, basic validation
+
+```java
+@Entity
+@Table(name = "families")
+@Getter @Setter
+@NoArgsConstructor
+public class Family {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "creator_id", nullable = false)
+    private UUID creatorId;
+
+    @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
+    private List<FamilyMember> members = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "setup_complete", nullable = false)
+    private boolean setupComplete = false;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+    }
+
+    // Business methods can live on entities for cohesion
+    public void addMember(FamilyMember member) {
+        if (members.size() >= 7) {
+            throw new IllegalStateException("Maximum 7 members allowed");
+        }
+        members.add(member);
+        member.setFamily(this);
+    }
+}
+```
+
+---
+
+## Database Schema
+
+```sql
+-- V1__create_users_table.sql
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    family_id UUID,
+    member_id UUID,
+    role VARCHAR(20) NOT NULL DEFAULT 'member',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_email ON users(email);
+CREATE INDEX idx_users_family_id ON users(family_id);
+
+-- V2__create_families_table.sql
+CREATE TABLE families (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    creator_id UUID NOT NULL REFERENCES users(id),
+    setup_complete BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE family_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+    name VARCHAR(50) NOT NULL,
+    color VARCHAR(20) NOT NULL,
+    avatar_url VARCHAR(500),
+    email VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT uk_family_member_color UNIQUE (family_id, color)
+);
+
+CREATE INDEX idx_family_members_family_id ON family_members(family_id);
+
+-- Add foreign key from users to family_members
+ALTER TABLE users
+ADD CONSTRAINT fk_users_family FOREIGN KEY (family_id) REFERENCES families(id),
+ADD CONSTRAINT fk_users_member FOREIGN KEY (member_id) REFERENCES family_members(id);
+
+-- V3__create_events_table.sql
+CREATE TABLE calendar_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+    member_id UUID NOT NULL REFERENCES family_members(id),
+    title VARCHAR(200) NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    event_date DATE NOT NULL,
+    is_all_day BOOLEAN NOT NULL DEFAULT false,
+    location VARCHAR(500),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_event_times CHECK (end_time > start_time OR is_all_day = true)
+);
+
+CREATE INDEX idx_events_family_date ON calendar_events(family_id, event_date);
+CREATE INDEX idx_events_member ON calendar_events(member_id);
+
+-- V4__create_refresh_tokens_table.sql
+CREATE TABLE refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_refresh_tokens_user ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires ON refresh_tokens(expires_at);
+```
+
+---
+
+## Security Architecture
+
+### Authentication Flow
+
+```
+┌──────────┐     ┌──────────┐     ┌──────────┐     ┌──────────┐
+│  Client  │     │   API    │     │  Auth    │     │   DB     │
+└────┬─────┘     └────┬─────┘     └────┬─────┘     └────┬─────┘
+     │                │                │                │
+     │ POST /login    │                │                │
+     │ {email, pass}  │                │                │
+     │───────────────▶│                │                │
+     │                │ validate       │                │
+     │                │───────────────▶│                │
+     │                │                │ find user      │
+     │                │                │───────────────▶│
+     │                │                │◀───────────────│
+     │                │                │                │
+     │                │                │ verify password│
+     │                │                │ generate JWT   │
+     │                │                │ create refresh │
+     │                │◀───────────────│                │
+     │                │                │ store token    │
+     │                │                │───────────────▶│
+     │ {accessToken,  │                │                │
+     │  refreshToken} │                │                │
+     │◀───────────────│                │                │
+     │                │                │                │
+
+     ... later ...
+
+     │ GET /api/family│                │                │
+     │ Auth: Bearer x │                │                │
+     │───────────────▶│                │                │
+     │                │ validate JWT   │                │
+     │                │───────────────▶│                │
+     │                │◀───────────────│                │
+     │                │ extract claims │                │
+     │                │ set security   │                │
+     │                │ context        │                │
+     │ {family data}  │                │                │
+     │◀───────────────│                │                │
+```
+
+### JWT Implementation
+
+```java
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    private final JwtConfig config;
+
+    public String generateAccessToken(User user) {
+        return Jwts.builder()
+            .subject(user.getId().toString())
+            .claim("familyId", user.getFamilyId())
+            .claim("memberId", user.getMemberId())
+            .claim("role", user.getRole().name())
+            .issuedAt(new Date())
+            .expiration(Date.from(Instant.now().plus(config.getAccessTokenExpiry())))
+            .signWith(getSigningKey())
+            .compact();
+    }
+
+    public Claims validateToken(String token) {
+        return Jwts.parser()
+            .verifyWith(getSigningKey())
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(config.getSecret().getBytes(StandardCharsets.UTF_8));
+    }
+}
+```
+
+### Security Filter Chain
+
+```java
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(csrf -> csrf.disable()) // Stateless API
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/health").permitAll()
+                .requestMatchers("/api/auth/**").permitAll()
+                .requestMatchers("/api/docs/**", "/swagger-ui/**").permitAll()
+                .anyRequest().authenticated())
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+            .exceptionHandling(ex -> ex
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint()))
+            .build();
+    }
+}
+```
+
+---
+
+## Error Handling
+
+### Exception Hierarchy
+
+```java
+// Base exception
+public abstract class FamilyHubException extends RuntimeException {
+    private final String code;
+    private final int status;
+
+    protected FamilyHubException(String message, String code, int status) {
+        super(message);
+        this.code = code;
+        this.status = status;
+    }
+}
+
+// Specific exceptions
+public class ResourceNotFoundException extends FamilyHubException {
+    public ResourceNotFoundException(String resource, UUID id) {
+        super(resource + " with id \"" + id + "\" not found",
+              "NOT_FOUND", 404);
+    }
+}
+
+public class ConflictException extends FamilyHubException {
+    public ConflictException(String message) {
+        super(message, "CONFLICT", 409);
+    }
+}
+
+public class ValidationException extends FamilyHubException {
+    private final String field;
+
+    public ValidationException(String field, String message) {
+        super(message, "VALIDATION_ERROR", 400);
+        this.field = field;
+    }
+}
+```
+
+### Global Exception Handler
+
+```java
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(FamilyHubException.class)
+    public ResponseEntity<ErrorResponse> handleFamilyHubException(FamilyHubException ex) {
+        log.warn("Business exception: {}", ex.getMessage());
+
+        ErrorResponse error = ErrorResponse.builder()
+            .code(ex.getCode())
+            .message(ex.getMessage())
+            .status(ex.getStatus())
+            .field(ex instanceof ValidationException ?
+                   ((ValidationException) ex).getField() : null)
+            .build();
+
+        return ResponseEntity.status(ex.getStatus()).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException ex) {
+        FieldError fieldError = ex.getBindingResult().getFieldError();
+
+        ErrorResponse error = ErrorResponse.builder()
+            .code("VALIDATION_ERROR")
+            .message(fieldError != null ? fieldError.getDefaultMessage() : "Validation failed")
+            .status(400)
+            .field(fieldError != null ? fieldError.getField() : null)
+            .build();
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleUnexpected(Exception ex) {
+        log.error("Unexpected error", ex);
+
+        ErrorResponse error = ErrorResponse.builder()
+            .code("SERVER_ERROR")
+            .message("An unexpected error occurred")
+            .status(500)
+            .build();
+
+        return ResponseEntity.internalServerError().body(error);
+    }
+}
+```
+
+---
+
+## Configuration
+
+### application.yml
+
+```yaml
+spring:
+  application:
+    name: family-hub-api
+
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:familyhub}
+    username: ${DB_USERNAME:familyhub}
+    password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 20000
+
+  jpa:
+    hibernate:
+      ddl-auto: validate  # Flyway handles migrations
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+    open-in-view: false  # Important for performance
+
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+jwt:
+  secret: ${JWT_SECRET}  # Must be at least 256 bits for HS256
+  access-token-expiry: 24h
+  refresh-token-expiry: 30d
+
+server:
+  port: ${PORT:8080}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+  endpoint:
+    health:
+      show-details: when_authorized
+
+logging:
+  level:
+    com.familyhub: DEBUG
+    org.springframework.security: DEBUG
+```
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Test service layer in isolation
+- Mock repositories
+- Focus on business logic
+
+```java
+@ExtendWith(MockitoExtension.class)
+class FamilyServiceTest {
+
+    @Mock
+    private FamilyRepository familyRepository;
+
+    @Mock
+    private FamilyMapper mapper;
+
+    @InjectMocks
+    private FamilyService familyService;
+
+    @Test
+    void createFamily_withDuplicateColors_throwsValidationException() {
+        // Given
+        CreateFamilyRequest request = new CreateFamilyRequest();
+        request.setName("Test Family");
+        request.setMembers(List.of(
+            new MemberRequest("Alice", FamilyColor.CORAL),
+            new MemberRequest("Bob", FamilyColor.CORAL) // Duplicate!
+        ));
+
+        // When/Then
+        assertThatThrownBy(() -> familyService.createFamily(UUID.randomUUID(), request))
+            .isInstanceOf(ValidationException.class)
+            .hasMessageContaining("CORAL");
+    }
+}
+```
+
+### Integration Tests
+- Test full request/response cycle
+- Use Testcontainers for real PostgreSQL
+- Test auth flows end-to-end
+
+```java
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class FamilyApiIntegrationTest {
+
+    @Container
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16");
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void createFamily_withValidRequest_returnsCreatedFamily() {
+        // Given
+        String token = loginAndGetToken("test@example.com");
+
+        CreateFamilyRequest request = new CreateFamilyRequest();
+        request.setName("Integration Test Family");
+        request.setMembers(List.of(
+            new MemberRequest("Alice", FamilyColor.CORAL)
+        ));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+
+        // When
+        ResponseEntity<FamilyResponse> response = restTemplate.exchange(
+            "/api/family",
+            HttpMethod.POST,
+            new HttpEntity<>(request, headers),
+            FamilyResponse.class
+        );
+
+        // Then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().getName()).isEqualTo("Integration Test Family");
+        assertThat(response.getBody().getMembers()).hasSize(1);
+    }
+}
+```
+
+---
+
+## Deployment Considerations
+
+### Docker
+
+```dockerfile
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+COPY target/family-hub-api.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+### Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `DB_HOST` | PostgreSQL host | Yes |
+| `DB_PORT` | PostgreSQL port | No (default: 5432) |
+| `DB_NAME` | Database name | Yes |
+| `DB_USERNAME` | Database user | Yes |
+| `DB_PASSWORD` | Database password | Yes |
+| `JWT_SECRET` | JWT signing secret (256+ bits) | Yes |
+| `REDIS_HOST` | Redis host | No (default: localhost) |
+| `REDIS_PORT` | Redis port | No (default: 6379) |
+
+---
+
+## Performance Considerations
+
+1. **Connection Pooling**: HikariCP configured with appropriate pool sizes
+2. **N+1 Prevention**: Use `@EntityGraph` or `JOIN FETCH` for eager loading
+3. **Pagination**: All list endpoints should support pagination
+4. **Caching**: Cache family data (changes infrequently) in Redis
+5. **Indexes**: Database indexes on frequently queried columns
+
+---
+
+*This architecture guide should evolve as the system grows. Document decisions and their rationale.*

--- a/docs/backend/04-ROADMAP.md
+++ b/docs/backend/04-ROADMAP.md
@@ -1,0 +1,731 @@
+# FamilyHub Backend Development Roadmap
+
+> **Purpose:** Step-by-step implementation guide for the Spring Boot backend
+> **Approach:** Incremental delivery with working software at each milestone
+
+---
+
+## Philosophy
+
+This roadmap follows these principles:
+
+1. **Vertical Slices** - Deliver complete features, not horizontal layers
+2. **Working Software** - Each phase ends with deployable, testable code
+3. **Frontend First** - Priority based on what frontend needs to function
+4. **Fail Fast** - Tackle risky integrations early (auth, DB)
+
+---
+
+## Pre-Development Checklist
+
+Before writing code, ensure you have:
+
+- [ ] Java 21 installed (`java -version`)
+- [ ] Maven 3.9+ installed (`mvn -version`)
+- [ ] Docker installed (for local PostgreSQL/Redis)
+- [ ] IDE configured (IntelliJ recommended)
+- [ ] PostgreSQL client (DBeaver, pgAdmin, or CLI)
+- [ ] Postman or similar for API testing
+
+---
+
+## Phase 0: Project Bootstrap
+
+**Goal:** Working Spring Boot application with CI pipeline
+
+### Tasks
+
+#### 0.1 Initialize Project
+```bash
+# Use Spring Initializr (start.spring.io) or CLI
+spring init \
+  --java-version=21 \
+  --dependencies=web,data-jpa,postgresql,security,validation,flyway,lombok,actuator \
+  --group-id=com.familyhub \
+  --artifact-id=family-hub-api \
+  --name=FamilyHubApi \
+  family-hub-backend
+```
+
+#### 0.2 Configure Docker Compose
+Create `docker/docker-compose.yml`:
+```yaml
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: familyhub
+      POSTGRES_PASSWORD: localdev
+      POSTGRES_DB: familyhub
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+
+volumes:
+  postgres_data:
+```
+
+#### 0.3 Add Core Dependencies
+Update `pom.xml`:
+```xml
+<dependencies>
+    <!-- JWT -->
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-api</artifactId>
+        <version>0.12.3</version>
+    </dependency>
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-impl</artifactId>
+        <version>0.12.3</version>
+        <scope>runtime</scope>
+    </dependency>
+    <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt-jackson</artifactId>
+        <version>0.12.3</version>
+        <scope>runtime</scope>
+    </dependency>
+
+    <!-- OpenAPI -->
+    <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        <version>2.3.0</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>postgresql</artifactId>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
+    </dependency>
+</dependencies>
+```
+
+#### 0.4 Create Health Endpoint
+```java
+@RestController
+@RequestMapping("/api")
+public class HealthController {
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+            "status", "healthy",
+            "timestamp", Instant.now().toString(),
+            "version", "0.1.0"
+        );
+    }
+}
+```
+
+#### 0.5 Setup CI Pipeline
+Create `.github/workflows/ci.yml`:
+```yaml
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: familyhub_test
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - run: mvn verify
+```
+
+### Deliverable
+- Application starts successfully
+- `/api/health` returns 200
+- CI pipeline passes
+
+---
+
+## Phase 1: Authentication System
+
+**Goal:** Users can register, login, and make authenticated requests
+
+### Tasks
+
+#### 1.1 Database Schema
+Create `V1__create_users_table.sql`:
+```sql
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    family_id UUID,
+    member_id UUID,
+    role VARCHAR(20) NOT NULL DEFAULT 'member',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE refresh_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+#### 1.2 User Entity & Repository
+```java
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password_hash", nullable = false)
+    private String passwordHash;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(name = "family_id")
+    private UUID familyId;
+
+    @Column(name = "member_id")
+    private UUID memberId;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole role = UserRole.MEMBER;
+
+    // ... getters, setters
+}
+```
+
+#### 1.3 JWT Service
+Implement token generation and validation (see Architecture doc)
+
+#### 1.4 Auth Controller
+```java
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthResponse register(@Valid @RequestBody RegisterRequest request);
+
+    @PostMapping("/login")
+    public AuthResponse login(@Valid @RequestBody LoginRequest request);
+
+    @PostMapping("/refresh")
+    public TokenResponse refresh(@Valid @RequestBody RefreshRequest request);
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void logout(@Valid @RequestBody RefreshRequest request);
+}
+```
+
+#### 1.5 Security Configuration
+Configure Spring Security filter chain with JWT validation
+
+#### 1.6 Write Tests
+- Unit tests for JwtService
+- Integration tests for auth endpoints
+- Test invalid token handling
+
+### Deliverable
+- Users can register with email/password
+- Users can login and receive tokens
+- Protected endpoints require valid JWT
+- Tokens can be refreshed
+
+---
+
+## Phase 2: Family Module
+
+**Goal:** Complete family CRUD matching frontend contract
+
+### Tasks
+
+#### 2.1 Database Schema
+Create `V2__create_families_table.sql`:
+```sql
+CREATE TABLE families (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(100) NOT NULL,
+    creator_id UUID NOT NULL REFERENCES users(id),
+    setup_complete BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE family_members (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+    name VARCHAR(50) NOT NULL,
+    color VARCHAR(20) NOT NULL,
+    avatar_url VARCHAR(500),
+    email VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uk_family_member_color UNIQUE (family_id, color)
+);
+```
+
+#### 2.2 Entities & Repositories
+Create `Family`, `FamilyMember` entities with proper JPA relationships
+
+#### 2.3 Family Service
+Implement business logic:
+- Create family with members
+- Update family name
+- Add/update/remove members
+- Validate color uniqueness
+- Enforce max 7 members
+
+#### 2.4 Family Controller
+Match API contract exactly:
+```java
+@RestController
+@RequestMapping("/api/family")
+public class FamilyController {
+
+    @GetMapping
+    public ApiResponse<FamilyResponse> getFamily(@CurrentUser UserPrincipal user);
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MutationResponse<FamilyResponse> createFamily(
+        @Valid @RequestBody CreateFamilyRequest request,
+        @CurrentUser UserPrincipal user);
+
+    @PatchMapping
+    public MutationResponse<FamilyResponse> updateFamily(
+        @Valid @RequestBody UpdateFamilyRequest request,
+        @CurrentUser UserPrincipal user);
+
+    @DeleteMapping
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteFamily(@CurrentUser UserPrincipal user);
+}
+
+@RestController
+@RequestMapping("/api/family/members")
+public class FamilyMemberController {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MutationResponse<MemberResponse> addMember(...);
+
+    @PatchMapping("/{id}")
+    public MutationResponse<MemberResponse> updateMember(...);
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void removeMember(...);
+}
+```
+
+#### 2.5 Response DTOs
+Match frontend types exactly:
+```java
+public record FamilyResponse(
+    UUID id,
+    String name,
+    List<MemberResponse> members,
+    Instant createdAt,
+    boolean setupComplete
+) {}
+
+public record MemberResponse(
+    UUID id,
+    String name,
+    FamilyColor color,
+    String avatarUrl,
+    String email
+) {}
+```
+
+#### 2.6 Write Tests
+- Service unit tests for all business rules
+- Integration tests for full CRUD flow
+- Test error cases (conflict, not found, validation)
+
+### Deliverable
+- Family CRUD operations work via API
+- Frontend can create/manage families
+- All error responses match contract
+
+---
+
+## Phase 3: Calendar Module
+
+**Goal:** Complete calendar event CRUD with filtering
+
+### Tasks
+
+#### 3.1 Database Schema
+Create `V3__create_events_table.sql`:
+```sql
+CREATE TABLE calendar_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    family_id UUID NOT NULL REFERENCES families(id) ON DELETE CASCADE,
+    member_id UUID NOT NULL REFERENCES family_members(id),
+    title VARCHAR(200) NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    event_date DATE NOT NULL,
+    is_all_day BOOLEAN NOT NULL DEFAULT false,
+    location VARCHAR(500),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_events_family_date ON calendar_events(family_id, event_date);
+```
+
+#### 3.2 Entity & Repository
+```java
+@Entity
+@Table(name = "calendar_events")
+public class CalendarEvent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "family_id", nullable = false)
+    private UUID familyId;
+
+    @Column(name = "member_id", nullable = false)
+    private UUID memberId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDate eventDate;
+
+    @Column(name = "is_all_day")
+    private boolean isAllDay;
+
+    private String location;
+}
+```
+
+#### 3.3 Time Format Utilities
+Handle 12-hour format conversion:
+```java
+public class TimeUtils {
+
+    private static final DateTimeFormatter TIME_12H =
+        DateTimeFormatter.ofPattern("h:mm a");
+
+    public static LocalTime parse12Hour(String time) {
+        return LocalTime.parse(time.toUpperCase(), TIME_12H);
+    }
+
+    public static String format12Hour(LocalTime time) {
+        return time.format(TIME_12H);
+    }
+}
+```
+
+#### 3.4 Calendar Service
+Implement:
+- CRUD operations
+- Date range filtering
+- Member filtering
+- Time validation (end > start)
+
+#### 3.5 Calendar Controller
+```java
+@RestController
+@RequestMapping("/api/calendar/events")
+public class CalendarController {
+
+    @GetMapping
+    public ApiResponse<List<EventResponse>> getEvents(
+        @RequestParam(required = false) LocalDate startDate,
+        @RequestParam(required = false) LocalDate endDate,
+        @RequestParam(required = false) UUID memberId,
+        @CurrentUser UserPrincipal user);
+
+    @GetMapping("/{id}")
+    public ApiResponse<EventResponse> getEvent(
+        @PathVariable UUID id,
+        @CurrentUser UserPrincipal user);
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public MutationResponse<EventResponse> createEvent(
+        @Valid @RequestBody CreateEventRequest request,
+        @CurrentUser UserPrincipal user);
+
+    @PatchMapping("/{id}")
+    public MutationResponse<EventResponse> updateEvent(
+        @PathVariable UUID id,
+        @Valid @RequestBody UpdateEventRequest request,
+        @CurrentUser UserPrincipal user);
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteEvent(
+        @PathVariable UUID id,
+        @CurrentUser UserPrincipal user);
+}
+```
+
+#### 3.6 Write Tests
+- Test time parsing/formatting
+- Test date range filtering
+- Test member filtering
+- Test authorization (can't access other family's events)
+
+### Deliverable
+- Full calendar CRUD works via API
+- Frontend calendar module fully functional
+- Filtering by date and member works
+
+---
+
+## Phase 4: Frontend Integration
+
+**Goal:** Connect frontend to real backend, migrate from mocks
+
+### Tasks
+
+#### 4.1 CORS Configuration
+```java
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+}
+```
+
+#### 4.2 Update Frontend Config
+In frontend, update environment:
+```typescript
+// .env.development
+VITE_API_BASE_URL=http://localhost:8080/api
+
+// .env.production
+VITE_API_BASE_URL=https://api.familyhub.app/api
+```
+
+#### 4.3 Add Auth to Frontend
+Create new hooks/context for authentication:
+- Login/register forms
+- Token storage (secure httpOnly cookies preferred)
+- Auth context provider
+- Protected route wrapper
+
+#### 4.4 Disable Mock Layer
+```typescript
+// Toggle USE_MOCK_API to false
+export const USE_MOCK_API = false;
+```
+
+#### 4.5 Data Migration Tool
+Create utility to migrate localStorage data:
+```typescript
+async function migrateLocalData() {
+  const localFamily = localStorage.getItem('family-hub-family');
+  if (localFamily) {
+    // Parse and send to backend
+    await familyService.createFamily(parsedFamily);
+    localStorage.removeItem('family-hub-family');
+  }
+}
+```
+
+#### 4.6 End-to-End Testing
+Run Playwright tests against real backend
+
+### Deliverable
+- Frontend works with real backend
+- Existing localStorage data can be migrated
+- E2E tests pass
+
+---
+
+## Phase 5: Production Readiness
+
+**Goal:** Deploy to production environment
+
+### Tasks
+
+#### 5.1 Environment Configuration
+- Production database (managed PostgreSQL)
+- Production Redis (managed or ElastiCache)
+- Secret management (environment variables or vault)
+
+#### 5.2 Dockerfile
+```dockerfile
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+#### 5.3 Health Checks
+Enhanced health endpoint:
+```java
+@GetMapping("/health")
+public Map<String, Object> health() {
+    return Map.of(
+        "status", "healthy",
+        "timestamp", Instant.now(),
+        "version", buildVersion,
+        "checks", Map.of(
+            "database", checkDatabase(),
+            "redis", checkRedis()
+        )
+    );
+}
+```
+
+#### 5.4 Logging & Monitoring
+- Structured JSON logging
+- Request/response logging (sanitized)
+- Metrics endpoint for Prometheus
+- Error alerting setup
+
+#### 5.5 Rate Limiting
+```java
+// Add rate limiting to auth endpoints
+@RateLimited(requests = 5, period = 60) // 5 per minute
+@PostMapping("/login")
+public AuthResponse login(...);
+```
+
+#### 5.6 Security Hardening
+- HTTPS enforced
+- Security headers (CSP, HSTS, etc.)
+- Input sanitization
+- SQL injection prevention (already via JPA)
+- Dependency vulnerability scanning
+
+### Deliverable
+- Deployed to production
+- Monitoring dashboard active
+- Automated deployments working
+
+---
+
+## Future Phases (Post-MVP)
+
+### Phase 6: Chores Module
+- [ ] Chore entity with recurrence
+- [ ] Assignment to family members
+- [ ] Completion tracking
+- [ ] Due date reminders
+
+### Phase 7: Meals Module
+- [ ] Meal plan entity
+- [ ] Recipe storage
+- [ ] Shopping list generation
+- [ ] Nutritional info (optional)
+
+### Phase 8: Real-Time Updates
+- [ ] WebSocket integration
+- [ ] Live event updates
+- [ ] Typing indicators
+- [ ] Online presence
+
+### Phase 9: External Integrations
+- [ ] Google Calendar sync
+- [ ] Apple Calendar sync
+- [ ] Push notifications (FCM/APNs)
+- [ ] Email notifications
+
+---
+
+## Appendix: Quick Reference Commands
+
+### Development
+```bash
+# Start dependencies
+docker compose -f docker/docker-compose.yml up -d
+
+# Run application
+./mvnw spring-boot:run
+
+# Run tests
+./mvnw test
+
+# Run with specific profile
+./mvnw spring-boot:run -Dspring.profiles.active=dev
+
+# Generate OpenAPI spec
+curl http://localhost:8080/api/docs > openapi.json
+```
+
+### Database
+```bash
+# Connect to local database
+psql -h localhost -U familyhub -d familyhub
+
+# Run migrations manually
+./mvnw flyway:migrate
+
+# Reset database
+./mvnw flyway:clean flyway:migrate
+```
+
+### Docker
+```bash
+# Build image
+docker build -t family-hub-api .
+
+# Run container
+docker run -p 8080:8080 \
+  -e DB_HOST=host.docker.internal \
+  -e DB_PASSWORD=secret \
+  -e JWT_SECRET=your-secret \
+  family-hub-api
+```
+
+---
+
+*Track progress in GitHub Issues/Projects. Each phase should have its own milestone.*

--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   clearStorage,
   createTestMember,
+  seedAuth,
   seedFamily,
   waitForCalendar,
   waitForDialogOpen,
@@ -13,6 +14,8 @@ test.describe("Calendar Event CRUD", () => {
     // Clear storage and seed a family
     await page.goto("/");
     await clearStorage(page);
+    // Seed auth token to bypass login screen
+    await seedAuth(page);
 
     // Seed family with one member
     await seedFamily(page, {

--- a/e2e/calendar-navigation.spec.ts
+++ b/e2e/calendar-navigation.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   clearStorage,
   createTestMember,
+  seedAuth,
   seedFamily,
   waitForCalendar,
   waitForHydration,
@@ -12,6 +13,8 @@ test.describe("Calendar View Navigation", () => {
     // Clear storage and seed a family with 2 members for filtering
     await page.goto("/");
     await clearStorage(page);
+    // Seed auth token to bypass login screen
+    await seedAuth(page);
 
     // Seed family with two members
     await seedFamily(page, {

--- a/e2e/family-management.spec.ts
+++ b/e2e/family-management.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import {
   clearStorage,
   createTestMember,
+  seedAuth,
   seedFamily,
   waitForCalendar,
   waitForDialogClosed,
@@ -14,6 +15,8 @@ test.describe("Family Member Management", () => {
     // Clear storage and seed a family with one member
     await page.goto("/");
     await clearStorage(page);
+    // Seed auth token to bypass login screen
+    await seedAuth(page);
 
     // Seed family with one member
     await seedFamily(page, {

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -29,6 +29,19 @@ export async function clearStorage(page: Page): Promise<void> {
 }
 
 /**
+ * Seed authentication token to bypass login screen.
+ * Must be called after page.goto() but before reload/navigation.
+ */
+export async function seedAuth(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    // Mock JWT token - the app only checks for token existence, not validity
+    const mockToken =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXVzZXIiLCJpYXQiOjE3MDAwMDAwMDB9.mock";
+    localStorage.setItem("family-hub-auth-token", mockToken);
+  });
+}
+
+/**
  * Seed family data into localStorage
  * This bypasses onboarding for tests that need an existing family
  */

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -100,6 +100,12 @@ test.describe("First-Time User Onboarding", () => {
     // Click Complete Setup
     await page.getByRole("button", { name: "Complete Setup" }).click();
 
+    // Wait for registration API call to complete and app to transition
+    // The onboarding screen should disappear
+    await expect(
+      page.getByRole("heading", { name: /create your login/i }),
+    ).toBeHidden({ timeout: 10000 });
+
     // Verify main app is showing
     // On mobile, this shows home dashboard first; on desktop, shows calendar
     // waitForCalendar handles both cases by navigating from home if needed

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -5,14 +5,15 @@ import {
   renderWithUser,
   resetFamilyStore,
   screen,
+  seedAuthStore,
 } from "./test/test-utils";
 
 describe("App", () => {
   beforeEach(() => {
     // Reset and mark as hydrated so App shows auth flow (not loading state)
     resetFamilyStore();
-    // Clear auth token to ensure we're not authenticated
-    localStorage.removeItem("family-hub-auth-token");
+    // Mark auth as hydrated (not authenticated) so login screen renders
+    seedAuthStore({ isAuthenticated: false });
   });
 
   it("renders login screen when not authenticated", async () => {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,27 +1,55 @@
 import { beforeEach } from "vitest";
 import FamilyHub from "./App";
-import { render, resetFamilyStore, screen } from "./test/test-utils";
+import {
+  render,
+  renderWithUser,
+  resetFamilyStore,
+  screen,
+} from "./test/test-utils";
 
 describe("App", () => {
   beforeEach(() => {
-    // Reset and mark as hydrated so App shows onboarding (not loading state)
+    // Reset and mark as hydrated so App shows auth flow (not loading state)
     resetFamilyStore();
+    // Clear auth token to ensure we're not authenticated
+    localStorage.removeItem("family-hub-auth-token");
   });
-  it("renders without crashing", async () => {
+
+  it("renders login screen when not authenticated", async () => {
     render(<FamilyHub />);
 
-    // In test environment, Zustand hydrates synchronously
-    // App renders onboarding when setupComplete is false
+    // App renders login screen when not authenticated
     // Use findByText to wait for lazy-loaded component
-    expect(await screen.findByText("Welcome to FamilyHub")).toBeInTheDocument();
+    expect(await screen.findByText("Welcome Back!")).toBeInTheDocument();
+    expect(
+      screen.getByText("Sign in to your family calendar"),
+    ).toBeInTheDocument();
   });
 
-  it("shows get started button in onboarding", async () => {
+  it("shows sign in button on login screen", async () => {
     render(<FamilyHub />);
 
-    // Wait for lazy-loaded onboarding component
+    // Wait for lazy-loaded login component
     expect(
-      await screen.findByRole("button", { name: /get started/i }),
+      await screen.findByRole("button", { name: /sign in/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("navigates to onboarding when Create an account is clicked", async () => {
+    const { user } = renderWithUser(<FamilyHub />);
+
+    // Wait for login screen to load
+    await screen.findByText("Welcome Back!");
+
+    // Click Create an account link
+    await user.click(
+      screen.getByRole("button", { name: /create an account/i }),
+    );
+
+    // Should now show onboarding welcome screen
+    expect(await screen.findByText("Welcome to FamilyHub")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /get started/i }),
     ).toBeInTheDocument();
   });
 });

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -1,4 +1,15 @@
 export {
+  authKeys,
+  clearStoredToken,
+  getStoredToken,
+  setStoredToken,
+  useCheckUsername,
+  useLogin,
+  useLogout,
+  useRegister,
+} from "./use-auth";
+
+export {
   calendarKeys,
   useCalendarEvent,
   useCalendarEvents,

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -1,0 +1,203 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ApiException } from "@/api/client";
+import { authService } from "@/api/services";
+import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
+import type {
+  FamilyApiResponse,
+  FamilyData,
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+  UsernameCheckResponse,
+} from "@/lib/types";
+import { familyKeys } from "./use-family";
+
+// ============================================================================
+// Query Keys Factory
+// ============================================================================
+
+export const authKeys = {
+  all: ["auth"] as const,
+  usernameCheck: (username: string) =>
+    [...authKeys.all, "username", username] as const,
+};
+
+// ============================================================================
+// Token Storage Helpers
+// ============================================================================
+
+/**
+ * Get stored auth token from localStorage.
+ */
+export function getStoredToken(): string | null {
+  try {
+    return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save auth token to localStorage.
+ */
+export function setStoredToken(token: string): void {
+  try {
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to save token to localStorage:", error);
+    }
+  }
+}
+
+/**
+ * Remove auth token from localStorage.
+ */
+export function clearStoredToken(): void {
+  try {
+    localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to clear token from localStorage:", error);
+    }
+  }
+}
+
+/**
+ * Write family data to localStorage (Zustand persist format).
+ */
+function writeFamilyToStorage(family: FamilyData): void {
+  try {
+    const stored = {
+      state: {
+        family,
+        _hasHydrated: true,
+      },
+      version: 0,
+    };
+    localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to write family to localStorage:", error);
+    }
+  }
+}
+
+// ============================================================================
+// Login Hook
+// ============================================================================
+
+interface LoginCallbacks {
+  onSuccess?: (data: LoginResponse) => void;
+  onError?: (error: ApiException) => void;
+}
+
+/**
+ * Login mutation that stores token and updates family cache.
+ */
+export function useLogin(callbacks?: LoginCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: LoginRequest) => authService.login(request),
+    onSuccess: (response) => {
+      // Store token
+      setStoredToken(response.data.token);
+
+      // Update family query cache
+      queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+        data: response.data.family,
+        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
+      });
+
+      // Write family to localStorage for hydration
+      writeFamilyToStorage(response.data.family);
+
+      callbacks?.onSuccess?.(response);
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+// ============================================================================
+// Register Hook
+// ============================================================================
+
+interface RegisterCallbacks {
+  onSuccess?: (data: RegisterResponse) => void;
+  onError?: (error: ApiException) => void;
+}
+
+/**
+ * Register mutation that creates family, stores token, and updates cache.
+ */
+export function useRegister(callbacks?: RegisterCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: RegisterRequest) => authService.register(request),
+    onSuccess: (response) => {
+      // Store token
+      setStoredToken(response.data.token);
+
+      // Update family query cache
+      queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+        data: response.data.family,
+        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
+      });
+
+      // Write family to localStorage for hydration
+      writeFamilyToStorage(response.data.family);
+
+      callbacks?.onSuccess?.(response);
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+// ============================================================================
+// Username Check Hook
+// ============================================================================
+
+/**
+ * Check if a username is available.
+ * Only runs when username is at least 3 characters.
+ */
+export function useCheckUsername(username: string, enabled = true) {
+  return useQuery<UsernameCheckResponse, ApiException>({
+    queryKey: authKeys.usernameCheck(username),
+    queryFn: () => authService.checkUsername(username),
+    enabled: enabled && username.length >= 3,
+    staleTime: 30 * 1000, // 30 seconds
+  });
+}
+
+// ============================================================================
+// Logout Hook
+// ============================================================================
+
+/**
+ * Returns a logout function that clears auth state and reloads the page.
+ */
+export function useLogout() {
+  const queryClient = useQueryClient();
+
+  return () => {
+    // Clear token from storage
+    clearStoredToken();
+
+    // Clear family data from localStorage
+    localStorage.removeItem(FAMILY_STORAGE_KEY);
+
+    // Clear all query cache
+    queryClient.clear();
+
+    // Force page reload to reset all state
+    window.location.reload();
+  };
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,16 +5,22 @@ export {
   ApiException,
   httpClient,
 } from "./client";
+// Hooks - Auth
 // Hooks - Calendar
 // Hooks - Family
 export {
+  authKeys,
   calendarKeys,
+  clearStoredToken,
   familyKeys,
+  getStoredToken,
   readFamilyFromStorage,
+  setStoredToken,
   syncFamilyFromStorage,
   useAddMember,
   useCalendarEvent,
   useCalendarEvents,
+  useCheckUsername,
   useCreateEvent,
   useCreateFamily,
   useDeleteEvent,
@@ -26,6 +32,9 @@ export {
   useFamilyMemberMap,
   useFamilyMembers,
   useFamilyName,
+  useLogin,
+  useLogout,
+  useRegister,
   useRemoveMember,
   useSetupComplete,
   useUnusedColors,
@@ -36,4 +45,4 @@ export {
 // Mocks
 export { USE_MOCK_API } from "./mocks";
 // Services
-export { calendarService, familyService } from "./services";
+export { authService, calendarService, familyService } from "./services";

--- a/src/api/mocks/auth.mock.ts
+++ b/src/api/mocks/auth.mock.ts
@@ -1,0 +1,261 @@
+import { ApiErrorCode, ApiException } from "@/api/client";
+import {
+  AUTH_TOKEN_STORAGE_KEY,
+  FAMILY_STORAGE_KEY,
+  MOCK_USERS_STORAGE_KEY,
+} from "@/lib/constants";
+import type {
+  FamilyData,
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+  UsernameCheckResponse,
+} from "@/lib/types";
+import { simulateApiCall } from "./delay";
+
+// ============================================================================
+// Mock User Types
+// ============================================================================
+
+interface MockUser {
+  username: string;
+  passwordHash: string; // In mock, stored as plain text for simplicity
+  familyId: string;
+}
+
+// ============================================================================
+// Persistence Helpers
+// ============================================================================
+
+/**
+ * Load mock users from localStorage.
+ */
+function loadUsersFromStorage(): MockUser[] {
+  try {
+    const stored = localStorage.getItem(MOCK_USERS_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save mock users to localStorage.
+ */
+function saveUsersToStorage(users: MockUser[]): void {
+  try {
+    localStorage.setItem(MOCK_USERS_STORAGE_KEY, JSON.stringify(users));
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to save users to localStorage:", error);
+    }
+  }
+}
+
+/**
+ * Load family data from localStorage.
+ */
+function loadFamilyFromStorage(): FamilyData | null {
+  try {
+    const stored = localStorage.getItem(FAMILY_STORAGE_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    return parsed?.state?.family ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Save family data to localStorage.
+ * Matches the Zustand persist format for compatibility.
+ */
+function saveFamilyToStorage(family: FamilyData): void {
+  try {
+    const stored = {
+      state: {
+        family,
+        _hasHydrated: true,
+      },
+      version: 0,
+    };
+    localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(stored));
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to save family to localStorage:", error);
+    }
+  }
+}
+
+/**
+ * Save auth token to localStorage.
+ */
+function saveTokenToStorage(token: string): void {
+  try {
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to save token to localStorage:", error);
+    }
+  }
+}
+
+// ============================================================================
+// Token Generation
+// ============================================================================
+
+/**
+ * Generate a mock JWT token.
+ * Not cryptographically valid - just for mock API simulation.
+ */
+function generateMockToken(username: string, familyId: string): string {
+  const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = btoa(
+    JSON.stringify({
+      sub: username,
+      familyId,
+      iat: Date.now(),
+      // 1 year expiration for long-lived token
+      exp: Date.now() + 365 * 24 * 60 * 60 * 1000,
+    }),
+  );
+  const signature = btoa("mock-signature-" + username);
+  return `${header}.${payload}.${signature}`;
+}
+
+// ============================================================================
+// Mock Handlers
+// ============================================================================
+
+export const authMockHandlers = {
+  /**
+   * Login with username and password.
+   * Returns JWT token and associated family data.
+   */
+  async login(request: LoginRequest): Promise<LoginResponse> {
+    await simulateApiCall({ delayMin: 300, delayMax: 600 });
+
+    const users = loadUsersFromStorage();
+    const normalizedUsername = request.username.toLowerCase().trim();
+    const user = users.find((u) => u.username === normalizedUsername);
+
+    // Check credentials
+    if (!user || user.passwordHash !== request.password) {
+      throw new ApiException({
+        code: ApiErrorCode.UNAUTHORIZED,
+        message: "Invalid username or password",
+        status: 401,
+      });
+    }
+
+    // Load associated family data
+    const family = loadFamilyFromStorage();
+    if (!family || family.id !== user.familyId) {
+      throw new ApiException({
+        code: ApiErrorCode.NOT_FOUND,
+        message: "Family data not found",
+        status: 404,
+      });
+    }
+
+    const token = generateMockToken(user.username, user.familyId);
+
+    // Save token to storage (simulating server-side session)
+    saveTokenToStorage(token);
+
+    return {
+      data: { token, family },
+      message: "Login successful",
+    };
+  },
+
+  /**
+   * Register a new family with credentials.
+   * Creates both user credentials and family data.
+   */
+  async register(request: RegisterRequest): Promise<RegisterResponse> {
+    await simulateApiCall({ delayMin: 400, delayMax: 800 });
+
+    const users = loadUsersFromStorage();
+    const normalizedUsername = request.username.toLowerCase().trim();
+
+    // Check if username already exists
+    if (users.some((u) => u.username === normalizedUsername)) {
+      throw new ApiException({
+        code: ApiErrorCode.CONFLICT,
+        message: "Username already taken",
+        status: 409,
+        field: "username",
+      });
+    }
+
+    // Check if family already exists
+    const existingFamily = loadFamilyFromStorage();
+    if (existingFamily) {
+      throw new ApiException({
+        code: ApiErrorCode.CONFLICT,
+        message: "Family already exists",
+        status: 409,
+      });
+    }
+
+    // Create family data
+    const family: FamilyData = {
+      id: crypto.randomUUID(),
+      name: request.familyName,
+      members: request.members.map((m) => ({
+        ...m,
+        id: crypto.randomUUID(),
+      })),
+      createdAt: new Date().toISOString(),
+      setupComplete: true,
+    };
+
+    // Create user credentials
+    const newUser: MockUser = {
+      username: normalizedUsername,
+      passwordHash: request.password, // In real API, this would be hashed
+      familyId: family.id,
+    };
+
+    // Save both to storage
+    saveFamilyToStorage(family);
+    saveUsersToStorage([...users, newUser]);
+
+    const token = generateMockToken(normalizedUsername, family.id);
+
+    // Save token to storage
+    saveTokenToStorage(token);
+
+    return {
+      data: { token, family },
+      message: "Registration successful",
+    };
+  },
+
+  /**
+   * Check if a username is available.
+   */
+  async checkUsername(username: string): Promise<UsernameCheckResponse> {
+    await simulateApiCall({ delayMin: 100, delayMax: 200 });
+
+    const users = loadUsersFromStorage();
+    const normalizedUsername = username.toLowerCase().trim();
+    const available = !users.some((u) => u.username === normalizedUsername);
+
+    return { available };
+  },
+
+  // ============================================================================
+  // Utility Methods (for testing)
+  // ============================================================================
+
+  /**
+   * Reset all auth-related mock data.
+   */
+  resetMockData(): void {
+    localStorage.removeItem(MOCK_USERS_STORAGE_KEY);
+    localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  },
+};

--- a/src/api/mocks/auth.mock.ts
+++ b/src/api/mocks/auth.mock.ts
@@ -120,7 +120,7 @@ function generateMockToken(username: string, familyId: string): string {
       exp: Date.now() + 365 * 24 * 60 * 60 * 1000,
     }),
   );
-  const signature = btoa("mock-signature-" + username);
+  const signature = btoa(`mock-signature-${username}`);
   return `${header}.${payload}.${signature}`;
 }
 

--- a/src/api/mocks/index.ts
+++ b/src/api/mocks/index.ts
@@ -1,3 +1,4 @@
+export { authMockHandlers } from "./auth.mock";
 export { calendarMockHandlers } from "./calendar.mock";
 export {
   delay,

--- a/src/api/services/auth.service.ts
+++ b/src/api/services/auth.service.ts
@@ -1,0 +1,45 @@
+import { httpClient } from "@/api/client";
+import { authMockHandlers, USE_MOCK_API } from "@/api/mocks";
+import type {
+  LoginRequest,
+  LoginResponse,
+  RegisterRequest,
+  RegisterResponse,
+  UsernameCheckResponse,
+} from "@/lib/types";
+
+export const authService = {
+  /**
+   * Login with username and password.
+   * Returns JWT token and associated family data.
+   */
+  async login(request: LoginRequest): Promise<LoginResponse> {
+    if (USE_MOCK_API) {
+      return authMockHandlers.login(request);
+    }
+    return httpClient.post<LoginResponse>("/auth/login", request);
+  },
+
+  /**
+   * Register a new family with credentials.
+   * Creates both user credentials and family data.
+   */
+  async register(request: RegisterRequest): Promise<RegisterResponse> {
+    if (USE_MOCK_API) {
+      return authMockHandlers.register(request);
+    }
+    return httpClient.post<RegisterResponse>("/auth/register", request);
+  },
+
+  /**
+   * Check if a username is available.
+   */
+  async checkUsername(username: string): Promise<UsernameCheckResponse> {
+    if (USE_MOCK_API) {
+      return authMockHandlers.checkUsername(username);
+    }
+    return httpClient.get<UsernameCheckResponse>("/auth/check-username", {
+      params: { username },
+    });
+  },
+};

--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -1,2 +1,3 @@
+export { authService } from "./auth.service";
 export { calendarService } from "./calendar.service";
 export { familyService } from "./family.service";

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,2 @@
+export { LoginFlow } from "./login-flow";
+export { LoginForm } from "./login-form";

--- a/src/components/auth/login-flow.tsx
+++ b/src/components/auth/login-flow.tsx
@@ -1,0 +1,9 @@
+import { LoginForm } from "./login-form";
+
+interface LoginFlowProps {
+  onStartOnboarding: () => void;
+}
+
+export function LoginFlow({ onStartOnboarding }: LoginFlowProps) {
+  return <LoginForm onSwitchToOnboarding={onStartOnboarding} />;
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,116 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useLogin } from "@/api";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form-error";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type LoginFormData, loginFormSchema } from "@/lib/validations/auth";
+import { useAuthStore } from "@/stores";
+
+interface LoginFormProps {
+  onSwitchToOnboarding: () => void;
+}
+
+export function LoginForm({ onSwitchToOnboarding }: LoginFormProps) {
+  const login = useLogin();
+  const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm<LoginFormData>({
+    resolver: zodResolver(loginFormSchema),
+  });
+
+  const onSubmit = (data: LoginFormData) => {
+    login.mutate(data, {
+      onSuccess: () => {
+        // Update auth store to trigger re-render
+        setAuthenticated(true);
+      },
+      onError: (error) => {
+        if (error.code === "UNAUTHORIZED") {
+          setError("root", { message: "Invalid username or password" });
+        } else {
+          setError("root", { message: "An error occurred. Please try again." });
+        }
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
+      <div className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <div className="space-y-3 text-center">
+            <h1 className="text-2xl font-bold text-foreground">
+              Welcome Back!
+            </h1>
+            <p className="text-muted-foreground">
+              Sign in to your family calendar
+            </p>
+          </div>
+
+          {errors.root && (
+            <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg">
+              <p className="text-sm text-destructive text-center">
+                {errors.root.message}
+              </p>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="login-username">Username</Label>
+              <Input
+                id="login-username"
+                placeholder="your_username"
+                autoComplete="username"
+                autoFocus
+                {...register("username")}
+              />
+              <FormError message={errors.username?.message} />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="login-password">Password</Label>
+              <Input
+                id="login-password"
+                type="password"
+                placeholder="********"
+                autoComplete="current-password"
+                {...register("password")}
+              />
+              <FormError message={errors.password?.message} />
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            size="lg"
+            className="w-full"
+            disabled={login.isPending}
+          >
+            {login.isPending ? "Signing in..." : "Sign In"}
+          </Button>
+
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground">
+              New to Family Hub?{" "}
+              <button
+                type="button"
+                onClick={onSwitchToOnboarding}
+                className="text-primary hover:underline font-medium"
+              >
+                Create an account
+              </button>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/index.ts
+++ b/src/components/onboarding/index.ts
@@ -1,5 +1,6 @@
 export { MemberCard } from "./member-card";
 export { MemberFormModal } from "./member-form-modal";
+export { OnboardingCredentials } from "./onboarding-credentials";
 export { OnboardingFamilyName } from "./onboarding-family-name";
 export { OnboardingFlow } from "./onboarding-flow";
 export { OnboardingMembers } from "./onboarding-members";

--- a/src/components/onboarding/onboarding-credentials.tsx
+++ b/src/components/onboarding/onboarding-credentials.tsx
@@ -1,0 +1,159 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ArrowLeft, Check, Loader2, X } from "lucide-react";
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { useCheckUsername } from "@/api";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form-error";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useDebounce } from "@/hooks";
+import {
+  type CredentialsFormData,
+  credentialsFormSchema,
+} from "@/lib/validations/auth";
+
+interface OnboardingCredentialsProps {
+  onNext: (username: string, password: string) => void;
+  onBack: () => void;
+  isSubmitting: boolean;
+}
+
+export function OnboardingCredentials({
+  onNext,
+  onBack,
+  isSubmitting,
+}: OnboardingCredentialsProps) {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setError,
+    clearErrors,
+    formState: { errors },
+  } = useForm<CredentialsFormData>({
+    resolver: zodResolver(credentialsFormSchema),
+  });
+
+  const username = watch("username");
+  const debouncedUsername = useDebounce(username || "", 500);
+
+  const { data: usernameCheck, isFetching: isCheckingUsername } =
+    useCheckUsername(debouncedUsername, debouncedUsername.length >= 3);
+
+  // Update error state based on username availability
+  useEffect(() => {
+    if (usernameCheck && !usernameCheck.available) {
+      setError("username", { message: "Username is already taken" });
+    } else if (
+      usernameCheck?.available &&
+      errors.username?.message === "Username is already taken"
+    ) {
+      clearErrors("username");
+    }
+  }, [usernameCheck, setError, clearErrors, errors.username?.message]);
+
+  const onSubmit = (data: CredentialsFormData) => {
+    if (usernameCheck && !usernameCheck.available) {
+      setError("username", { message: "Username is already taken" });
+      return;
+    }
+    onNext(data.username, data.password);
+  };
+
+  const showUsernameStatus = debouncedUsername.length >= 3;
+
+  return (
+    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
+      {/* Header with back button */}
+      <div className="flex items-center gap-2 mb-8">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onBack}
+          aria-label="Go back"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <span className="text-sm text-muted-foreground">Step 3 of 3</span>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+          <div className="space-y-3 text-center">
+            <h1 className="text-2xl font-bold text-foreground">
+              Create Your Login
+            </h1>
+            <p className="text-muted-foreground">
+              Your family will use these credentials to sign in on any device.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="credentials-username">Username</Label>
+              <div className="relative">
+                <Input
+                  id="credentials-username"
+                  placeholder="your_family_username"
+                  autoComplete="username"
+                  autoFocus
+                  className="pr-10"
+                  {...register("username")}
+                />
+                {showUsernameStatus && (
+                  <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                    {isCheckingUsername ? (
+                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                    ) : usernameCheck?.available ? (
+                      <Check className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <X className="h-4 w-4 text-destructive" />
+                    )}
+                  </div>
+                )}
+              </div>
+              <FormError message={errors.username?.message} />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="credentials-password">Password</Label>
+              <Input
+                id="credentials-password"
+                type="password"
+                placeholder="At least 8 characters"
+                autoComplete="new-password"
+                {...register("password")}
+              />
+              <FormError message={errors.password?.message} />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="credentials-confirm-password">
+                Confirm Password
+              </Label>
+              <Input
+                id="credentials-confirm-password"
+                type="password"
+                placeholder="Confirm your password"
+                autoComplete="new-password"
+                {...register("confirmPassword")}
+              />
+              <FormError message={errors.confirmPassword?.message} />
+            </div>
+          </div>
+
+          <Button
+            type="submit"
+            size="lg"
+            className="w-full"
+            disabled={isSubmitting || isCheckingUsername}
+          >
+            {isSubmitting ? "Creating Account..." : "Complete Setup"}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -45,7 +45,7 @@ export function OnboardingFamilyName({
         >
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <span className="text-sm text-muted-foreground">Step 1 of 2</span>
+        <span className="text-sm text-muted-foreground">Step 1 of 3</span>
       </div>
 
       {/* Content */}

--- a/src/components/onboarding/onboarding-flow.test.tsx
+++ b/src/components/onboarding/onboarding-flow.test.tsx
@@ -7,7 +7,12 @@ import {
   expect,
   it,
 } from "vitest";
-import { getMockFamily, resetMockFamily, server } from "@/test/mocks/server";
+import {
+  getMockFamily,
+  resetMockFamily,
+  resetMockUsers,
+  server,
+} from "@/test/mocks/server";
 import {
   render,
   renderWithUser,
@@ -23,6 +28,7 @@ describe("OnboardingFlow", () => {
   afterEach(() => {
     server.resetHandlers();
     resetMockFamily();
+    resetMockUsers();
   });
   afterAll(() => server.close());
 
@@ -63,7 +69,7 @@ describe("OnboardingFlow", () => {
 
       await user.click(screen.getByRole("button", { name: /get started/i }));
 
-      expect(screen.getByText("Step 1 of 2")).toBeInTheDocument();
+      expect(screen.getByText("Step 1 of 3")).toBeInTheDocument();
     });
 
     it("has back button that returns to welcome", async () => {
@@ -142,7 +148,7 @@ describe("OnboardingFlow", () => {
       const { user } = renderWithUser(<OnboardingFlow />);
       await navigateToMembersStep(user);
 
-      expect(screen.getByText("Step 2 of 2")).toBeInTheDocument();
+      expect(screen.getByText("Step 2 of 3")).toBeInTheDocument();
     });
 
     it("shows Add Family Member button", async () => {
@@ -152,13 +158,11 @@ describe("OnboardingFlow", () => {
       expect(screen.getByText("Add Family Member")).toBeInTheDocument();
     });
 
-    it("disables Complete Setup button when no members", async () => {
+    it("disables Continue button when no members", async () => {
       const { user } = renderWithUser(<OnboardingFlow />);
       await navigateToMembersStep(user);
 
-      expect(
-        screen.getByRole("button", { name: /complete setup/i }),
-      ).toBeDisabled();
+      expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
       expect(
         screen.getByText("Add at least one family member to continue"),
       ).toBeInTheDocument();
@@ -213,7 +217,7 @@ describe("OnboardingFlow", () => {
       expect(screen.getByText("John")).toBeInTheDocument();
     });
 
-    it("enables Complete Setup after adding a member", async () => {
+    it("enables Continue after adding a member", async () => {
       const { user } = renderWithUser(<OnboardingFlow />);
       await navigateToMembersStep(user);
 
@@ -234,9 +238,9 @@ describe("OnboardingFlow", () => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
 
-      // Complete Setup should now be enabled
+      // Continue should now be enabled
       expect(
-        screen.getByRole("button", { name: /complete setup/i }),
+        screen.getByRole("button", { name: /continue/i }),
       ).not.toBeDisabled();
     });
 
@@ -277,6 +281,18 @@ describe("OnboardingFlow", () => {
       await waitFor(() => {
         expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
       });
+
+      // Continue to credentials step
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      // Step 4: Credentials
+      expect(screen.getByText("Create Your Login")).toBeInTheDocument();
+      await user.type(screen.getByLabelText(/username/i), "testfamily");
+      await user.type(screen.getByLabelText(/^password$/i), "password123");
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        "password123",
+      );
 
       // Complete setup
       await user.click(screen.getByRole("button", { name: /complete setup/i }));
@@ -335,6 +351,18 @@ describe("OnboardingFlow", () => {
       // Both members should be visible
       expect(screen.getByText("Mom")).toBeInTheDocument();
       expect(screen.getByText("Dad")).toBeInTheDocument();
+
+      // Continue to credentials step
+      await user.click(screen.getByRole("button", { name: /continue/i }));
+
+      // Step 4: Credentials
+      expect(screen.getByText("Create Your Login")).toBeInTheDocument();
+      await user.type(screen.getByLabelText(/username/i), "bigfamily");
+      await user.type(screen.getByLabelText(/^password$/i), "password123");
+      await user.type(
+        screen.getByLabelText(/confirm password/i),
+        "password123",
+      );
 
       // Complete
       await user.click(screen.getByRole("button", { name: /complete setup/i }));

--- a/src/components/onboarding/onboarding-members.tsx
+++ b/src/components/onboarding/onboarding-members.tsx
@@ -14,7 +14,7 @@ interface OnboardingMembersProps {
   onAddMember: (data: MemberFormData) => void;
   onEditMember: (id: string, data: MemberFormData) => void;
   onRemoveMember: (id: string) => void;
-  onComplete: () => void;
+  onNext: () => void;
   onBack: () => void;
 }
 
@@ -23,7 +23,7 @@ export function OnboardingMembers({
   onAddMember,
   onEditMember,
   onRemoveMember,
-  onComplete,
+  onNext,
   onBack,
 }: OnboardingMembersProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
@@ -69,7 +69,7 @@ export function OnboardingMembers({
         >
           <ArrowLeft className="h-5 w-5" />
         </Button>
-        <span className="text-sm text-muted-foreground">Step 2 of 2</span>
+        <span className="text-sm text-muted-foreground">Step 2 of 3</span>
       </div>
 
       {/* Content */}
@@ -114,15 +114,15 @@ export function OnboardingMembers({
           )}
         </div>
 
-        {/* Complete button */}
+        {/* Continue button */}
         <div className="pt-6">
           <Button
             size="lg"
             className="w-full"
-            onClick={onComplete}
+            onClick={onNext}
             disabled={!canComplete}
           >
-            Complete Setup
+            Continue
           </Button>
           {!canComplete && (
             <p className="text-sm text-muted-foreground text-center mt-2">

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,6 +1,6 @@
-import { Users, X } from "lucide-react";
+import { LogOut, Users, X } from "lucide-react";
 import { useState } from "react";
-import { useFamilyMembers, useFamilyName } from "@/api";
+import { useFamilyMembers, useFamilyName, useLogout } from "@/api";
 import { FamilySettingsModal, MemberProfileModal } from "@/components/settings";
 import { Button } from "@/components/ui/button";
 import { colorMap } from "@/lib/types";
@@ -14,6 +14,9 @@ export function SidebarMenu() {
   // From family-store
   const familyName = useFamilyName();
   const familyMembers = useFamilyMembers();
+
+  // Auth
+  const logout = useLogout();
 
   // Modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -31,6 +34,7 @@ export function SidebarMenu() {
 
   const menuItems = [
     { icon: Users, label: "Family Settings", action: handleOpenSettings },
+    { icon: LogOut, label: "Sign Out", action: logout },
   ];
 
   return (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useDebounce } from "./use-debounce";
 export { useIsMobile } from "./use-is-mobile";

--- a/src/hooks/use-debounce.ts
+++ b/src/hooks/use-debounce.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Debounce a value by a specified delay.
+ * Returns the debounced value that only updates after the delay has passed.
+ *
+ * @param value - The value to debounce
+ * @param delay - The delay in milliseconds
+ * @returns The debounced value
+ *
+ * @example
+ * const searchTerm = useDebounce(inputValue, 500);
+ * // searchTerm only updates 500ms after inputValue stops changing
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,3 +10,15 @@
  * { state: { family: FamilyData | null, _hasHydrated: boolean }, version: number }
  */
 export const FAMILY_STORAGE_KEY = "family-hub-family";
+
+/**
+ * localStorage key for auth token.
+ * Stores the JWT token for authenticated requests.
+ */
+export const AUTH_TOKEN_STORAGE_KEY = "family-hub-auth-token";
+
+/**
+ * localStorage key for mock user credentials.
+ * Used only in mock mode for simulating auth backend.
+ */
+export const MOCK_USERS_STORAGE_KEY = "family-hub-mock-users";

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -1,0 +1,55 @@
+import type { FamilyData, FamilyMember } from "./family";
+
+// ============================================================================
+// Auth Request/Response Types
+// ============================================================================
+
+/**
+ * Request to login with family credentials.
+ */
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+/**
+ * Response from successful login.
+ * Returns JWT token and associated family data.
+ */
+export interface LoginResponse {
+  data: {
+    token: string;
+    family: FamilyData;
+  };
+  message: string;
+}
+
+/**
+ * Request to register a new family with credentials.
+ * Combines family creation with credential setup.
+ */
+export interface RegisterRequest {
+  username: string;
+  password: string;
+  familyName: string;
+  members: Array<Omit<FamilyMember, "id">>;
+}
+
+/**
+ * Response from successful registration.
+ * Returns JWT token and created family data.
+ */
+export interface RegisterResponse {
+  data: {
+    token: string;
+    family: FamilyData;
+  };
+  message: string;
+}
+
+/**
+ * Response from username availability check.
+ */
+export interface UsernameCheckResponse {
+  available: boolean;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./auth";
 export * from "./calendar";
 export * from "./chores";
 export * from "./family";

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,0 +1,59 @@
+import { z } from "zod";
+
+/**
+ * Schema for username validation.
+ * - 3-30 characters
+ * - Lowercase alphanumeric and underscores only
+ * - Automatically trimmed and lowercased
+ */
+export const usernameSchema = z
+  .string()
+  .transform((val) => val.trim().toLowerCase())
+  .pipe(
+    z
+      .string()
+      .min(3, "Username must be at least 3 characters")
+      .max(30, "Username must be 30 characters or less")
+      .regex(
+        /^[a-z0-9_]+$/,
+        "Username can only contain letters, numbers, and underscores",
+      ),
+  );
+
+/**
+ * Schema for password validation.
+ * - Minimum 8 characters
+ * - Maximum 100 characters
+ */
+export const passwordSchema = z
+  .string()
+  .min(8, "Password must be at least 8 characters")
+  .max(100, "Password must be 100 characters or less");
+
+/**
+ * Schema for login form validation.
+ * Uses relaxed password validation (just checks not empty).
+ */
+export const loginFormSchema = z.object({
+  username: usernameSchema,
+  password: z.string().min(1, "Password is required"),
+});
+
+export type LoginFormData = z.infer<typeof loginFormSchema>;
+
+/**
+ * Schema for registration credentials form.
+ * Includes password confirmation with match validation.
+ */
+export const credentialsFormSchema = z
+  .object({
+    username: usernameSchema,
+    password: passwordSchema,
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export type CredentialsFormData = z.infer<typeof credentialsFormSchema>;

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -1,0 +1,82 @@
+import { create } from "zustand";
+import { AUTH_TOKEN_STORAGE_KEY } from "@/lib/constants";
+
+/**
+ * Auth store - handles token hydration state.
+ *
+ * The actual auth operations (login, logout, etc.) are handled by TanStack Query
+ * hooks in src/api/hooks/use-auth.ts. This store only tracks whether we've
+ * completed the initial localStorage check for an existing token.
+ *
+ * @see useLogin, useRegister, useLogout in @/api
+ */
+interface AuthHydrationState {
+  /**
+   * Whether the initial localStorage read has completed.
+   */
+  _hasHydrated: boolean;
+
+  /**
+   * Whether a valid token exists in localStorage.
+   * Updated during hydration and by auth operations.
+   */
+  isAuthenticated: boolean;
+
+  setHasHydrated: (state: boolean) => void;
+  setAuthenticated: (state: boolean) => void;
+}
+
+export const useAuthStore = create<AuthHydrationState>()((set) => ({
+  _hasHydrated: false,
+  isAuthenticated: false,
+  setHasHydrated: (state) => set({ _hasHydrated: state }),
+  setAuthenticated: (state) => set({ isAuthenticated: state }),
+}));
+
+// ============================================================================
+// Hydration Initialization
+// ============================================================================
+
+/**
+ * Check if localStorage has an auth token and mark as hydrated.
+ * This runs immediately on module load.
+ */
+function initializeAuthHydration(): void {
+  // In SSR/test environments, skip hydration
+  if (typeof window === "undefined") {
+    useAuthStore.getState().setHasHydrated(true);
+    return;
+  }
+
+  try {
+    const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    useAuthStore.getState().setAuthenticated(!!token);
+    useAuthStore.getState().setHasHydrated(true);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to check localStorage for auth token:", error);
+    }
+    // Still mark as hydrated to prevent infinite loading
+    useAuthStore.getState().setHasHydrated(true);
+  }
+}
+
+// Run hydration check immediately
+initializeAuthHydration();
+
+// ============================================================================
+// Selectors
+// ============================================================================
+
+/**
+ * Check if auth store has hydrated from localStorage.
+ * Use this to gate app rendering until we know the auth state.
+ */
+export const useAuthHasHydrated = () =>
+  useAuthStore((state) => state._hasHydrated);
+
+/**
+ * Check if user is authenticated (has a token).
+ */
+export const useIsAuthenticated = () =>
+  useAuthStore((state) => state.isAuthenticated);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,5 +1,11 @@
 // App Store
 export { type ModuleType, useAppStore } from "./app-store";
+// Auth Store - Hydration only (auth operations in @/api)
+export {
+  useAuthHasHydrated,
+  useAuthStore,
+  useIsAuthenticated,
+} from "./auth-store";
 // Calendar Store
 export {
   useCalendarActions,

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -6,6 +6,7 @@ import {
   handlers,
   resetMockEvents,
   resetMockFamily,
+  resetMockUsers,
   seedMockEvents,
   seedMockFamily,
 } from "./handlers";
@@ -54,6 +55,7 @@ export function setupMswServer() {
     server.resetHandlers();
     resetMockEvents();
     resetMockFamily();
+    resetMockUsers();
   });
   afterAll(() => server.close());
 }
@@ -65,6 +67,7 @@ export {
   getMockFamily,
   resetMockEvents,
   resetMockFamily,
+  resetMockUsers,
   seedMockEvents,
   seedMockFamily,
 };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -47,8 +47,9 @@ window.scrollTo = vi.fn();
 // =============================================================================
 
 // Import stores directly to reset them (avoid circular deps with test-utils)
-import { FAMILY_STORAGE_KEY } from "@/lib/constants";
+import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
 import { useAppStore } from "@/stores/app-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useFamilyStore } from "@/stores/family-store";
 import { resetTestQueryClient } from "@/test/test-utils";
@@ -84,6 +85,13 @@ function resetAllStores(): void {
     activeModule: "calendar",
     isSidebarOpen: false,
   });
+
+  // Reset auth store
+  useAuthStore.setState({
+    _hasHydrated: false,
+    isAuthenticated: false,
+  });
+  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
 }
 
 // =============================================================================

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -3,7 +3,7 @@ import { type RenderOptions, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactElement, ReactNode } from "react";
 import { type FamilyApiResponse, familyKeys } from "@/api";
-import { FAMILY_STORAGE_KEY } from "@/lib/constants";
+import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
 import type {
   CalendarEvent,
   CalendarViewType,
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/types";
 import type { ModuleType } from "@/stores/app-store";
 import { useAppStore } from "@/stores/app-store";
+import { useAuthStore } from "@/stores/auth-store";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useFamilyStore } from "@/stores/family-store";
 import { resetMockFamily, seedMockFamily } from "./mocks/handlers";
@@ -300,6 +301,30 @@ export function seedAppStore(data: {
 }
 
 /**
+ * Reset the auth store to its initial state.
+ */
+export function resetAuthStore(): void {
+  useAuthStore.setState({
+    _hasHydrated: false,
+    isAuthenticated: false,
+  });
+  localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+}
+
+/**
+ * Seed the auth store with initial state for testing.
+ *
+ * @example
+ * seedAuthStore({ isAuthenticated: true });
+ */
+export function seedAuthStore(data?: { isAuthenticated?: boolean }): void {
+  useAuthStore.setState({
+    _hasHydrated: true,
+    isAuthenticated: data?.isAuthenticated ?? false,
+  });
+}
+
+/**
  * Reset all stores to their initial state.
  * Call this in afterEach to ensure test isolation.
  */
@@ -308,4 +333,5 @@ export function resetAllStores(): void {
   resetFamilyStore();
   resetCalendarStore();
   resetAppStore();
+  resetAuthStore();
 }


### PR DESCRIPTION
## Summary

Adds JWT-based authentication to Family Hub. Each family now has a single set of credentials (username + password) that all family members use to access their family calendar from any device.

### Why
- Enable families to securely access their data from multiple devices
- Prepare for backend integration with real authentication
- Prevent unauthorized access to family data

### What Changed
- **New login screen** - Shown when no auth token exists
- **Extended onboarding** - Added credentials step (username + password)
- **Auth API layer** - Mock handlers + service + TanStack Query hooks
- **Token management** - Stored in localStorage, injected in API requests
- **Logout** - Added to sidebar menu, clears auth state

## Test Fixes

This PR required updates to both unit tests and E2E tests to handle the new authentication flow.

### Unit Test Fixes

**Problem:** 4 tests in `calendar-module.test.tsx` and `event-form.test.tsx` were failing because form submission callbacks were never invoked.

**Root Cause:** The new `auth-store.ts` initializes immediately on module load (`initializeAuthHydration()` at line 65) but was NOT reset in `resetAllStores()` in `src/test/setup.ts`. This caused auth state leakage between tests:
- `beforeEach` clears localStorage
- But `useAuthStore` retains stale state from previous tests
- Inconsistent auth state affects API calls and form submission callbacks

**Solution:**
1. Added `useAuthStore` reset to `resetAllStores()` in `src/test/setup.ts`
2. Added `resetAuthStore()` and `seedAuthStore()` helpers in `src/test/test-utils.tsx`
3. Updated `App.test.tsx` to seed auth store with `{ isAuthenticated: false }` so login screen renders

### E2E Test Fixes

**Problem:** All 16 E2E tests failed because they expected to see onboarding/calendar directly, but now users see a login screen first.

**Root Cause:** The auth PR added a login screen that gates access to the app. E2E tests were not seeding authentication state.

**Solution:**
1. Added `seedAuth()` helper to `e2e/helpers/test-helpers.ts` that seeds a mock JWT token in localStorage
2. Updated all E2E test `beforeEach` hooks to call `seedAuth()` after `clearStorage()`
3. Updated `onboarding.spec.ts` for the new 3-step flow:
   - Step 1: Family Name (was "Step 1 of 2", now "Step 1 of 3")
   - Step 2: Members (was "Step 2 of 2", now "Step 2 of 3")
   - Step 3: Credentials (NEW - "Step 3 of 3")
4. Added explicit wait for onboarding to disappear after registration (using `expect().toBeHidden()` with auto-retry, consistent with PR#34 patterns)

### Patterns Applied (from PR#34)

| Pattern | Where Applied | Why |
|---------|---------------|-----|
| `expect().toBeVisible/Hidden()` with timeout | Onboarding test after registration | Auto-retry handles timing variations |
| State-based waits over `waitForTimeout()` | All E2E tests | More reliable than arbitrary delays |
| Explicit transition waits | After registration completes | Ensures app has transitioned before checking next state |

## Debugging Guide (for future auth-related test issues)

### Unit Test Failures (store state leakage)

**Symptoms:**
- Tests pass individually but fail when run together
- Mock callbacks not being invoked
- Async state appears stale

**Investigation:**
```bash
# Run the failing tests in isolation
npm run test -- --run path/to/failing.test.tsx

# If they pass individually, it's state leakage
# Check if new stores are being reset in setup.ts
```

**Fix pattern:**
```typescript
// In src/test/setup.ts resetAllStores()
useNewStore.setState({
  _hasHydrated: false,
  // ... other initial state
});
localStorage.removeItem(NEW_STORE_KEY);
```

### E2E Test Failures (auth gating)

**Symptoms:**
- Tests can't find expected elements
- Stuck on login/loading screen
- "element not found" for app UI elements

**Investigation:**
```bash
# Check what screen the test is seeing
npx playwright test --project=chromium --debug e2e/failing.spec.ts

# Look at screenshots in test-results/
```

**Fix pattern:**
```typescript
// In test beforeEach, seed auth after clearing storage
await clearStorage(page);
await seedAuth(page);  // Add this line
await page.reload();
```

## Test Plan
- [x] Fresh start shows login screen
- [x] Can complete registration flow with credentials
- [x] Can log in with created credentials
- [x] Auth persists across page refresh
- [x] Logout clears state and shows login
- [x] Invalid login shows error message
- [x] Username availability checked in real-time
- [x] All 381 unit tests pass
- [x] All 16 E2E tests pass (4 browsers × 4 test files)

## Files Changed (Test Infrastructure)

| File | Change |
|------|--------|
| `src/test/setup.ts` | Added auth store reset to `resetAllStores()` |
| `src/test/test-utils.tsx` | Added `resetAuthStore()` and `seedAuthStore()` helpers |
| `src/App.test.tsx` | Seed auth store in beforeEach |
| `e2e/helpers/test-helpers.ts` | Added `seedAuth()` helper |
| `e2e/calendar-crud.spec.ts` | Added `seedAuth()` to beforeEach |
| `e2e/calendar-navigation.spec.ts` | Added `seedAuth()` to beforeEach |
| `e2e/family-management.spec.ts` | Added `seedAuth()` to beforeEach |
| `e2e/onboarding.spec.ts` | Updated for 3-step flow + added `seedAuth()` |

## Notes
- Mobile-chrome tests have pre-existing flakiness (noted in PR#34) - this PR adds extra stability waits but doesn't fully resolve the underlying issue
- The auth store uses immediate initialization on module load - any new store following this pattern needs to be added to `resetAllStores()`