### PR TITLE
feat: deploy guards, version display, and release-please auto-update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ src/
 │   ├── shared/                # App-wide components
 │   │   ├── app-header.tsx     # Top bar (family name, date, weather, settings)
 │   │   ├── navigation-tabs.tsx # Left sidebar module tabs
-│   │   └── sidebar-menu.tsx   # Settings slide-out menu
+│   │   └── sidebar-menu.tsx   # Settings slide-out menu (includes version footer)
 │   │
 │   ├── calendar/
 │   │   ├── calendar-module.tsx # Module orchestrator (wires API hooks to views)
@@ -297,6 +297,15 @@ GitHub Actions runs lint, tests, E2E tests, build, and **Lighthouse CI** on all 
 - HTML reports archived as GitHub artifacts (90 days)
 - Run locally: `npm run lighthouse`
 
+**Deployment** via `deploy.sh` with pre-deploy safety guards (ordered fastest-to-slowest):
+1. Clean working tree check
+2. Must be on `main` branch
+3. Must be synced with `origin/main`
+4. Tagged release check (warning + interactive prompt if untagged)
+5. Lint (`npm run lint`)
+6. Tests (`npm test -- --run`)
+7. Build → rsync to server → HTTP health check
+
 ### Versioning & Releases
 
 **Automated via [release-please](https://github.com/googleapis/release-please)** — triggered on push to `main`.
@@ -315,9 +324,11 @@ GitHub Actions runs lint, tests, E2E tests, build, and **Lighthouse CI** on all 
 
 **Important:** Use **regular merge commits** (not squash) so release-please sees individual `feat:`/`fix:` commits. If squashing, ensure the squash commit message uses conventional format.
 
+**Version display:** The app version from `package.json` is injected at build time via Vite's `define` as `__APP_VERSION__` (declared in `src/vite-env.d.ts`). Displayed in the sidebar footer. Vitest config defines it separately as `"0.0.0-test"`.
+
 **Config files:**
 - `.github/workflows/release.yml` — The GitHub Action
-- `release-please-config.json` — CHANGELOG sections, versioning rules
+- `release-please-config.json` — CHANGELOG sections, versioning rules, extra-files (auto-updates `README.md` version)
 - `.release-please-manifest.json` — Tracks current version
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Why I chose what I chose:
 
 ## Current Status
 
-**v0.3.0** — Calendar is feature-complete with mock API. Ready for backend integration.
+**v0.3.0** — Calendar is feature-complete with mock API. Ready for backend integration. <!-- x-release-please-version -->
 
 | Module   | Status           |
 | -------- | ---------------- |

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,25 +3,67 @@
 set -e
 
 # === CONFIGURATION ===
-# Replace with your SSH login (same as: ssh username@ip)
 SERVER="root@joe-bor.me"
 REMOTE_PATH="/var/www/familyhub"
+URL="https://familyhub.joe-bor.me"
+VERSION=$(node -p "require('./package.json').version")
 
-# === DEPLOY ===
-echo "Building..."
+# === PRE-DEPLOY CHECKS (ordered fastest → slowest) ===
+
+# 1. Clean working tree?
+if [ -n "$(git status --porcelain)" ]; then
+  echo "✗ Working tree is dirty. Commit or stash changes first."
+  exit 1
+fi
+
+# 2. On main branch?
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "main" ]; then
+  echo "✗ Must deploy from main branch (currently on '$BRANCH')."
+  exit 1
+fi
+
+# 3. Synced with remote?
+git fetch origin main --quiet
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "✗ Local main is not in sync with origin/main. Pull or push first."
+  exit 1
+fi
+
+# 4. Tagged release? (warning only)
+if ! git tag -l "v$VERSION" | grep -q .; then
+  echo "⚠ No git tag found for v$VERSION."
+  read -r -p "Deploy untagged version? [y/N] " response
+  if [[ ! "$response" =~ ^[Yy]$ ]]; then
+    echo "Deploy cancelled."
+    exit 0
+  fi
+fi
+
+# 5. Lint
+echo "Running lint..."
+npm run lint
+
+# 6. Tests
+echo "Running tests..."
+npm test -- --run
+
+# === BUILD & DEPLOY ===
+echo "Building v$VERSION..."
 npm run build
 
 echo "Deploying to $SERVER..."
 rsync -avz --delete dist/ "$SERVER:$REMOTE_PATH/"
 
 echo "Verifying deployment..."
-sleep 2  # Give nginx a moment
+sleep 2
 
-URL="https://familyhub.joe-bor.me"
 STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
 
 if [ "$STATUS" = "200" ]; then
-  echo "✓ Deploy successful! Site is live at $URL"
+  echo "✓ Deploy successful! v$VERSION is live at $URL"
 else
   echo "✗ Warning: Site returned HTTP $STATUS"
   exit 1

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "node",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
+      "extra-files": [{ "type": "generic", "path": "README.md" }],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -123,6 +123,11 @@ export function SidebarMenu() {
             })}
           </div>
         </nav>
+
+        {/* Version */}
+        <div className="border-t border-border px-6 py-4">
+          <p className="text-xs text-muted-foreground">v{__APP_VERSION__}</p>
+        </div>
       </aside>
 
       {/* Family Settings Modal */}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,11 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
+
+const { version } = JSON.parse(readFileSync("package.json", "utf-8"));
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -82,6 +85,9 @@ export default defineConfig({
       brotliSize: true,
     }),
   ],
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     "import.meta.env.VITE_API_BASE_URL": JSON.stringify(
       "http://localhost:3000/api",
     ),
+    __APP_VERSION__: JSON.stringify("0.0.0-test"),
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- Configure release-please to auto-update the README version line on each release via `extra-files` with generic type annotation
- Rewrite `deploy.sh` with pre-deploy safety guards: clean git check, main branch check, remote sync check, tagged release warning, lint, and tests — ordered fastest-to-slowest for fast failure
- Display app version (`v0.3.0`) in the sidebar footer, injected at build time via Vite `define` with proper `JSON.stringify` wrapping

## Test plan
- [x] `npm test -- --run` — 407 tests pass (vitest `define` for `__APP_VERSION__` works)
- [x] `npm run build` — builds successfully
- [x] `npm run dev` → open sidebar → confirm version appears at bottom
- [x] Test deploy guards locally (dirty tree, wrong branch, untagged version)
- [ ] After next release-please PR, verify README version auto-updates