### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/joe-bor/FamilyHub/security/code-scanning/4](https://github.com/joe-bor/FamilyHub/security/code-scanning/4)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow (either at the top level, applying to all jobs, or within the specific job). The block should grant only the minimal permissions needed. For this CI workflow, which only checks out code, sets up Node, runs tests, and uploads artifacts, read access to repository contents is sufficient; no write permissions appear necessary.

The single best fix without changing functionality is to add a root-level `permissions` block just under the `name: CI` line. This will apply to all jobs (currently just `check`) and constrain the `GITHUB_TOKEN` to `contents: read`. No other scopes (like `pull-requests`, `issues`, or `packages`) are needed based on the shown steps. The only required change is in `.github/workflows/ci.yml` at the top of the file, inserting the block:
```yaml
permissions:
  contents: read
```
with correct indentation so it sits alongside `on:` and `jobs:` at the root level. No imports, methods, or definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
