### PR TITLE
Add family mutation hook tests with optimistic update coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -580,7 +580,7 @@ describe("optimistic updates", () => {
       },
     });
     // Seed query cache with initial data
-    testQueryClient.setQueryData(queryKeys.data(), { data: testData });
+    testQueryClient.setQueryData(familyKeys.family(), { data: testData });
   });
 
   afterEach(() => {
@@ -599,7 +599,7 @@ describe("optimistic updates", () => {
     });
 
     // Cache assertions now work because gcTime: Infinity prevents GC
-    const cached = testQueryClient.getQueryData(queryKeys.data());
+    const cached = testQueryClient.getQueryData(familyKeys.family());
     expect(cached?.data?.name).toBe("New Name");
   });
 });

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -1,6 +1,6 @@
 # Technical Debt & Deferred Improvements
 
-**Last Updated:** January 27, 2026
+**Last Updated:** February 1, 2026
 
 This document tracks known technical debt, deferred improvements, and future enhancements identified during code reviews. Items are prioritized and linked to relevant sprints.
 
@@ -8,26 +8,7 @@ This document tracks known technical debt, deferred improvements, and future enh
 
 ## High Priority (Address Soon)
 
-### 1. Missing Family Mutation Tests
-**Source:** PR #32 Code Review
-**Files:** `src/api/hooks/use-family.test.tsx`
-**Status:** Should add for completeness
-
-**Problem:**
-The test file (372 lines) only tests read operations:
-- ✅ Selectors tested (`useFamilyData`, `useFamilyMembers`, etc.)
-- ✅ Memoization tested (`useFamilyMemberMap`, `useUnusedColors`)
-- ❌ `useCreateFamily` not tested
-- ❌ `useAddMember` not tested
-- ❌ Optimistic updates not tested
-- ❌ Rollback on error not tested
-
-**Suggested Fix:**
-Add mutation tests covering:
-- Successful mutations update query cache
-- Optimistic updates show immediately
-- Rollback restores previous state on error
-- localStorage write-through works
+_No high priority items at this time._
 
 ---
 
@@ -212,6 +193,7 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| Family Mutation Tests (optimistic updates, rollback, useUpdateMember, useDeleteFamily) | - | - | Feb 1, 2026 |
 | Outdated TODO Comments in use-family.ts | - | - | Jan 29, 2026 |
 | CI Flakiness Remediation (test helpers + documentation) | Sprint 7 | #41 | Jan 27, 2026 |
 | Onboarding Registration Error Handling | Sprint 7 | #40 | Jan 26, 2026 |


### PR DESCRIPTION
## Summary

- Add comprehensive tests for family mutation hooks (`useUpdateMember`, `useDeleteFamily`)
- Add tests for optimistic update behavior and rollback on error
- Update tech debt document to mark item as complete
- Document the testing pattern in CLAUDE.md for future reference

## Problem Encountered

When testing TanStack Query mutations that use optimistic updates or rollback behavior, tests were failing because the query cache data was `undefined` when assertions ran.

**Root Cause:** The shared test `QueryClient` uses `gcTime: 0` (garbage collection time), which causes cached query data to be garbage collected immediately after queries become inactive. Since mutation tests seed the cache, trigger a mutation, and then assert on cache state, the data was being garbage collected before the assertions could verify it.

**Symptoms:**
```
AssertionError: expected undefined to be 'Test Family'
AssertionError: Target cannot be null or undefined
```

## Solution

Create dedicated `QueryClient` instances for mutation tests with `gcTime: Infinity`:

```typescript
let testQueryClient: QueryClient;

beforeEach(() => {
  testQueryClient = new QueryClient({
    defaultOptions: {
      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
      mutations: { retry: false },
    },
  });
  testQueryClient.setQueryData(familyKeys.family(), { data: testFamily });
});
```

This prevents garbage collection during the test lifecycle, allowing assertions on cache state to work correctly.

## New Tests Added (11 total)

| Category | Tests |
|----------|-------|
| `useUpdateMember` | 2 (success + localStorage) |
| `useDeleteFamily` | 2 (cache clear + localStorage) |
| Optimistic updates | 3 (updateFamily, addMember, removeMember) |
| Rollback on error | 4 (updateFamily, addMember, removeMember, updateMember) |

## Test Plan

- [x] All 44 tests in `use-family.test.tsx` pass
- [x] Full test suite (412 tests) passes with no regressions
- [x] Linting passes