### PR TITLE
fix(release): remove release-type override so config-file is respected

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          release-type: node
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Remove `release-type: node` from the workflow action inputs — it overrides `config-file` entirely, causing `extra-files` (README auto-update) to be silently ignored
- The `release-type` is already defined in `release-please-config.json`, so this is redundant

Ref: https://github.com/googleapis/release-please-action/issues/975

## Test plan
- [x] After merge, close current release PR #78 and let release-please regenerate — README.md should appear in the diff