### PR TITLE
fix(settings): send complete member payload on PUT updates

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -110,7 +110,36 @@ Lighthouse detected unused JavaScript in the bundle.
 
 ---
 
-### 6. PWA Optimizations
+### 6. MemberProfileModal Component Tests
+**Source:** PR #67 Review
+**Files:** `src/components/settings/member-profile-modal.tsx`
+**Status:** Testing gap
+
+**Problem:**
+No component-level tests verify that each mutation call site (form submit, avatar upload, avatar remove) sends the correct fields. Hook-level tests cover optimistic updates, but a modal refactor could regress the payload completeness fix from PR #67.
+
+**Suggested Fix:**
+- Add tests asserting each mutation call includes all required fields (`name`, `color`, `email`, `avatarUrl`)
+- Verify avatar removal sends `avatarUrl: null` (not `undefined`)
+- Verify form submit preserves `avatarUrl` from current member data
+
+---
+
+### 7. Silent Avatar Upload Validation Failures
+**Source:** PR #67 Review (pre-existing)
+**Files:** `src/components/settings/member-profile-modal.tsx` (lines 92-99)
+**Status:** UX gap
+
+**Problem:**
+`handleAvatarUpload` silently returns on invalid file type or file size (>500KB) with no user feedback. Users get no indication why their upload didn't work.
+
+**Suggested Fix:**
+- Show a toast or inline error for invalid file type ("Please select an image file")
+- Show a toast or inline error for oversized files ("Image must be under 500KB")
+
+---
+
+### 8. PWA Optimizations
 **Source:** Lighthouse CI (PR #60)
 **Files:** `vite.config.ts` (vite-plugin-pwa)
 **Status:** Deferred - PWA basics in place

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -372,7 +372,7 @@ export function useUpdateMember(callbacks?: UpdateMemberCallbacks) {
                   color: request.color,
                   avatarUrl:
                     request.avatarUrl !== undefined
-                      ? request.avatarUrl
+                      ? (request.avatarUrl ?? undefined)
                       : m.avatarUrl,
                   email: request.email !== undefined ? request.email : m.email,
                 }

--- a/src/api/mocks/family.mock.ts
+++ b/src/api/mocks/family.mock.ts
@@ -258,7 +258,7 @@ export const familyMockHandlers = {
       color: request.color,
       avatarUrl:
         request.avatarUrl !== undefined
-          ? request.avatarUrl
+          ? (request.avatarUrl ?? undefined)
           : existingMember.avatarUrl,
       email: request.email !== undefined ? request.email : existingMember.email,
     };

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -80,6 +80,7 @@ export function MemberProfileModal({
       name: data.name,
       color: data.color,
       email: data.email || undefined,
+      avatarUrl: member.avatarUrl ?? undefined,
     });
     onOpenChange(false);
   };
@@ -105,6 +106,7 @@ export function MemberProfileModal({
         id: memberId,
         name: member.name,
         color: member.color,
+        email: member.email ?? undefined,
         avatarUrl: base64,
       });
     };
@@ -116,7 +118,8 @@ export function MemberProfileModal({
       id: memberId,
       name: member.name,
       color: member.color,
-      avatarUrl: undefined,
+      email: member.email ?? undefined,
+      avatarUrl: null,
     });
   };
 

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -139,7 +139,7 @@ export interface UpdateMemberRequest {
   id: string;
   name: string;
   color: FamilyColor;
-  avatarUrl?: string;
+  avatarUrl?: string | null;
   email?: string;
 }
 


### PR DESCRIPTION
## Summary

- **Form submit** now includes `avatarUrl` to preserve the current avatar when saving name/color/email changes
- **Avatar upload** now includes `email` to preserve the current email when uploading an avatar
- **Avatar remove** now includes `email` and uses `null` (instead of `undefined`) for `avatarUrl` to explicitly signal deletion

All three mutation call sites in `MemberProfileModal` were sending incomplete payloads, causing data loss under PUT replacement semantics.

## Test plan

- [x] Existing family hook tests pass (44/44)
- [x] Lint passes
- [x] Manual: edit member name/email → verify avatar is preserved
- [x] Manual: upload avatar → verify email is preserved
- [x] Manual: remove avatar → verify email is preserved