### PR TITLE
refactor: unify API response types

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -8,7 +8,33 @@ This document tracks known technical debt, deferred improvements, and future enh
 
 ## High Priority (Address Soon)
 
-### 1. Outdated TODO Comments in use-family.ts
+### 1. Missing Error Handling in Onboarding Registration
+**Source:** Manual Testing (Jan 2026)
+**Files:** `src/components/onboarding/onboarding-flow.tsx`
+**Status:** Bug - causes silent failures
+
+**Problem:**
+The `handleCredentialsNext` function calls `registerFamily.mutate()` with only an `onSuccess` callback - no `onError` handler:
+```typescript
+registerFamily.mutate(
+  { username, password, familyName, members },
+  {
+    onSuccess: () => setAuthenticated(true),
+    // Missing: onError handler!
+  },
+);
+```
+
+When registration fails (e.g., family already exists in localStorage, username taken), the user sees nothing - no error message, no feedback. The button just stops working.
+
+**Fix:**
+- Add `onError` callback to display error message to user
+- Consider adding error state to `OnboardingCredentials` component
+- Show toast or inline error when registration fails
+
+---
+
+### 2. Outdated TODO Comments in use-family.ts
 **Source:** PR #32 Code Review
 **Files:** `src/api/hooks/use-family.ts`
 **Status:** Quick fix

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -108,7 +108,6 @@ export function useLogin(callbacks?: LoginCallbacks) {
       // Update family query cache
       queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
         data: response.data.family,
-        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
       });
 
       // Write family to localStorage for hydration
@@ -146,7 +145,6 @@ export function useRegister(callbacks?: RegisterCallbacks) {
       // Update family query cache
       queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
         data: response.data.family,
-        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
       });
 
       // Write family to localStorage for hydration

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -3,12 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { calendarService } from "@/api/services";
 import { parseLocalDate } from "@/lib/time-utils";
-import type {
-  ApiResponse,
-  CalendarEvent,
-  GetEventsParams,
-  MutationResponse,
-} from "@/lib/types";
+import type { ApiResponse, CalendarEvent, GetEventsParams } from "@/lib/types";
 
 // Query keys factory for type-safe cache management
 export const calendarKeys = {
@@ -54,7 +49,7 @@ export function useCalendarEvent(
 // Mutations
 
 interface CreateEventCallbacks {
-  onSuccess?: (data: MutationResponse<CalendarEvent>) => void;
+  onSuccess?: (data: ApiResponse<CalendarEvent>) => void;
   onError?: (error: ApiException) => void;
 }
 
@@ -74,7 +69,7 @@ export function useCreateEvent(callbacks?: CreateEventCallbacks) {
 }
 
 interface UpdateEventCallbacks {
-  onSuccess?: (data: MutationResponse<CalendarEvent>) => void;
+  onSuccess?: (data: ApiResponse<CalendarEvent>) => void;
   onError?: (error: ApiException) => void;
 }
 

--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -182,7 +182,6 @@ describe("useFamilyData", () => {
     // Seed query cache
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useFamilyData(), {
@@ -205,7 +204,6 @@ describe("useFamilyMembers", () => {
   it("returns members array when present", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useFamilyMembers(), {
@@ -228,7 +226,6 @@ describe("useFamilyName", () => {
   it("returns family name when present", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useFamilyName(), {
@@ -251,7 +248,6 @@ describe("useSetupComplete", () => {
   it("returns true when setup is complete", async () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useSetupComplete(), {
@@ -267,7 +263,6 @@ describe("useSetupComplete", () => {
     const incompleteFamily = { ...testFamily, setupComplete: false };
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: incompleteFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useSetupComplete(), {
@@ -284,7 +279,6 @@ describe("useFamilyMemberById", () => {
   beforeEach(() => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
   });
 
@@ -317,7 +311,6 @@ describe("useFamilyMemberMap", () => {
   it("returns map with O(1) lookups", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useFamilyMemberMap(), {
@@ -332,7 +325,6 @@ describe("useFamilyMemberMap", () => {
   it("returns same map instance for same members (memoized)", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result, rerender } = renderHook(() => useFamilyMemberMap(), {
@@ -360,7 +352,6 @@ describe("useUnusedColors", () => {
   it("filters out used colors", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result } = renderHook(() => useUnusedColors(), {
@@ -375,7 +366,6 @@ describe("useUnusedColors", () => {
   it("returns same array instance for same members (memoized)", () => {
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
 
     const { result, rerender } = renderHook(() => useUnusedColors(), {
@@ -450,7 +440,6 @@ describe("useUpdateFamily", () => {
     seedMockFamily(testFamily);
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
   });
 
@@ -498,7 +487,6 @@ describe("useAddMember", () => {
     seedMockFamily(testFamily);
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
   });
 
@@ -555,7 +543,6 @@ describe("useRemoveMember", () => {
     seedMockFamily(testFamily);
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: testFamily,
-      meta: { timestamp: Date.now(), requestId: "test" },
     });
   });
 

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -97,10 +97,7 @@ export function useFamily(
     initialData: () => {
       const cached = readFamilyFromStorage();
       if (cached) {
-        return {
-          data: cached,
-          meta: { timestamp: Date.now(), requestId: "local-cache" },
-        };
+        return { data: cached };
       }
       return undefined;
     },
@@ -208,7 +205,6 @@ export function useCreateFamily(callbacks?: CreateFamilyCallbacks) {
       // Update query cache
       queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
         data: response.data,
-        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
       });
       // Write-through to localStorage
       writeFamilyToStorage(response.data);
@@ -266,7 +262,6 @@ export function useUpdateFamily(callbacks?: UpdateFamilyCallbacks) {
       // Update with server response
       queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
         data: response.data,
-        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
       });
       // Write-through to localStorage
       writeFamilyToStorage(response.data);
@@ -494,7 +489,6 @@ export function useDeleteFamily(callbacks?: DeleteFamilyCallbacks) {
       // Clear query cache
       queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
         data: null,
-        meta: { timestamp: Date.now(), requestId: crypto.randomUUID() },
       });
       // Clear localStorage
       writeFamilyToStorage(null);
@@ -520,6 +514,5 @@ export function syncFamilyFromStorage(
   const family = readFamilyFromStorage();
   queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
     data: family,
-    meta: { timestamp: Date.now(), requestId: "cross-tab-sync" },
   });
 }

--- a/src/api/mocks/auth.mock.ts
+++ b/src/api/mocks/auth.mock.ts
@@ -244,7 +244,7 @@ export const authMockHandlers = {
     const normalizedUsername = username.toLowerCase().trim();
     const available = !users.some((u) => u.username === normalizedUsername);
 
-    return { available };
+    return { data: { available } };
   },
 
   // ============================================================================

--- a/src/api/mocks/calendar.mock.ts
+++ b/src/api/mocks/calendar.mock.ts
@@ -6,7 +6,6 @@ import type {
   CalendarEvent,
   CreateEventRequest,
   GetEventsParams,
-  MutationResponse,
   UpdateEventRequest,
 } from "@/lib/types";
 import { simulateApiCall } from "./delay";
@@ -159,21 +158,8 @@ function ensureSampleEventsExist(): void {
 // In-memory storage for mock data (initialized from localStorage or generated)
 let mockEvents: CalendarEvent[] = initializeMockEvents();
 
-function createApiResponse<T>(data: T): ApiResponse<T> {
-  return {
-    data,
-    meta: {
-      timestamp: Date.now(),
-      requestId: crypto.randomUUID(),
-    },
-  };
-}
-
-function createMutationResponse<T>(
-  data: T,
-  message: string,
-): MutationResponse<T> {
-  return { data, message };
+function createApiResponse<T>(data: T, message?: string): ApiResponse<T> {
+  return message ? { data, message } : { data };
 }
 
 export const calendarMockHandlers = {
@@ -231,7 +217,7 @@ export const calendarMockHandlers = {
 
   async createEvent(
     request: CreateEventRequest,
-  ): Promise<MutationResponse<CalendarEvent>> {
+  ): Promise<ApiResponse<CalendarEvent>> {
     await simulateApiCall();
 
     const newEvent: CalendarEvent = {
@@ -248,12 +234,12 @@ export const calendarMockHandlers = {
     mockEvents = [...mockEvents, newEvent];
     saveEventsToStorage(mockEvents);
 
-    return createMutationResponse(newEvent, "Event created successfully");
+    return createApiResponse(newEvent, "Event created successfully");
   },
 
   async updateEvent(
     request: UpdateEventRequest,
-  ): Promise<MutationResponse<CalendarEvent>> {
+  ): Promise<ApiResponse<CalendarEvent>> {
     await simulateApiCall();
 
     const index = mockEvents.findIndex((e) => e.id === request.id);
@@ -284,7 +270,7 @@ export const calendarMockHandlers = {
     ];
     saveEventsToStorage(mockEvents);
 
-    return createMutationResponse(updatedEvent, "Event updated successfully");
+    return createApiResponse(updatedEvent, "Event updated successfully");
   },
 
   async deleteEvent(id: string): Promise<void> {

--- a/src/api/mocks/family.mock.ts
+++ b/src/api/mocks/family.mock.ts
@@ -66,13 +66,7 @@ function loadFamilyFromStorage(): FamilyData | null {
 // ============================================================================
 
 function createFamilyResponse(family: FamilyData | null): FamilyApiResponse {
-  return {
-    data: family,
-    meta: {
-      timestamp: Date.now(),
-      requestId: crypto.randomUUID(),
-    },
-  };
+  return { data: family };
 }
 
 function createFamilyMutationResponse(

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -5,7 +5,6 @@ import type {
   CalendarEvent,
   CreateEventRequest,
   GetEventsParams,
-  MutationResponse,
   UpdateEventRequest,
 } from "@/lib/types";
 
@@ -30,11 +29,11 @@ export const calendarService = {
 
   async createEvent(
     request: CreateEventRequest,
-  ): Promise<MutationResponse<CalendarEvent>> {
+  ): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
       return calendarMockHandlers.createEvent(request);
     }
-    return httpClient.post<MutationResponse<CalendarEvent>>(
+    return httpClient.post<ApiResponse<CalendarEvent>>(
       "/calendar/events",
       request,
     );
@@ -42,11 +41,11 @@ export const calendarService = {
 
   async updateEvent(
     request: UpdateEventRequest,
-  ): Promise<MutationResponse<CalendarEvent>> {
+  ): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
       return calendarMockHandlers.updateEvent(request);
     }
-    return httpClient.patch<MutationResponse<CalendarEvent>>(
+    return httpClient.patch<ApiResponse<CalendarEvent>>(
       `/calendar/events/${request.id}`,
       request,
     );

--- a/src/components/onboarding/onboarding-credentials.tsx
+++ b/src/components/onboarding/onboarding-credentials.tsx
@@ -43,10 +43,10 @@ export function OnboardingCredentials({
 
   // Update error state based on username availability
   useEffect(() => {
-    if (usernameCheck && !usernameCheck.available) {
+    if (usernameCheck && !usernameCheck.data.available) {
       setError("username", { message: "Username is already taken" });
     } else if (
-      usernameCheck?.available &&
+      usernameCheck?.data.available &&
       errors.username?.message === "Username is already taken"
     ) {
       clearErrors("username");
@@ -54,7 +54,7 @@ export function OnboardingCredentials({
   }, [usernameCheck, setError, clearErrors, errors.username?.message]);
 
   const onSubmit = (data: CredentialsFormData) => {
-    if (usernameCheck && !usernameCheck.available) {
+    if (usernameCheck && !usernameCheck.data.available) {
       setError("username", { message: "Username is already taken" });
       return;
     }
@@ -106,7 +106,7 @@ export function OnboardingCredentials({
                   <div className="absolute right-3 top-1/2 -translate-y-1/2">
                     {isCheckingUsername ? (
                       <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                    ) : usernameCheck?.available ? (
+                    ) : usernameCheck?.data.available ? (
                       <Check className="h-4 w-4 text-green-500" />
                     ) : (
                       <X className="h-4 w-4 text-destructive" />

--- a/src/lib/types/api-response.ts
+++ b/src/lib/types/api-response.ts
@@ -1,0 +1,8 @@
+/**
+ * Unified API response wrapper.
+ * All API responses use this consistent shape.
+ */
+export interface ApiResponse<T> {
+  data: T;
+  message?: string;
+}

--- a/src/lib/types/auth.ts
+++ b/src/lib/types/auth.ts
@@ -1,3 +1,4 @@
+import type { ApiResponse } from "./api-response";
 import type { FamilyData, FamilyMember } from "./family";
 
 // ============================================================================
@@ -16,13 +17,10 @@ export interface LoginRequest {
  * Response from successful login.
  * Returns JWT token and associated family data.
  */
-export interface LoginResponse {
-  data: {
-    token: string;
-    family: FamilyData;
-  };
-  message: string;
-}
+export type LoginResponse = ApiResponse<{
+  token: string;
+  family: FamilyData;
+}>;
 
 /**
  * Request to register a new family with credentials.
@@ -39,17 +37,12 @@ export interface RegisterRequest {
  * Response from successful registration.
  * Returns JWT token and created family data.
  */
-export interface RegisterResponse {
-  data: {
-    token: string;
-    family: FamilyData;
-  };
-  message: string;
-}
+export type RegisterResponse = ApiResponse<{
+  token: string;
+  family: FamilyData;
+}>;
 
 /**
  * Response from username availability check.
  */
-export interface UsernameCheckResponse {
-  available: boolean;
-}
+export type UsernameCheckResponse = ApiResponse<{ available: boolean }>;

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -44,15 +44,5 @@ export interface GetEventsParams {
   memberId?: string;
 }
 
-export interface ApiResponse<T> {
-  data: T;
-  meta?: {
-    timestamp: number;
-    requestId: string;
-  };
-}
-
-export interface MutationResponse<T> {
-  data: T;
-  message?: string;
-}
+// Re-export unified response type for backwards compatibility
+export type { ApiResponse } from "./api-response";

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -143,30 +143,24 @@ export interface UpdateMemberRequest {
   email?: string;
 }
 
+// Re-export unified response type
+export type { ApiResponse } from "./api-response";
+
+// Type aliases using unified ApiResponse
+import type { ApiResponse } from "./api-response";
+
 /**
  * API response wrapper for family data.
  * Returns null when no family exists (triggers onboarding).
  */
-export interface FamilyApiResponse {
-  data: FamilyData | null;
-  meta?: {
-    timestamp: number;
-    requestId: string;
-  };
-}
+export type FamilyApiResponse = ApiResponse<FamilyData | null>;
 
 /**
  * Mutation response for family operations.
  */
-export interface FamilyMutationResponse {
-  data: FamilyData;
-  message?: string;
-}
+export type FamilyMutationResponse = ApiResponse<FamilyData>;
 
 /**
  * Mutation response for member operations.
  */
-export interface MemberMutationResponse {
-  data: FamilyMember;
-  message?: string;
-}
+export type MemberMutationResponse = ApiResponse<FamilyMember>;

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,3 +1,4 @@
+export * from "./api-response";
 export * from "./auth";
 export * from "./calendar";
 export * from "./chores";

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -10,7 +10,6 @@ import type {
   FamilyMember,
   LoginRequest,
   LoginResponse,
-  MutationResponse,
   RegisterRequest,
   RegisterResponse,
   UpdateEventRequest,
@@ -82,21 +81,8 @@ export function getMockFamily(): FamilyData | null {
   return mockFamily;
 }
 
-function createApiResponse<T>(data: T): ApiResponse<T> {
-  return {
-    data,
-    meta: {
-      timestamp: Date.now(),
-      requestId: crypto.randomUUID(),
-    },
-  };
-}
-
-function createMutationResponse<T>(
-  data: T,
-  message: string,
-): MutationResponse<T> {
-  return { data, message };
+function createApiResponse<T>(data: T, message?: string): ApiResponse<T> {
+  return message ? { data, message } : { data };
 }
 
 // Base URL for API endpoints
@@ -190,7 +176,7 @@ export const handlers = [
     mockEvents = [...mockEvents, newEvent];
 
     return HttpResponse.json(
-      createMutationResponse(newEvent, "Event created successfully"),
+      createApiResponse(newEvent, "Event created successfully"),
     );
   }),
 
@@ -226,7 +212,7 @@ export const handlers = [
     ];
 
     return HttpResponse.json(
-      createMutationResponse(updatedEvent, "Event updated successfully"),
+      createApiResponse(updatedEvent, "Event updated successfully"),
     );
   }),
 
@@ -278,7 +264,7 @@ export const handlers = [
     };
 
     return HttpResponse.json(
-      createMutationResponse(mockFamily, "Family created successfully"),
+      createApiResponse(mockFamily, "Family created successfully"),
     );
   }),
 
@@ -298,7 +284,7 @@ export const handlers = [
     };
 
     return HttpResponse.json(
-      createMutationResponse(mockFamily, "Family updated successfully"),
+      createApiResponse(mockFamily, "Family updated successfully"),
     );
   }),
 
@@ -332,7 +318,7 @@ export const handlers = [
     };
 
     return HttpResponse.json(
-      createMutationResponse(newMember, "Member added successfully"),
+      createApiResponse(newMember, "Member added successfully"),
     );
   }),
 
@@ -378,7 +364,7 @@ export const handlers = [
     };
 
     return HttpResponse.json(
-      createMutationResponse(updatedMember, "Member updated successfully"),
+      createApiResponse(updatedMember, "Member updated successfully"),
     );
   }),
 
@@ -493,7 +479,7 @@ export const handlers = [
     const username = url.searchParams.get("username")?.toLowerCase().trim();
 
     const available = !mockUsers.some((u) => u.username === username);
-    const response: UsernameCheckResponse = { available };
+    const response: UsernameCheckResponse = { data: { available } };
 
     return HttpResponse.json(response);
   }),

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -150,10 +150,7 @@ export function seedFamilyStore(
   };
 
   // Seed TanStack Query cache
-  const response: FamilyApiResponse = {
-    data: familyData,
-    meta: { timestamp: Date.now(), requestId: "test-seed" },
-  };
+  const response: FamilyApiResponse = { data: familyData };
   testQueryClient.setQueryData(familyKeys.family(), response);
 
   // Seed MSW mock (for background refetches that hit the API)
@@ -176,10 +173,7 @@ export function seedFamilyStore(
  */
 export function resetFamilyStore(): void {
   // Clear query cache
-  testQueryClient.setQueryData(familyKeys.family(), {
-    data: null,
-    meta: { timestamp: Date.now(), requestId: "test-reset" },
-  });
+  testQueryClient.setQueryData(familyKeys.family(), { data: null });
 
   // Clear MSW mock
   resetMockFamily();


### PR DESCRIPTION
## Summary

- Consolidate 6+ API response type shapes into a single unified structure
- Remove the unused `meta` field that was being generated but never read
- Simplify mock handlers and test utilities

**Before:** Multiple response shapes with write-only `meta` field
```typescript
ApiResponse<T>        = { data, meta? }
FamilyApiResponse     = { data, meta? }
MutationResponse<T>   = { data, message? }
FamilyMutationResponse = { data, message? }
MemberMutationResponse = { data, message? }
LoginResponse         = { data, message }
UsernameCheckResponse = { available }  // no wrapper
```

**After:** Single unified shape
```typescript
ApiResponse<T> = { data: T; message?: string }
```

## Changes

| Area | Files Changed |
|------|---------------|
| Types | `api-response.ts` (new), `calendar.ts`, `family.ts`, `auth.ts`, `index.ts` |
| Mocks | `calendar.mock.ts`, `family.mock.ts`, `auth.mock.ts` |
| API Hooks | `use-family.ts`, `use-auth.ts`, `use-calendar.ts` |
| Services | `calendar.service.ts` |
| Tests | `test-utils.tsx`, `handlers.ts`, `use-family.test.tsx` |
| Components | `onboarding-credentials.tsx` |

## Test plan

- [x] TypeScript build passes (`npm run build`)
- [x] All 381 unit tests pass (`npm run test`)
- [ ] E2E tests pass (requires browser install)
- [x] Manual verification: Login/register flows, username availability check, family CRUD, calendar CRUD