### PR TITLE
fix(api): fix FE-BE wiring issues

### DIFF
--- a/src/api/client/api-error.test.ts
+++ b/src/api/client/api-error.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { ApiErrorCode, mapStatusToErrorCode } from "./api-error";
+
+describe("mapStatusToErrorCode", () => {
+  it("maps 400 to VALIDATION_ERROR", () => {
+    expect(mapStatusToErrorCode(400)).toBe(ApiErrorCode.VALIDATION_ERROR);
+  });
+
+  it("maps 401 to UNAUTHORIZED", () => {
+    expect(mapStatusToErrorCode(401)).toBe(ApiErrorCode.UNAUTHORIZED);
+  });
+
+  it("maps 403 to FORBIDDEN", () => {
+    expect(mapStatusToErrorCode(403)).toBe(ApiErrorCode.FORBIDDEN);
+  });
+
+  it("maps 404 to NOT_FOUND", () => {
+    expect(mapStatusToErrorCode(404)).toBe(ApiErrorCode.NOT_FOUND);
+  });
+
+  it("maps 409 to CONFLICT", () => {
+    expect(mapStatusToErrorCode(409)).toBe(ApiErrorCode.CONFLICT);
+  });
+
+  it("maps 422 to VALIDATION_ERROR", () => {
+    expect(mapStatusToErrorCode(422)).toBe(ApiErrorCode.VALIDATION_ERROR);
+  });
+
+  it("maps 5xx to SERVER_ERROR", () => {
+    expect(mapStatusToErrorCode(500)).toBe(ApiErrorCode.SERVER_ERROR);
+    expect(mapStatusToErrorCode(502)).toBe(ApiErrorCode.SERVER_ERROR);
+    expect(mapStatusToErrorCode(503)).toBe(ApiErrorCode.SERVER_ERROR);
+  });
+
+  it("maps unknown 4xx to NETWORK_ERROR", () => {
+    expect(mapStatusToErrorCode(418)).toBe(ApiErrorCode.NETWORK_ERROR);
+  });
+});

--- a/src/api/client/api-error.ts
+++ b/src/api/client/api-error.ts
@@ -48,6 +48,8 @@ export class ApiException extends Error {
 
 export function mapStatusToErrorCode(status: number): ApiErrorCode {
   switch (status) {
+    case 400:
+      return ApiErrorCode.VALIDATION_ERROR;
     case 401:
       return ApiErrorCode.UNAUTHORIZED;
     case 403:

--- a/src/api/client/http-client.test.ts
+++ b/src/api/client/http-client.test.ts
@@ -1,0 +1,57 @@
+import { HttpResponse, http } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { server } from "@/test/mocks/server";
+import { createHttpClient } from "./http-client";
+
+// MSW server setup
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+afterEach(() => server.resetHandlers());
+
+describe("createHttpClient URL resolution", () => {
+  it("preserves base URL path when endpoint has leading slash", async () => {
+    // Handler at /api/family — if the /api prefix is dropped, this won't match
+    server.use(
+      http.get("http://localhost:9999/api/family", () => {
+        return HttpResponse.json({ data: "ok" });
+      }),
+    );
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:9999/api",
+    });
+
+    const result = await client.get<{ data: string }>("/family");
+    expect(result.data).toBe("ok");
+  });
+
+  it("works with endpoint without leading slash", async () => {
+    server.use(
+      http.get("http://localhost:9999/api/calendar/events", () => {
+        return HttpResponse.json({ data: [] });
+      }),
+    );
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:9999/api",
+    });
+
+    const result = await client.get<{ data: unknown[] }>("calendar/events");
+    expect(result.data).toEqual([]);
+  });
+
+  it("works when base URL already has trailing slash", async () => {
+    server.use(
+      http.get("http://localhost:9999/api/family", () => {
+        return HttpResponse.json({ data: "ok" });
+      }),
+    );
+
+    const client = createHttpClient({
+      baseUrl: "http://localhost:9999/api/",
+    });
+
+    const result = await client.get<{ data: string }>("/family");
+    expect(result.data).toBe("ok");
+  });
+});

--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -16,6 +16,7 @@ import { FAMILY_STORAGE_KEY } from "@/lib/constants";
 import type { FamilyApiResponse, FamilyData, FamilyMember } from "@/lib/types";
 import { resetMockFamily, seedMockFamily } from "@/test/mocks/handlers";
 import { server } from "@/test/mocks/server";
+import { seedAuthStore } from "@/test/test-utils";
 import {
   familyKeys,
   readFamilyFromStorage,
@@ -258,6 +259,18 @@ describe("useSetupComplete", () => {
     await waitFor(() => {
       expect(result.current).toBe(true);
     });
+  });
+
+  it("returns false and does not fire query when unauthenticated", () => {
+    seedAuthStore({ isAuthenticated: false });
+    seedMockFamily(testFamily);
+
+    const { result } = renderHook(() => useSetupComplete(), {
+      wrapper: createWrapper(),
+    });
+
+    // Query should be disabled — no network request, returns false
+    expect(result.current).toBe(false);
   });
 
   it("returns false when family exists but has no members", async () => {
@@ -817,7 +830,7 @@ describe("rollback on error", () => {
   it("useUpdateFamily restores previous state on server error", async () => {
     // Override handler to return error
     server.use(
-      http.put("http://localhost:3000/family", () => {
+      http.put("http://localhost:3000/api/family", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );
@@ -843,7 +856,7 @@ describe("rollback on error", () => {
 
   it("useAddMember removes optimistic member on server error", async () => {
     server.use(
-      http.post("http://localhost:3000/family/members", () => {
+      http.post("http://localhost:3000/api/family/members", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );
@@ -872,7 +885,7 @@ describe("rollback on error", () => {
 
   it("useRemoveMember restores member on server error", async () => {
     server.use(
-      http.delete("http://localhost:3000/family/members/:id", () => {
+      http.delete("http://localhost:3000/api/family/members/:id", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );
@@ -900,7 +913,7 @@ describe("rollback on error", () => {
 
   it("useUpdateMember restores original member data on server error", async () => {
     server.use(
-      http.put("http://localhost:3000/family/members/:id", () => {
+      http.put("http://localhost:3000/api/family/members/:id", () => {
         return HttpResponse.json({ message: "Server error" }, { status: 500 });
       }),
     );

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -138,6 +138,12 @@ export function useFamilyName(): string {
 /**
  * Check if setup is complete.
  * Derived: true when family data exists and has at least one member.
+ *
+ * Auth guard: Unlike other derived selectors (useFamilyName, useFamilyMembers, etc.)
+ * which are only rendered inside authenticated routes, this hook is called at the
+ * top-level routing layer (App.tsx) before the auth guard. Without the `enabled`
+ * check, useFamily() would fire GET /family on every page load — returning 401
+ * for unauthenticated users and triggering an infinite reload loop.
  */
 export function useSetupComplete(): boolean {
   const isAuthenticated = useIsAuthenticated();

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -16,6 +16,7 @@ import type {
   UpdateMemberRequest,
 } from "@/lib/types";
 import { familyColors } from "@/lib/types";
+import { useIsAuthenticated } from "@/stores";
 
 // ============================================================================
 // Query Keys Factory
@@ -139,7 +140,8 @@ export function useFamilyName(): string {
  * Derived: true when family data exists and has at least one member.
  */
 export function useSetupComplete(): boolean {
-  const { data, isFetched } = useFamily();
+  const isAuthenticated = useIsAuthenticated();
+  const { data, isFetched } = useFamily({ enabled: isAuthenticated });
   if (!isFetched) return false;
   const family = data?.data;
   return family != null && family.members.length > 0;

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -84,10 +84,8 @@ function createApiResponse<T>(data: T, message?: string): ApiResponse<T> {
   return message ? { data, message } : { data };
 }
 
-// Base URL for API endpoints
-// Note: Service endpoints start with "/" which makes them absolute paths from the origin
-// So /calendar/events with baseUrl http://localhost:3000/api becomes http://localhost:3000/calendar/events
-export const API_BASE = "http://localhost:3000";
+// Base URL for API endpoints — must match vitest.config.ts VITE_API_BASE_URL
+export const API_BASE = "http://localhost:3000/api";
 
 /**
  * MSW request handlers for calendar API endpoints.
@@ -108,7 +106,7 @@ export const API_BASE = "http://localhost:3000";
  * Override handlers for error scenarios:
  * ```typescript
  * server.use(
- *   http.get("http://localhost:3000/calendar/events", () => {
+ *   http.get("http://localhost:3000/api/calendar/events", () => {
  *     return HttpResponse.json({ message: "Server error" }, { status: 500 });
  *   })
  * );


### PR DESCRIPTION
## Summary

- **URL path resolution**: Normalize base URL and strip leading `/` from endpoints so `new URL()` resolves paths correctly (previously `/api` prefix was dropped)
- **HTTP 400 mapping**: Map HTTP 400 to `VALIDATION_ERROR` (Spring Boot's default for `@Valid` failures) instead of falling through to `NETWORK_ERROR`
- **Infinite reload loop**: Guard `useSetupComplete()` with auth check so the family query doesn't fire before login; only reload on session expiry (token existed), not first-visit 401s

## Test plan

- [x] All 419 tests pass (`npm run test -- --run`)
- [x] Lint clean (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Manual: set `VITE_USE_MOCK_API=false`, start BE + FE, confirm no reload loop and login screen appears
- [x] Manual: verify API calls hit `/api/...` paths
- [x] Manual: verify mock mode still works with `VITE_USE_MOCK_API=true`