### PR TITLE
refactor: remove setupComplete from FamilyData

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ const createEvent = useCreateEvent({ onSuccess: () => console.log("Created!") })
 
 // Server state from TanStack Query (family)
 const members = useFamilyMembers()  // Derived selector from useFamily()
-const setupComplete = useSetupComplete()  // Check if onboarding done
+const setupComplete = useSetupComplete()  // Derived: true when family has members
 ```
 
 ### API Layer
@@ -457,7 +457,7 @@ describe("ComponentWithStore", () => {
 
     // Seed TanStack Query cache for family data
     queryClient.setQueryData(familyKeys.family(), {
-      data: { name: "Test Family", members: testMembers, setupComplete: true }
+      data: { name: "Test Family", members: testMembers }
     })
   });
 

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -11,7 +11,6 @@ interface FamilyStorageData {
       name: string;
       members: FamilyMember[];
       createdAt: string;
-      setupComplete: boolean;
     } | null;
     _hasHydrated: boolean;
   };
@@ -59,7 +58,6 @@ export async function seedFamily(
         name: options.name,
         members: options.members,
         createdAt: new Date().toISOString(),
-        setupComplete: true,
       },
       _hasHydrated: true,
     },

--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -55,7 +55,6 @@ const testFamily: FamilyData = {
   name: "Test Family",
   members: [testMember1, testMember2],
   createdAt: "2025-01-01T00:00:00.000Z",
-  setupComplete: true,
 };
 
 // ============================================================================
@@ -261,8 +260,8 @@ describe("useSetupComplete", () => {
     });
   });
 
-  it("returns false when family exists but setup is not complete", async () => {
-    const incompleteFamily = { ...testFamily, setupComplete: false };
+  it("returns false when family exists but has no members", async () => {
+    const incompleteFamily = { ...testFamily, members: [] };
     queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
       data: incompleteFamily,
     });

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -136,12 +136,13 @@ export function useFamilyName(): string {
 
 /**
  * Check if setup is complete.
+ * Derived: true when family data exists and has at least one member.
  */
 export function useSetupComplete(): boolean {
   const { data, isFetched } = useFamily();
-  // Only return true if we've fetched and have a family with setupComplete
   if (!isFetched) return false;
-  return data?.data?.setupComplete ?? false;
+  const family = data?.data;
+  return family != null && family.members.length > 0;
 }
 
 /**

--- a/src/api/mocks/auth.mock.ts
+++ b/src/api/mocks/auth.mock.ts
@@ -209,7 +209,6 @@ export const authMockHandlers = {
         id: crypto.randomUUID(),
       })),
       createdAt: new Date().toISOString(),
-      setupComplete: true,
     };
 
     // Create user credentials

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -60,7 +60,6 @@ describe("CalendarModule", () => {
     seedFamilyStore({
       name: "Test Family",
       members: testMembers,
-      setupComplete: true,
     });
     // Initialize filter with all members selected
     seedCalendarStore({

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -22,7 +22,6 @@ describe("EventForm", () => {
     seedFamilyStore({
       name: "Test Family",
       members: testMembers,
-      setupComplete: true,
     });
   });
 

--- a/src/components/onboarding/onboarding-flow.test.tsx
+++ b/src/components/onboarding/onboarding-flow.test.tsx
@@ -306,7 +306,6 @@ describe("OnboardingFlow", () => {
         expect(mockFamily?.name).toBe("The Test Family");
         expect(mockFamily?.members).toHaveLength(1);
         expect(mockFamily?.members[0].name).toBe("Parent One");
-        expect(mockFamily?.members).toHaveLength(1);
       });
     });
 

--- a/src/components/onboarding/onboarding-flow.test.tsx
+++ b/src/components/onboarding/onboarding-flow.test.tsx
@@ -306,7 +306,7 @@ describe("OnboardingFlow", () => {
         expect(mockFamily?.name).toBe("The Test Family");
         expect(mockFamily?.members).toHaveLength(1);
         expect(mockFamily?.members[0].name).toBe("Parent One");
-        expect(mockFamily?.setupComplete).toBe(true);
+        expect(mockFamily?.members).toHaveLength(1);
       });
     });
 
@@ -525,7 +525,6 @@ describe("OnboardingFlow", () => {
                 name: "Test Family",
                 members: [],
                 createdAt: new Date().toISOString(),
-                setupComplete: true,
               },
             },
             message: "Registration successful",
@@ -578,7 +577,6 @@ describe("OnboardingFlow", () => {
                 name: "Test Family",
                 members: [],
                 createdAt: new Date().toISOString(),
-                setupComplete: true,
               },
             },
             message: "Registration successful",

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -29,7 +29,6 @@ export interface FamilyData {
   name: string;
   members: FamilyMember[];
   createdAt: string;
-  setupComplete: boolean;
 }
 
 /**

--- a/src/lib/validations/family.test.ts
+++ b/src/lib/validations/family.test.ts
@@ -427,7 +427,6 @@ describe("family validations", () => {
         { id: "member-2", name: "Jane", color: "teal" as const },
       ],
       createdAt: "2025-12-23T10:30:00Z",
-      setupComplete: true,
     };
 
     describe("id field", () => {
@@ -541,32 +540,6 @@ describe("family validations", () => {
       });
     });
 
-    describe("setupComplete field", () => {
-      it("accepts true", () => {
-        const result = familyDataSchema.safeParse({
-          ...validFamilyData,
-          setupComplete: true,
-        });
-        expect(result.success).toBe(true);
-      });
-
-      it("accepts false", () => {
-        const result = familyDataSchema.safeParse({
-          ...validFamilyData,
-          setupComplete: false,
-        });
-        expect(result.success).toBe(true);
-      });
-
-      it("rejects non-boolean", () => {
-        const result = familyDataSchema.safeParse({
-          ...validFamilyData,
-          setupComplete: "true",
-        });
-        expect(result.success).toBe(false);
-      });
-    });
-
     describe("complete validation", () => {
       it("validates complete valid family data", () => {
         const result = familyDataSchema.safeParse(validFamilyData);
@@ -575,7 +548,6 @@ describe("family validations", () => {
           expect(result.data.id).toBe("family-1");
           expect(result.data.name).toBe("Smith Family");
           expect(result.data.members).toHaveLength(2);
-          expect(result.data.setupComplete).toBe(true);
         }
       });
 
@@ -595,7 +567,6 @@ describe("family validations", () => {
       name: "Smith Family",
       members: [{ id: "member-1", name: "John", color: "coral" }],
       createdAt: "2025-12-23T10:30:00Z",
-      setupComplete: true,
     };
 
     let consoleWarnSpy: ReturnType<typeof vi.spyOn>;

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -146,7 +146,6 @@ export const familyDataSchema = z.object({
   name: z.string().min(1).max(50),
   members: z.array(familyMemberSchema),
   createdAt: z.string().datetime({ offset: true }).or(z.string().min(1)),
-  setupComplete: z.boolean(),
 });
 
 export type ValidatedFamilyData = z.infer<typeof familyDataSchema>;

--- a/src/test/fixtures/family.ts
+++ b/src/test/fixtures/family.ts
@@ -22,7 +22,6 @@ export const testFamily: FamilyData = {
   name: "Test Family",
   members: testMembers,
   createdAt: "2025-01-01T00:00:00.000Z",
-  setupComplete: true,
 };
 
 /**
@@ -33,7 +32,6 @@ export const incompleteFamily: FamilyData = {
   name: "Incomplete Family",
   members: [],
   createdAt: "2025-01-01T00:00:00.000Z",
-  setupComplete: false,
 };
 
 /**
@@ -61,7 +59,6 @@ export function createTestFamily(
     id: `family-${Date.now()}`,
     name: "Test Family",
     createdAt: new Date().toISOString(),
-    setupComplete: true,
     ...overrides,
     members,
   };

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -425,7 +425,6 @@ export const handlers = [
         id: `member-${Date.now()}-${Math.random().toString(36).slice(2)}`,
       })),
       createdAt: new Date().toISOString(),
-      setupComplete: true,
     };
 
     // Create user

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -168,7 +168,6 @@ export { customRender as render, renderWithUser, createTestQueryClient };
  * seedFamilyStore({
  *   name: "Test Family",
  *   members: [{ id: "1", name: "John", color: "coral" }],
- *   setupComplete: true,
  * });
  */
 export function seedFamilyStore(
@@ -180,7 +179,6 @@ export function seedFamilyStore(
     name: data.name ?? "Test Family",
     members: data.members,
     createdAt: data.createdAt ?? new Date().toISOString(),
-    setupComplete: data.setupComplete !== false, // Default to true
   };
 
   // Seed TanStack Query cache


### PR DESCRIPTION
## Summary

- Replace explicit `setupComplete: boolean` field on `FamilyData` with derived logic in `useSetupComplete()` — returns true when family data exists and has at least one member
- Remove the field from the TypeScript interface, Zod validation schema, mock handlers, test fixtures, E2E helpers, and all test files
- No behavioral change: the BE never returned this field, and a family with members already implies setup is complete

## Test plan

- [x] `npm run build` — type-check passes (no references to removed field)
- [x] `npm run lint` — no new lint errors
- [x] `npm run test` — all 407 unit/integration tests pass
- [x] `npm run test:e2e` — E2E tests pass (CI)