### PR TITLE
fix(calendar): edit event fails when backend returns null location

### DIFF
--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -141,6 +141,9 @@ export function CalendarModule() {
     onSuccess: () => {
       closeEditModal();
     },
+    onError: (error) => {
+      console.error("Failed to update event:", error.message);
+    },
   });
 
   // Client-side filtering based on filter state
@@ -170,10 +173,11 @@ export function CalendarModule() {
   };
 
   const handleUpdateEvent = (formData: EventFormData) => {
-    if (!editingEvent) return;
+    const currentEditingEvent = useCalendarStore.getState().editingEvent;
+    if (!currentEditingEvent) return;
 
     const request: UpdateEventRequest = {
-      id: editingEvent.id,
+      id: currentEditingEvent.id,
       title: formData.title,
       startTime: format24hTo12h(formData.startTime),
       endTime: format24hTo12h(formData.endTime),

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -36,7 +36,7 @@ function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
     startTime: format12hTo24h(event.startTime),
     endTime: format12hTo24h(event.endTime),
     memberId: event.memberId,
-    location: event.location,
+    location: event.location ?? undefined,
     isAllDay: event.isAllDay,
   };
 }


### PR DESCRIPTION
## Summary

- Fix silent edit form validation failure caused by backend returning `location: null` — Zod's `z.string().optional()` rejects `null`, only accepts `string | undefined`
- Read `editingEvent` from store via `getState()` at call time instead of relying on render-time closure value
- Add `onError` callback to update mutation for visibility

## Root cause

`eventToFormData()` passed `null` location straight into react-hook-form defaults. On submit, Zod validation rejected `null` silently (no error callback on `handleSubmit`). The fix is `location: event.location ?? undefined`.

PR #84 was a misdiagnosis (stale closure theory) — closed with explanation.

## Test plan

- [x] `npm run build` — type-check passes
- [x] `npm run test -- --run` — all 419 tests pass
- [x] `npm run lint` — clean
- [x] No debug `console.log` statements remain