### PR TITLE
Remove dead createFamily code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ src/
 │   │   └── api-error.ts       # ApiException, ApiErrorCode
 │   ├── hooks/                 # TanStack Query hooks
 │   │   ├── use-calendar.ts    # useCalendarEvents, useCreateEvent, etc.
-│   │   └── use-family.ts      # useFamily, useFamilyMembers, useCreateFamily, etc.
+│   │   └── use-family.ts      # useFamily, useFamilyMembers, useUpdateFamily, etc.
 │   ├── services/              # API service functions
 │   │   ├── calendar.service.ts # CRUD operations for calendar
 │   │   └── family.service.ts  # CRUD operations for family/members
@@ -142,7 +142,7 @@ Uses a hybrid approach: **TanStack Query** for server state (API data) and **Zus
 - `useSetupComplete()` - Check if onboarding is complete
 - `useFamilyMemberMap()` - O(1) member lookups
 - `useUnusedColors()` - Colors not assigned to any member
-- Mutations: `useCreateFamily`, `useUpdateFamily`, `useAddMember`, `useUpdateMember`, `useRemoveMember`, `useDeleteFamily`
+- Mutations: `useUpdateFamily`, `useAddMember`, `useUpdateMember`, `useRemoveMember`, `useDeleteFamily`
 
 **calendar-store.ts:**
 - `currentDate`, `calendarView`, `filter` - Calendar UI preferences
@@ -208,7 +208,6 @@ familyKeys.family()       // ["family", "data"]
 - `useSetupComplete()`, `useFamilyLoading()` - Status selectors
 - `useFamilyMemberById(id)`, `useFamilyMemberMap()` - Member lookups
 - `useUnusedColors()` - Available colors for new members
-- `useCreateFamily(callbacks?)` - Create family (onboarding)
 - `useUpdateFamily(callbacks?)` - Update family name
 - `useAddMember(callbacks?)`, `useUpdateMember(callbacks?)`, `useRemoveMember(callbacks?)` - Member CRUD
 - `useDeleteFamily(callbacks?)` - Reset family

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -23,7 +23,6 @@ export {
   readFamilyFromStorage,
   syncFamilyFromStorage,
   useAddMember,
-  useCreateFamily,
   useDeleteFamily,
   useFamily,
   useFamilyData,

--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -20,7 +20,6 @@ import {
   familyKeys,
   readFamilyFromStorage,
   useAddMember,
-  useCreateFamily,
   useDeleteFamily,
   useFamily,
   useFamilyData,
@@ -387,55 +386,6 @@ describe("useUnusedColors", () => {
 // ============================================================================
 // Mutation Hook Tests
 // ============================================================================
-
-describe("useCreateFamily", () => {
-  it("creates a family and updates query cache on success", async () => {
-    const onSuccess = vi.fn();
-    const { result } = renderHook(() => useCreateFamily({ onSuccess }), {
-      wrapper: createWrapper(),
-    });
-
-    result.current.mutate({
-      name: "New Family",
-      members: [{ name: "Alice", color: "coral" }],
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    // Check callback was called with response data
-    expect(onSuccess).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          name: "New Family",
-          setupComplete: true,
-        }),
-      }),
-    );
-  });
-
-  it("writes family to localStorage on success", async () => {
-    const { result } = renderHook(() => useCreateFamily(), {
-      wrapper: createWrapper(),
-    });
-
-    result.current.mutate({
-      name: "Persisted Family",
-      members: [{ name: "Bob", color: "teal" }],
-    });
-
-    await waitFor(() => {
-      expect(result.current.isSuccess).toBe(true);
-    });
-
-    // Check localStorage was updated
-    const stored = localStorage.getItem(FAMILY_STORAGE_KEY);
-    expect(stored).not.toBeNull();
-    const parsed = JSON.parse(stored!);
-    expect(parsed.state.family.name).toBe("Persisted Family");
-  });
-});
 
 describe("useUpdateFamily", () => {
   beforeEach(() => {

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -6,7 +6,6 @@ import { familyService } from "@/api/services";
 import { FAMILY_STORAGE_KEY } from "@/lib/constants";
 import type {
   AddMemberRequest,
-  CreateFamilyRequest,
   FamilyApiResponse,
   FamilyColor,
   FamilyData,
@@ -186,35 +185,6 @@ export function useUnusedColors(): FamilyColor[] {
 // ============================================================================
 // Mutations
 // ============================================================================
-
-interface CreateFamilyCallbacks {
-  onSuccess?: (data: FamilyMutationResponse) => void;
-  onError?: (error: ApiException) => void;
-}
-
-/**
- * Create a new family (during onboarding).
- */
-export function useCreateFamily(callbacks?: CreateFamilyCallbacks) {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (request: CreateFamilyRequest) =>
-      familyService.createFamily(request),
-    onSuccess: (response) => {
-      // Update query cache
-      queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
-        data: response.data,
-      });
-      // Write-through to localStorage
-      writeFamilyToStorage(response.data);
-      callbacks?.onSuccess?.(response);
-    },
-    onError: (error: ApiException) => {
-      callbacks?.onError?.(error);
-    },
-  });
-}
 
 interface UpdateFamilyCallbacks {
   onSuccess?: (data: FamilyMutationResponse) => void;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,7 +22,6 @@ export {
   useCalendarEvents,
   useCheckUsername,
   useCreateEvent,
-  useCreateFamily,
   useDeleteEvent,
   useDeleteFamily,
   useFamily,

--- a/src/api/mocks/family.mock.ts
+++ b/src/api/mocks/family.mock.ts
@@ -2,7 +2,6 @@ import { ApiErrorCode, ApiException } from "@/api/client";
 import { FAMILY_STORAGE_KEY } from "@/lib/constants";
 import type {
   AddMemberRequest,
-  CreateFamilyRequest,
   FamilyApiResponse,
   FamilyData,
   FamilyMember,
@@ -96,41 +95,6 @@ export const familyMockHandlers = {
     await simulateApiCall({ delayMin: 100, delayMax: 300 });
     const family = loadFamilyFromStorage();
     return createFamilyResponse(family);
-  },
-
-  /**
-   * Create a new family (during onboarding).
-   * Generates IDs for family and all members.
-   */
-  async createFamily(
-    request: CreateFamilyRequest,
-  ): Promise<FamilyMutationResponse> {
-    await simulateApiCall();
-
-    // Check if family already exists
-    const existing = loadFamilyFromStorage();
-    if (existing) {
-      throw new ApiException({
-        code: ApiErrorCode.CONFLICT,
-        message: "Family already exists. Use updateFamily to modify.",
-        status: 409,
-      });
-    }
-
-    // Create family with generated IDs
-    const family: FamilyData = {
-      id: crypto.randomUUID(),
-      name: request.name,
-      members: request.members.map((m) => ({
-        ...m,
-        id: crypto.randomUUID(),
-      })),
-      createdAt: new Date().toISOString(),
-      setupComplete: true, // Mark setup as complete when family is created via API
-    };
-
-    saveFamilyToStorage(family);
-    return createFamilyMutationResponse(family, "Family created successfully");
   },
 
   /**

--- a/src/api/services/family.service.ts
+++ b/src/api/services/family.service.ts
@@ -2,7 +2,6 @@ import { httpClient } from "@/api/client";
 import { familyMockHandlers, USE_MOCK_API } from "@/api/mocks";
 import type {
   AddMemberRequest,
-  CreateFamilyRequest,
   FamilyApiResponse,
   FamilyMutationResponse,
   MemberMutationResponse,
@@ -20,18 +19,6 @@ export const familyService = {
       return familyMockHandlers.getFamily();
     }
     return httpClient.get<FamilyApiResponse>("/family");
-  },
-
-  /**
-   * Create a new family (during onboarding).
-   */
-  async createFamily(
-    request: CreateFamilyRequest,
-  ): Promise<FamilyMutationResponse> {
-    if (USE_MOCK_API) {
-      return familyMockHandlers.createFamily(request);
-    }
-    return httpClient.post<FamilyMutationResponse>("/family", request);
   },
 
   /**

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -108,14 +108,6 @@ export const familyColors: FamilyColor[] = [
 // ============================================================================
 
 /**
- * Request to create a new family (during onboarding).
- */
-export interface CreateFamilyRequest {
-  name: string;
-  members: Array<Omit<FamilyMember, "id">>;
-}
-
-/**
  * Request to update family properties.
  */
 export interface UpdateFamilyRequest {

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -5,7 +5,6 @@ import type {
   ApiResponse,
   CalendarEvent,
   CreateEventRequest,
-  CreateFamilyRequest,
   FamilyData,
   FamilyMember,
   LoginRequest,
@@ -240,32 +239,6 @@ export const handlers = [
   // GET /family - Get family data
   http.get(`${API_BASE}/family`, () => {
     return HttpResponse.json(createApiResponse(mockFamily));
-  }),
-
-  // POST /family - Create new family
-  http.post(`${API_BASE}/family`, async ({ request }) => {
-    if (mockFamily) {
-      return HttpResponse.json(
-        { message: "Family already exists" },
-        { status: 409 },
-      );
-    }
-
-    const body = (await request.json()) as CreateFamilyRequest;
-    mockFamily = {
-      id: `family-${Date.now()}`,
-      name: body.name,
-      members: body.members.map((m) => ({
-        ...m,
-        id: `member-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-      })),
-      createdAt: new Date().toISOString(),
-      setupComplete: true,
-    };
-
-    return HttpResponse.json(
-      createApiResponse(mockFamily, "Family created successfully"),
-    );
   }),
 
   // PUT /family - Update family


### PR DESCRIPTION
## Summary

- Remove `CreateFamilyRequest` type, `createFamily` service method, `useCreateFamily` hook, mock handler, MSW test handler, tests, and barrel exports
- Family creation only happens through registration (`POST /api/auth/register` via `useRegister`); the standalone `POST /api/family` endpoint was dropped from the backend

## Test plan

- [x] `npm run build` passes (no broken imports or type errors)
- [x] `npm run test` passes (all 410 tests pass)
- [x] `npm run lint` passes (via pre-commit hooks)
- [x] Grep confirms zero remaining references to `CreateFamilyRequest` or `useCreateFamily`