### PR TITLE
docs: update API response types to unified ApiResponse<T>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,8 +427,7 @@ describe("ComponentWithStore", () => {
 
     // Seed TanStack Query cache for family data
     queryClient.setQueryData(familyKeys.family(), {
-      data: { name: "Test Family", members: testMembers, setupComplete: true },
-      meta: { timestamp: Date.now(), requestId: "test" }
+      data: { name: "Test Family", members: testMembers, setupComplete: true }
     })
   });
 
@@ -446,7 +445,7 @@ describe("ComponentWithStore", () => {
 - `resetCalendarStore()`, `resetAppStore()`, `resetAuthStore()`, `resetAllStores()` - Reset utilities (called globally in setup.ts afterEach)
 
 **Family data in tests:**
-Family data is now in TanStack Query, not Zustand. Seed via `queryClient.setQueryData(familyKeys.family(), { data: familyData, meta: {...} })`.
+Family data is now in TanStack Query, not Zustand. Seed via `queryClient.setQueryData(familyKeys.family(), { data: familyData })`.
 
 **Important:** All Zustand stores (calendar, app, family, auth) are **automatically reset** after each test by `src/test/setup.ts`. This prevents state leakage between tests. Query clients should be created fresh for each test. When adding new stores with immediate initialization (like auth-store), remember to add them to `resetAllStores()`.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -150,12 +150,12 @@ Test Infrastructure:
 
 **Family Endpoints:**
 ```
-GET    /family                  → FamilyApiResponse { data: FamilyData | null }
-POST   /family                  → FamilyMutationResponse { data: FamilyData }
-PATCH  /family                  → FamilyMutationResponse { data: FamilyData }
+GET    /family                  → ApiResponse<FamilyData | null>
+POST   /family                  → ApiResponse<FamilyData>
+PATCH  /family                  → ApiResponse<FamilyData>
 DELETE /family                  → void
-POST   /family/members          → MemberMutationResponse { data: FamilyMember }
-PATCH  /family/members/:id      → MemberMutationResponse { data: FamilyMember }
+POST   /family/members          → ApiResponse<FamilyMember>
+PATCH  /family/members/:id      → ApiResponse<FamilyMember>
 DELETE /family/members/:id      → void
 ```
 
@@ -163,8 +163,8 @@ DELETE /family/members/:id      → void
 ```
 GET    /calendar/events         → ApiResponse<CalendarEvent[]> (params: startDate, endDate, memberId)
 GET    /calendar/events/:id     → ApiResponse<CalendarEvent>
-POST   /calendar/events         → MutationResponse<CalendarEvent>
-PATCH  /calendar/events/:id     → MutationResponse<CalendarEvent>
+POST   /calendar/events         → ApiResponse<CalendarEvent>
+PATCH  /calendar/events/:id     → ApiResponse<CalendarEvent>
 DELETE /calendar/events/:id     → void
 ```
 

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -196,7 +196,7 @@ Types: `src/lib/types/calendar.ts`
 
 **Family** (ready to use):
 ```
-GET    /family                   → FamilyApiResponse { data: FamilyData | null }
+GET    /family                   → ApiResponse<FamilyData | null>
 POST   /family                   body: CreateFamilyRequest
 PATCH  /family                   body: UpdateFamilyRequest
 DELETE /family

--- a/docs/backend/02-API-CONTRACT.md
+++ b/docs/backend/02-API-CONTRACT.md
@@ -48,20 +48,12 @@ Authorization: Bearer <jwt_token>
 ```typescript
 interface ApiResponse<T> {
   data: T;
-  meta?: {
-    timestamp: number;    // Unix timestamp (milliseconds)
-    requestId: string;    // UUID for tracing
-  };
+  message?: string;       // Human-readable success/info message
 }
 ```
 
-### Mutation Response
-```typescript
-interface MutationResponse<T> {
-  data: T;
-  message?: string;       // Human-readable success message
-}
-```
+> **Note:** All endpoints (queries and mutations) use the same `ApiResponse<T>` envelope.
+> The `message` field is optional and used for success confirmations on mutations.
 
 ### Error Response
 ```typescript

--- a/docs/backend/03-ARCHITECTURE.md
+++ b/docs/backend/03-ARCHITECTURE.md
@@ -221,12 +221,12 @@ public class FamilyController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public MutationResponse<FamilyResponse> createFamily(
+    public ApiResponse<FamilyResponse> createFamily(
             @Valid @RequestBody CreateFamilyRequest request,
             @CurrentUser UserPrincipal user) {
         // Validation handled by @Valid + Bean Validation
         FamilyResponse family = familyService.createFamily(user.getId(), request);
-        return MutationResponse.of(family, "Family created successfully");
+        return ApiResponse.of(family, "Family created successfully");
     }
 }
 ```

--- a/docs/backend/04-ROADMAP.md
+++ b/docs/backend/04-ROADMAP.md
@@ -321,12 +321,12 @@ public class FamilyController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public MutationResponse<FamilyResponse> createFamily(
+    public ApiResponse<FamilyResponse> createFamily(
         @Valid @RequestBody CreateFamilyRequest request,
         @CurrentUser UserPrincipal user);
 
     @PatchMapping
-    public MutationResponse<FamilyResponse> updateFamily(
+    public ApiResponse<FamilyResponse> updateFamily(
         @Valid @RequestBody UpdateFamilyRequest request,
         @CurrentUser UserPrincipal user);
 
@@ -341,10 +341,10 @@ public class FamilyMemberController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public MutationResponse<MemberResponse> addMember(...);
+    public ApiResponse<MemberResponse> addMember(...);
 
     @PatchMapping("/{id}")
-    public MutationResponse<MemberResponse> updateMember(...);
+    public ApiResponse<MemberResponse> updateMember(...);
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -489,12 +489,12 @@ public class CalendarController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public MutationResponse<EventResponse> createEvent(
+    public ApiResponse<EventResponse> createEvent(
         @Valid @RequestBody CreateEventRequest request,
         @CurrentUser UserPrincipal user);
 
     @PatchMapping("/{id}")
-    public MutationResponse<EventResponse> updateEvent(
+    public ApiResponse<EventResponse> updateEvent(
         @PathVariable UUID id,
         @Valid @RequestBody UpdateEventRequest request,
         @CurrentUser UserPrincipal user);


### PR DESCRIPTION
## Summary

- Update documentation to reflect PR #37's type unification
- Remove outdated `meta` field references that no longer exist
- Replace old type names with unified `ApiResponse<T>` in API contracts

## Changes

| File | Update |
|------|--------|
| `CLAUDE.md` | Remove `meta` from test seeding examples |
| `docs/ROADMAP.md` | Replace `FamilyApiResponse`, `FamilyMutationResponse`, `MemberMutationResponse`, `MutationResponse<T>` with `ApiResponse<T>` |
| `docs/TECHNICAL-DEBT.md` | Replace `FamilyApiResponse` with `ApiResponse<T>` |
| `docs/backend/02-API-CONTRACT.md` | Consolidate response envelopes into single `ApiResponse<T>` |
| `docs/backend/03-ARCHITECTURE.md` | Replace `MutationResponse` with `ApiResponse` |
| `docs/backend/04-ROADMAP.md` | Replace `MutationResponse` with `ApiResponse` |

## Context

PR #37 unified all API response types:
```typescript
// Before: 6+ different shapes
ApiResponse<T> = { data, meta? }
MutationResponse<T> = { data, message? }
FamilyApiResponse = { data, meta? }
// etc.

// After: Single unified shape
ApiResponse<T> = { data: T; message?: string }
```

The documentation was not updated in that PR.

## Test plan

- [x] Documentation-only changes, no code affected
- [x] Verified no remaining `MutationResponse` references in docs
- [x] Verified no remaining `meta` field references