### PR TITLE
Add CI flakiness remediation utilities and documentation

### DIFF
--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -27,6 +27,9 @@ import {
   screen,
   seedCalendarStore,
   seedFamilyStore,
+  TEST_TIMEOUTS,
+  typeAndWait,
+  waitForMemberSelected,
 } from "@/test/test-utils";
 import { CalendarModule } from "./calendar-module";
 
@@ -203,25 +206,12 @@ describe("CalendarModule", () => {
 
       // Wait for first member button to appear AND be selected (has text-white when selected)
       // This ensures both DOM is ready AND form state has been updated via useEffect
-      const firstMemberButton = await screen.findByRole("button", {
-        name: testMembers[0].name,
-      });
-      await waitFor(
-        () => {
-          expect(firstMemberButton).toHaveClass("text-white");
-        },
-        { timeout: 3000 },
-      );
+      await waitForMemberSelected(testMembers[0].name);
 
-      // Fill in the form
+      // Fill in the form and wait for value to propagate
       const titleInput = screen.getByLabelText(/event name/i);
       await user.clear(titleInput);
-      await user.type(titleInput, "New Test Event");
-
-      // Wait for title to be in the input before submitting
-      await waitFor(() => {
-        expect(titleInput).toHaveValue("New Test Event");
-      });
+      await typeAndWait(user, titleInput, "New Test Event");
 
       // Submit the form (find button within dialog)
       const dialog = screen.getByRole("dialog");
@@ -235,7 +225,7 @@ describe("CalendarModule", () => {
         () => {
           expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         },
-        { timeout: 3000 },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
       );
 
       // Verify event was created in mock storage
@@ -248,7 +238,7 @@ describe("CalendarModule", () => {
         () => {
           expect(screen.getByText("New Test Event")).toBeInTheDocument();
         },
-        { timeout: 3000 },
+        { timeout: TEST_TIMEOUTS.QUERY_REFETCH },
       );
     });
 

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -6,7 +6,10 @@ import {
   renderWithUser,
   screen,
   seedFamilyStore,
+  TEST_TIMEOUTS,
+  typeAndWait,
   waitFor,
+  waitForMemberSelected,
 } from "@/test/test-utils";
 import { EventForm } from "./event-form";
 
@@ -89,24 +92,11 @@ describe("EventForm", () => {
       );
 
       // Wait for member button to be visible AND selected
-      const memberButton = await screen.findByRole("button", {
-        name: testMembers[0].name,
-      });
-      await waitFor(
-        () => {
-          expect(memberButton).toHaveClass("text-white");
-        },
-        { timeout: 3000 },
-      );
+      await waitForMemberSelected(testMembers[0].name);
 
       // Fill title and submit to verify first member is selected
       const titleInput = screen.getByLabelText(/event name/i);
-      await user.type(titleInput, "Test Event");
-
-      // Wait for title to be in the input before submitting
-      await waitFor(() => {
-        expect(titleInput).toHaveValue("Test Event");
-      });
+      await typeAndWait(user, titleInput, "Test Event");
 
       await user.click(screen.getByRole("button", { name: /add event/i }));
 
@@ -118,7 +108,7 @@ describe("EventForm", () => {
             }),
           );
         },
-        { timeout: 3000 },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
       );
     });
   });
@@ -279,24 +269,11 @@ describe("EventForm", () => {
       );
 
       // Wait for member button to be visible AND selected
-      const memberButton = await screen.findByRole("button", {
-        name: testMembers[0].name,
-      });
-      await waitFor(
-        () => {
-          expect(memberButton).toHaveClass("text-white");
-        },
-        { timeout: 3000 },
-      );
+      await waitForMemberSelected(testMembers[0].name);
 
-      // Fill in the title
+      // Fill in the title and wait for value to propagate
       const titleInput = screen.getByLabelText(/event name/i);
-      await user.type(titleInput, "New Team Meeting");
-
-      // Wait for title to be in the input before submitting
-      await waitFor(() => {
-        expect(titleInput).toHaveValue("New Team Meeting");
-      });
+      await typeAndWait(user, titleInput, "New Team Meeting");
 
       // Submit the form
       await user.click(screen.getByRole("button", { name: /add event/i }));
@@ -311,7 +288,7 @@ describe("EventForm", () => {
             }),
           );
         },
-        { timeout: 3000 },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
       );
     });
 
@@ -412,15 +389,7 @@ describe("EventForm", () => {
       );
 
       // Wait for first member button to be visible AND selected
-      const firstMember = await screen.findByRole("button", {
-        name: testMembers[0].name,
-      });
-      await waitFor(
-        () => {
-          expect(firstMember).toHaveClass("text-white");
-        },
-        { timeout: 3000 },
-      );
+      await waitForMemberSelected(testMembers[0].name);
 
       // Click on second member to change selection
       const secondMember = screen.getByRole("button", {
@@ -429,21 +398,11 @@ describe("EventForm", () => {
       await user.click(secondMember);
 
       // Wait for second member to become selected
-      await waitFor(
-        () => {
-          expect(secondMember).toHaveClass("text-white");
-        },
-        { timeout: 3000 },
-      );
+      await waitForMemberSelected(testMembers[1].name);
 
-      // Fill title
+      // Fill title and wait for value to propagate
       const titleInput = screen.getByLabelText(/event name/i);
-      await user.type(titleInput, "Test Event");
-
-      // Wait for title to be in the input before submitting
-      await waitFor(() => {
-        expect(titleInput).toHaveValue("Test Event");
-      });
+      await typeAndWait(user, titleInput, "Test Event");
 
       // Submit form
       await user.click(screen.getByRole("button", { name: /add event/i }));
@@ -456,7 +415,7 @@ describe("EventForm", () => {
             }),
           );
         },
-        { timeout: 3000 },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
       );
     });
 


### PR DESCRIPTION
## Summary

- Add standardized test timeout constants (`TEST_TIMEOUTS`) for consistent timing across all unit tests
- Add form test helper functions (`typeAndWait`, `waitForMemberSelected`) to prevent race conditions
- Document the async form initialization problem and fix patterns in CLAUDE.md
- Consolidate flakiness documentation in TECHNICAL-DEBT.md with cross-references

## Background

CI runs with coverage instrumentation add overhead that exposes race conditions not visible locally. Forms using async TanStack Query hooks (like `useFamilyMembers()`) can be flaky because there's a timing window between initial render and when async data arrives.

## Changes

### New Test Utilities (`src/test/test-utils.tsx`)

**Timeout Constants:**
- `TEST_TIMEOUTS.FORM_STATE` (3s) - Wait for form state propagation
- `TEST_TIMEOUTS.FORM_SUBMIT` (3s) - Wait for form submission
- `TEST_TIMEOUTS.ELEMENT_VISIBLE` (5s) - Wait for element visibility
- `TEST_TIMEOUTS.DIALOG_READY` (10s) - Wait for dialog open/close
- `TEST_TIMEOUTS.QUERY_REFETCH` (5s) - Wait for query refetch

**Helper Functions:**
- `typeAndWait(user, input, value)` - Type and verify value propagation before submit
- `waitForMemberSelected(name)` - Wait for member button to show selected state

### Documentation Updates

**CLAUDE.md:**
- Added "Async Form Testing (CI Flakiness Prevention)" section with:
  - Explanation of the race condition timeline
  - Solution patterns with code examples
  - When to use explicit defaultValues
  - Available helper functions

**TECHNICAL-DEBT.md:**
- Consolidated flakiness documentation with cross-references to CLAUDE.md
- Added key distinction table between E2E and Unit test flakiness
- Updated completed items table

## Test plan

- [x] All existing tests pass locally (`npm run test`)
- [x] All tests pass with coverage (`npm run test:coverage`)
- [x] Lint passes (`npm run lint`)