### PR TITLE
Change calendar event update from PATCH to PUT

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -65,7 +65,8 @@
       "!!dist",
       "!!node_modules",
       "!!.husky",
-      "!!coverage"
+      "!!coverage",
+      "!!test-results"
     ]
   }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -164,7 +164,7 @@ DELETE /family/members/:id      → void
 GET    /calendar/events         → ApiResponse<CalendarEvent[]> (params: startDate, endDate, memberId)
 GET    /calendar/events/:id     → ApiResponse<CalendarEvent>
 POST   /calendar/events         → ApiResponse<CalendarEvent>
-PATCH  /calendar/events/:id     → ApiResponse<CalendarEvent>
+PUT    /calendar/events/:id     → ApiResponse<CalendarEvent>
 DELETE /calendar/events/:id     → void
 ```
 

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -191,7 +191,7 @@ See `.env.example` for environment variable documentation.
 GET    /calendar/events          params: startDate, endDate, memberId
 GET    /calendar/events/:id
 POST   /calendar/events          body: CreateEventRequest
-PATCH  /calendar/events/:id      body: UpdateEventRequest
+PUT    /calendar/events/:id      body: UpdateEventRequest
 DELETE /calendar/events/:id
 ```
 Types: `src/lib/types/calendar.ts`

--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -60,6 +60,13 @@ test.describe("Calendar Event CRUD", () => {
     // VIEW EVENT DETAILS
     // ============================================
 
+    // Switch to Day view to avoid overlapping event cards in Weekly view
+    // (mock events like "Tutoring" at 3:30 PM can overlap the newly created event)
+    await page
+      .getByTestId("view-switcher")
+      .getByRole("button", { name: "Day" })
+      .click();
+
     // Click on the event card to open detail modal
     const eventCard = page
       .getByRole("button", { name: /Team Meeting/ })
@@ -69,9 +76,9 @@ test.describe("Calendar Event CRUD", () => {
     // Wait for dialog to fully open and get dialog locator
     const dialog = await waitForDialogReady(page);
 
-    // Verify event title in modal
+    // Verify event title in modal (scoped to dialog)
     await expect(
-      page.getByRole("heading", { name: "Team Meeting" }),
+      dialog.getByRole("heading", { name: "Team Meeting" }),
     ).toBeVisible();
 
     // Verify member is shown (scope to dialog to avoid matching filter pills)
@@ -118,9 +125,9 @@ test.describe("Calendar Event CRUD", () => {
     await safeClick(updatedCard);
 
     // Wait for dialog to fully open
-    await waitForDialogReady(page);
+    const detailDialog = await waitForDialogReady(page);
     await expect(
-      page.getByRole("heading", { name: "Updated Meeting" }),
+      detailDialog.getByRole("heading", { name: "Updated Meeting" }),
     ).toBeVisible();
 
     // Click Delete button

--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -4,6 +4,7 @@ import {
   createTestMember,
   safeClick,
   seedAuth,
+  seedEmptyCalendar,
   seedFamily,
   waitForCalendarReady,
   waitForDialogReady,
@@ -23,6 +24,9 @@ test.describe("Calendar Event CRUD", () => {
       name: "Test Family",
       members: [createTestMember("Alice", "coral")],
     });
+
+    // Prevent random mock events from overlapping with test-created events
+    await seedEmptyCalendar(page);
 
     // Navigate and wait for app
     await page.reload();
@@ -59,13 +63,6 @@ test.describe("Calendar Event CRUD", () => {
     // ============================================
     // VIEW EVENT DETAILS
     // ============================================
-
-    // Switch to Day view to avoid overlapping event cards in Weekly view
-    // (mock events like "Tutoring" at 3:30 PM can overlap the newly created event)
-    await page
-      .getByTestId("view-switcher")
-      .getByRole("button", { name: "Day" })
-      .click();
 
     // Click on the event card to open detail modal
     const eventCard = page

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -162,8 +162,8 @@ export async function waitForDialogReady(page: Page): Promise<Locator> {
   // Use expect with auto-retry for better CI stability
   await expect(dialog).toBeVisible({ timeout: 10000 });
 
-  // Ensure Radix has finished mounting by checking data-state
-  await page.waitForSelector('[data-state="open"]', { state: "attached" });
+  // Ensure Radix has finished mounting — scoped to the dialog, not page-wide
+  await expect(dialog).toHaveAttribute("data-state", "open", { timeout: 5000 });
 
   return dialog;
 }

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -70,6 +70,31 @@ export async function seedFamily(
 }
 
 /**
+ * Seed calendar events storage to prevent random mock event generation.
+ * Uses a single far-past event as a sentinel — satisfies the mock's
+ * "has stored events" check without appearing in the current week.
+ * Must be called after page.goto() but before reload/navigation.
+ */
+export async function seedEmptyCalendar(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const sentinel = [
+      {
+        id: "seed-sentinel",
+        title: "_",
+        date: "2000-01-01T00:00:00.000Z",
+        startTime: "12:00 AM",
+        endTime: "1:00 AM",
+        memberId: "_",
+      },
+    ];
+    localStorage.setItem(
+      "family-hub-calendar-events",
+      JSON.stringify(sentinel),
+    );
+  });
+}
+
+/**
  * Wait for app hydration (Zustand rehydrates from localStorage)
  * The app shows "Loading..." while hydrating
  */

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -99,9 +99,7 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
                 ? {
                     ...event,
                     ...updatedEvent,
-                    date: updatedEvent.date
-                      ? parseLocalDate(updatedEvent.date) // Parse as local date, not UTC
-                      : event.date,
+                    date: parseLocalDate(updatedEvent.date),
                   }
                 : event,
             ),

--- a/src/api/mocks/calendar.mock.ts
+++ b/src/api/mocks/calendar.mock.ts
@@ -251,16 +251,15 @@ export const calendarMockHandlers = {
       });
     }
 
-    const existingEvent = mockEvents[index];
     const updatedEvent: CalendarEvent = {
-      ...existingEvent,
-      title: request.title ?? existingEvent.title,
-      startTime: request.startTime ?? existingEvent.startTime,
-      endTime: request.endTime ?? existingEvent.endTime,
-      date: request.date ? parseLocalDate(request.date) : existingEvent.date, // Parse as local date, not UTC
-      memberId: request.memberId ?? existingEvent.memberId,
-      isAllDay: request.isAllDay ?? existingEvent.isAllDay,
-      location: request.location ?? existingEvent.location,
+      id: request.id,
+      title: request.title,
+      startTime: request.startTime,
+      endTime: request.endTime,
+      date: parseLocalDate(request.date),
+      memberId: request.memberId,
+      isAllDay: request.isAllDay ?? mockEvents[index].isAllDay,
+      location: request.location ?? mockEvents[index].location,
     };
 
     mockEvents = [

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -45,7 +45,7 @@ export const calendarService = {
     if (USE_MOCK_API) {
       return calendarMockHandlers.updateEvent(request);
     }
-    return httpClient.patch<ApiResponse<CalendarEvent>>(
+    return httpClient.put<ApiResponse<CalendarEvent>>(
       `/calendar/events/${request.id}`,
       request,
     );

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -29,11 +29,11 @@ export interface CreateEventRequest {
 
 export interface UpdateEventRequest {
   id: string;
-  title?: string;
-  startTime?: string;
-  endTime?: string;
-  date?: string;
-  memberId?: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  date: string;
+  memberId: string;
   isAllDay?: boolean;
   location?: string;
 }

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -179,8 +179,8 @@ export const handlers = [
     );
   }),
 
-  // PATCH /calendar/events/:id - Update event
-  http.patch(`${API_BASE}/calendar/events/:id`, async ({ params, request }) => {
+  // PUT /calendar/events/:id - Update event (full replacement)
+  http.put(`${API_BASE}/calendar/events/:id`, async ({ params, request }) => {
     const { id } = params;
     const body = (await request.json()) as Omit<UpdateEventRequest, "id">;
 
@@ -192,16 +192,15 @@ export const handlers = [
       );
     }
 
-    const existingEvent = mockEvents[index];
     const updatedEvent: CalendarEvent = {
-      ...existingEvent,
-      title: body.title ?? existingEvent.title,
-      startTime: body.startTime ?? existingEvent.startTime,
-      endTime: body.endTime ?? existingEvent.endTime,
-      date: body.date ? parseLocalDate(body.date) : existingEvent.date,
-      memberId: body.memberId ?? existingEvent.memberId,
-      isAllDay: body.isAllDay ?? existingEvent.isAllDay,
-      location: body.location ?? existingEvent.location,
+      id: id as string,
+      title: body.title,
+      startTime: body.startTime,
+      endTime: body.endTime,
+      date: parseLocalDate(body.date),
+      memberId: body.memberId,
+      isAllDay: body.isAllDay ?? mockEvents[index].isAllDay,
+      location: body.location ?? mockEvents[index].location,
     };
 
     mockEvents = [


### PR DESCRIPTION
## Summary

- Changed calendar event update endpoint from `PATCH` to `PUT` to match backend API contract change
- Made all fields (except `isAllDay` and `location`) required on `UpdateEventRequest` — no partial updates
- Updated mock handlers (both app mocks and MSW test mocks) to use full replacement semantics
- Simplified optimistic update logic since `date` is now always present
- Fixed E2E calendar CRUD test flakiness across all viewports (desktop + mobile)
- Excluded `test-results/` from Biome linting

## E2E flakiness fixes

### Fix 1: Dialog scoping

**Problem:** `waitForDialogReady()` matched any element with `data-state="open"` — not scoped to the dialog. Tooltips or other Radix primitives could satisfy the check before the actual dialog opened.

**Fix:** Scoped `data-state="open"` check to the dialog element using `expect()` auto-retry, and scoped heading/member assertions to the `dialog` locator.

### Fix 2: Mock event overlap (latest commit)

**Problem:** `generateSampleEvents()` places random mock events on the current week. The test's "Team Meeting" (smart-defaulted to ~3:15 PM) overlapped with mock events like "Tutoring" (3:30 PM) in the weekly column. `safeClick` with `force: true` dispatched at coordinates that landed on the wrong card.

A previous fix switched to Day view to avoid overlap, but that **broke mobile-chrome** — the "Day" button label is inside `<span className="hidden sm:inline">` and has no accessible name on viewports < 640px, causing a 20s timeout.

**Fix:** Added `seedEmptyCalendar()` E2E helper that seeds `family-hub-calendar-events` in localStorage with a single far-past sentinel event (Jan 1, 2000). This satisfies the mock's `if (stored && stored.length > 0)` check, preventing `generateSampleEvents()` from running. The test's event becomes the only visible card — no overlap on any view, any viewport. Removed the Day view switch entirely.

## Files changed

| File | Change |
|------|--------|
| `src/lib/types/calendar.ts` | `UpdateEventRequest` fields now required |
| `src/api/services/calendar.service.ts` | `PATCH` → `PUT` |
| `src/api/hooks/use-calendar.ts` | Simplified optimistic update |
| `src/api/mocks/calendar.mock.ts` | Mock handler uses `PUT` + full replacement |
| `src/test/mocks/handlers.ts` | MSW test handler uses `PUT` |
| `docs/API-CONTRACT.md` | Updated API docs for PUT semantics |
| `e2e/helpers/test-helpers.ts` | Added `seedEmptyCalendar()` helper |
| `e2e/calendar-crud.spec.ts` | Use `seedEmptyCalendar`, remove Day view switch |
| `biome.jsonc` | Exclude `test-results/` |

## Test plan

- [x] `npm run build` — TypeScript confirms no call site sends partial data
- [x] `npm run test` — All unit/integration tests pass
- [x] `npm run test:e2e --project=chromium` — Calendar CRUD passes
- [x] `npm run test:e2e --project=mobile-chrome` — Calendar CRUD passes (the key regression)
- [x] `npm run lint` — Clean
- [x] CI pipeline passes (lint, tests, E2E, build, Lighthouse)