### PR TITLE
fix(calendar): edit event mutation not firing with real backend

### DIFF
--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -141,6 +141,9 @@ export function CalendarModule() {
     onSuccess: () => {
       closeEditModal();
     },
+    onError: (error) => {
+      console.error("Failed to update event:", error.message);
+    },
   });
 
   // Client-side filtering based on filter state
@@ -170,10 +173,11 @@ export function CalendarModule() {
   };
 
   const handleUpdateEvent = (formData: EventFormData) => {
-    if (!editingEvent) return;
+    const currentEditingEvent = useCalendarStore.getState().editingEvent;
+    if (!currentEditingEvent) return;
 
     const request: UpdateEventRequest = {
-      id: editingEvent.id,
+      id: currentEditingEvent.id,
       title: formData.title,
       startTime: format24hTo12h(formData.startTime),
       endTime: format24hTo12h(formData.endTime),


### PR DESCRIPTION
## Summary

- Fix stale closure in `handleUpdateEvent` that prevented the update mutation from firing when React Compiler memoized a `null` `editingEvent` value
- Read `editingEvent` from Zustand store at call time via `getState()` instead of relying on the render closure
- Add `onError` callback to the update mutation so failures aren't silently swallowed

## Root cause

With React Compiler enabled, `handleUpdateEvent` captured `editingEvent` from the render closure. The compiler's automatic memoization could preserve a stale `null` reference, causing the `if (!editingEvent) return` guard to silently exit before `updateEvent.mutate()` was ever called. Adding events was unaffected because `handleAddEvent` has no store-dependent guard.

## Test plan

- [x] `npm run build` — type-check passes
- [x] `npm run test -- --run` — all 419 tests pass
- [x] `npm run lint` — clean
- [ ] Manual: with `VITE_USE_MOCK_API=false`, edit an event and confirm PUT request fires
- [ ] Manual: with `VITE_USE_MOCK_API=true`, edit still works in mock mode