### PR TITLE
fix(docs): update README version from v0.2.0 to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Why I chose what I chose:
 
 ## Current Status
 
-**v0.2.0** — Calendar is feature-complete with mock API. Ready for backend integration.
+**v0.3.0** — Calendar is feature-complete with mock API. Ready for backend integration.
 
 | Module   | Status           |
 | -------- | ---------------- |


### PR DESCRIPTION
## Summary
- README showed `v0.2.0` but `package.json` is at `0.3.0` — fixes the drift

## Test plan
- [x] Confirm README line 55 now shows `v0.3.0`