### PR TITLE
fix(api): align frontend error handling with backend ErrorResponse

### DIFF
--- a/src/api/client/api-error.ts
+++ b/src/api/client/api-error.ts
@@ -11,18 +11,23 @@ export const ApiErrorCode = {
 
 export type ApiErrorCode = (typeof ApiErrorCode)[keyof typeof ApiErrorCode];
 
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
 export interface ApiErrorDetails {
   code: ApiErrorCode;
   message: string;
   status: number;
-  details?: Record<string, unknown>;
+  errors?: ValidationError[];
   field?: string;
 }
 
 export class ApiException extends Error {
   readonly code: ApiErrorCode;
   readonly status: number;
-  readonly details?: Record<string, unknown>;
+  readonly errors?: ValidationError[];
   readonly field?: string;
   readonly originalError?: unknown;
 
@@ -31,7 +36,7 @@ export class ApiException extends Error {
     this.name = "ApiException";
     this.code = error.code;
     this.status = error.status;
-    this.details = error.details;
+    this.errors = error.errors;
     this.field = error.field;
     this.originalError = originalError;
   }

--- a/src/api/client/http-client.ts
+++ b/src/api/client/http-client.ts
@@ -1,5 +1,10 @@
 import { AUTH_TOKEN_STORAGE_KEY } from "@/lib/constants";
-import { ApiErrorCode, ApiException, mapStatusToErrorCode } from "./api-error";
+import {
+  ApiErrorCode,
+  ApiException,
+  mapStatusToErrorCode,
+  type ValidationError,
+} from "./api-error";
 
 type QueryParams = Record<string, string | number | boolean | undefined>;
 
@@ -33,7 +38,7 @@ async function parseErrorResponse(response: Response): Promise<{
   code: ApiErrorCode;
   message: string;
   status: number;
-  details?: Record<string, unknown>;
+  errors?: ValidationError[];
   field?: string;
 }> {
   try {
@@ -42,8 +47,8 @@ async function parseErrorResponse(response: Response): Promise<{
       code: mapStatusToErrorCode(response.status),
       message: body.message || response.statusText,
       status: response.status,
-      details: body.details,
-      field: body.field,
+      errors: body.errors,
+      field: body.errors?.[0]?.field,
     };
   } catch {
     return {

--- a/src/api/client/index.ts
+++ b/src/api/client/index.ts
@@ -3,5 +3,6 @@ export {
   type ApiErrorDetails,
   ApiException,
   mapStatusToErrorCode,
+  type ValidationError,
 } from "./api-error";
 export { createHttpClient, httpClient } from "./http-client";


### PR DESCRIPTION
## Why

The backend API returns validation errors in this shape:

```json
{
  "httpStatus": 404,
  "path": "/api/family/123",
  "message": "Family not found",
  "timeStamp": "2025-01-16T10:00:00Z",
  "errors": [{ "field": "name", "message": "must not be blank" }]
}
```

However, the frontend was expecting `body.details` (a generic object) and `body.field` (a top-level field), which don't match the backend's `errors` array structure. This mismatch meant validation errors weren't being properly captured or displayed.

## How

### 1. Added `ValidationError` type (`api-error.ts`)

```typescript
export interface ValidationError {
  field: string;
  message: string;
}
```

### 2. Updated `ApiErrorDetails` and `ApiException`

Changed from generic `details?: Record<string, unknown>` to typed `errors?: ValidationError[]` to match the backend structure.

### 3. Updated `parseErrorResponse` (`http-client.ts`)

- Map `body.errors` directly to the `errors` field
- Extract the first field for convenience: `field: body.errors?.[0]?.field`

## Details

**Files changed:**
- `src/api/client/api-error.ts` - Type definitions
- `src/api/client/http-client.ts` - Error response parsing

**Breaking change:** Code that previously accessed `ApiException.details` should now use `ApiException.errors`. The `field` property remains available as a convenience accessor for the first error's field.

## Testing

- **Type check:** `npm run build` ✓
- **Linter:** `npm run lint` ✓
- **Unit tests:** `npm run test` ✓ (all 325 tests passing)

**Manual verification:** With backend running, validation errors should now populate `ApiException.errors` with the full array and `ApiException.field` with the first error's field name.