### PR TITLE
refactor(api): align family updates with BE PUT semantics

### DIFF
--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -616,7 +616,11 @@ describe("useUpdateMember", () => {
       wrapper: createWrapper(),
     });
 
-    result.current.mutate({ id: "member-1", name: "Alice Updated" });
+    result.current.mutate({
+      id: "member-1",
+      name: "Alice Updated",
+      color: "coral",
+    });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -637,7 +641,7 @@ describe("useUpdateMember", () => {
       wrapper: createWrapper(),
     });
 
-    result.current.mutate({ id: "member-1", color: "purple" });
+    result.current.mutate({ id: "member-1", name: "Alice", color: "purple" });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -864,7 +868,7 @@ describe("rollback on error", () => {
   it("useUpdateFamily restores previous state on server error", async () => {
     // Override handler to return error
     server.use(
-      http.patch("http://localhost:3000/family", () => {
+      http.put("http://localhost:3000/family", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );
@@ -947,7 +951,7 @@ describe("rollback on error", () => {
 
   it("useUpdateMember restores original member data on server error", async () => {
     server.use(
-      http.patch("http://localhost:3000/family/members/:id", () => {
+      http.put("http://localhost:3000/family/members/:id", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );
@@ -957,7 +961,11 @@ describe("rollback on error", () => {
       wrapper: createRollbackWrapper(),
     });
 
-    result.current.mutate({ id: "member-1", name: "Should Rollback" });
+    result.current.mutate({
+      id: "member-1",
+      name: "Should Rollback",
+      color: "coral",
+    });
 
     await waitFor(() => {
       expect(result.current.isError).toBe(true);

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -241,7 +241,7 @@ export function useUpdateFamily(callbacks?: UpdateFamilyCallbacks) {
       if (previousData?.data) {
         const optimisticFamily: FamilyData = {
           ...previousData.data,
-          name: request.name ?? previousData.data.name,
+          name: request.name,
         };
         queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
           ...previousData,
@@ -368,8 +368,8 @@ export function useUpdateMember(callbacks?: UpdateMemberCallbacks) {
             m.id === request.id
               ? {
                   ...m,
-                  name: request.name ?? m.name,
-                  color: request.color ?? m.color,
+                  name: request.name,
+                  color: request.color,
                   avatarUrl:
                     request.avatarUrl !== undefined
                       ? request.avatarUrl

--- a/src/api/mocks/family.mock.ts
+++ b/src/api/mocks/family.mock.ts
@@ -152,7 +152,7 @@ export const familyMockHandlers = {
 
     const updatedFamily: FamilyData = {
       ...family,
-      name: request.name ?? family.name,
+      name: request.name,
     };
 
     saveFamilyToStorage(updatedFamily);
@@ -240,7 +240,6 @@ export const familyMockHandlers = {
 
     // Check for color conflict with other members
     if (
-      request.color &&
       family.members.some(
         (m) => m.id !== request.id && m.color === request.color,
       )
@@ -255,8 +254,8 @@ export const familyMockHandlers = {
     const existingMember = family.members[memberIndex];
     const updatedMember: FamilyMember = {
       ...existingMember,
-      name: request.name ?? existingMember.name,
-      color: request.color ?? existingMember.color,
+      name: request.name,
+      color: request.color,
       avatarUrl:
         request.avatarUrl !== undefined
           ? request.avatarUrl

--- a/src/api/services/family.service.ts
+++ b/src/api/services/family.service.ts
@@ -43,7 +43,7 @@ export const familyService = {
     if (USE_MOCK_API) {
       return familyMockHandlers.updateFamily(request);
     }
-    return httpClient.patch<FamilyMutationResponse>("/family", request);
+    return httpClient.put<FamilyMutationResponse>("/family", request);
   },
 
   /**
@@ -65,7 +65,7 @@ export const familyService = {
     if (USE_MOCK_API) {
       return familyMockHandlers.updateMember(request);
     }
-    return httpClient.patch<MemberMutationResponse>(
+    return httpClient.put<MemberMutationResponse>(
       `/family/members/${request.id}`,
       request,
     );

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -101,13 +101,23 @@ export function MemberProfileModal({
     const reader = new FileReader();
     reader.onload = (e) => {
       const base64 = e.target?.result as string;
-      updateMemberMutation.mutate({ id: memberId, avatarUrl: base64 });
+      updateMemberMutation.mutate({
+        id: memberId,
+        name: member.name,
+        color: member.color,
+        avatarUrl: base64,
+      });
     };
     reader.readAsDataURL(file);
   };
 
   const handleRemoveAvatar = () => {
-    updateMemberMutation.mutate({ id: memberId, avatarUrl: undefined });
+    updateMemberMutation.mutate({
+      id: memberId,
+      name: member.name,
+      color: member.color,
+      avatarUrl: undefined,
+    });
   };
 
   const colors = colorMap[member.color];

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -119,7 +119,7 @@ export interface CreateFamilyRequest {
  * Request to update family properties.
  */
 export interface UpdateFamilyRequest {
-  name?: string;
+  name: string;
 }
 
 /**
@@ -137,8 +137,8 @@ export interface AddMemberRequest {
  */
 export interface UpdateMemberRequest {
   id: string;
-  name?: string;
-  color?: FamilyColor;
+  name: string;
+  color: FamilyColor;
   avatarUrl?: string;
   email?: string;
 }

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -268,8 +268,8 @@ export const handlers = [
     );
   }),
 
-  // PATCH /family - Update family
-  http.patch(`${API_BASE}/family`, async ({ request }) => {
+  // PUT /family - Update family
+  http.put(`${API_BASE}/family`, async ({ request }) => {
     if (!mockFamily) {
       return HttpResponse.json(
         { message: "No family exists" },
@@ -280,7 +280,7 @@ export const handlers = [
     const body = (await request.json()) as UpdateFamilyRequest;
     mockFamily = {
       ...mockFamily,
-      name: body.name ?? mockFamily.name,
+      name: body.name,
     };
 
     return HttpResponse.json(
@@ -322,8 +322,8 @@ export const handlers = [
     );
   }),
 
-  // PATCH /family/members/:id - Update member
-  http.patch(`${API_BASE}/family/members/:id`, async ({ params, request }) => {
+  // PUT /family/members/:id - Update member
+  http.put(`${API_BASE}/family/members/:id`, async ({ params, request }) => {
     if (!mockFamily) {
       return HttpResponse.json(
         { message: "No family exists" },
@@ -345,8 +345,8 @@ export const handlers = [
     const existingMember = mockFamily.members[index];
     const updatedMember: FamilyMember = {
       ...existingMember,
-      name: body.name ?? existingMember.name,
-      color: body.color ?? existingMember.color,
+      name: body.name,
+      color: body.color,
       avatarUrl:
         body.avatarUrl !== undefined
           ? body.avatarUrl


### PR DESCRIPTION
## Summary

- Change family update HTTP methods from PATCH to PUT to match BE Spring Boot contract
- Make `name` required on `UpdateFamilyRequest` and `name`/`color` required on `UpdateMemberRequest` (`avatarUrl` and `email` remain optional/nullable)
- Update all callers (MemberProfileModal avatar upload/removal) to send full required fields
- Simplify optimistic update logic by removing fallback merge (`??`) for required fields
- Update dev mocks, MSW test handlers, and mutation tests for PUT behavior

## Note

`setupComplete` on `FamilyData` is read by `useSetupComplete()` to gate onboarding. It's set during family creation and never modified. If the BE stops returning this field, users would be trapped in onboarding. Needs BE confirmation — out of scope for this PR.

## Test plan

- [x] `npm run build` — TypeScript catches any callers still sending partial data
- [x] `npm run test` — all 412 unit tests pass with updated mutate calls and MSW handlers
- [x] `npm run lint` — no lint regressions