### PR TITLE
fix(api): enforce true PUT semantics in mock handlers

### DIFF
--- a/src/api/hooks/use-calendar-put.test.tsx
+++ b/src/api/hooks/use-calendar-put.test.tsx
@@ -83,29 +83,8 @@ describe("PUT full-replacement semantics", () => {
       data: [original],
     } satisfies ApiResponse<CalendarEvent[]>);
 
-    // Capture the PUT request body
+    // Intercept the PUT request to capture the body and respond
     let capturedBody: UpdateEventRequest | null = null;
-    server.use(
-      http.put(
-        `${API_BASE}/calendar/events/:id`,
-        async ({ request, params }) => {
-          const body = await request.json();
-          capturedBody = {
-            id: params.id as string,
-            ...body,
-          } as UpdateEventRequest;
-
-          // Let the default handler process it
-          return undefined as unknown as Response;
-        },
-      ),
-    );
-
-    // Remove the passthrough handler and use a concrete one
-    server.resetHandlers();
-    seedMockEvents([original]);
-
-    // Intercept and respond
     server.use(
       http.put(
         `${API_BASE}/calendar/events/:id`,

--- a/src/api/hooks/use-calendar-put.test.tsx
+++ b/src/api/hooks/use-calendar-put.test.tsx
@@ -1,0 +1,295 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import type {
+  ApiResponse,
+  CalendarEvent,
+  UpdateEventRequest,
+} from "@/lib/types";
+import {
+  createTestEvent,
+  createUpdateRequest,
+  testMembers,
+} from "@/test/fixtures";
+import {
+  API_BASE,
+  resetMockEvents,
+  seedMockEvents,
+  server,
+} from "@/test/mocks/server";
+import { calendarKeys, useUpdateEvent } from "./use-calendar";
+
+/**
+ * Tests verifying PUT (full-replacement) semantics for calendar event updates.
+ *
+ * The API contract says PUT replaces the entire resource — omitted fields are
+ * NOT preserved. These tests ensure the MSW mock handler faithfully implements
+ * this contract and that the mutation hook sends all required fields.
+ */
+describe("PUT full-replacement semantics", () => {
+  let testQueryClient: QueryClient;
+
+  function createTestWrapper() {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={testQueryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  beforeAll(() => server.listen({ onUnhandledRequest: "warn" }));
+  afterEach(() => {
+    server.resetHandlers();
+    resetMockEvents();
+    testQueryClient.clear();
+  });
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    testQueryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  it("preserves all fields when only title is changed", async () => {
+    const original = createTestEvent({
+      id: "event-put-1",
+      title: "Original Title",
+      startTime: "9:00 AM",
+      endTime: "10:00 AM",
+      memberId: testMembers[0].id,
+      location: "Office",
+      isAllDay: false,
+    });
+    seedMockEvents([original]);
+
+    // Seed the query cache so optimistic update has data to work with
+    testQueryClient.setQueryData(calendarKeys.eventList(), {
+      data: [original],
+    } satisfies ApiResponse<CalendarEvent[]>);
+
+    // Capture the PUT request body
+    let capturedBody: UpdateEventRequest | null = null;
+    server.use(
+      http.put(
+        `${API_BASE}/calendar/events/:id`,
+        async ({ request, params }) => {
+          const body = await request.json();
+          capturedBody = {
+            id: params.id as string,
+            ...body,
+          } as UpdateEventRequest;
+
+          // Let the default handler process it
+          return undefined as unknown as Response;
+        },
+      ),
+    );
+
+    // Remove the passthrough handler and use a concrete one
+    server.resetHandlers();
+    seedMockEvents([original]);
+
+    // Intercept and respond
+    server.use(
+      http.put(
+        `${API_BASE}/calendar/events/:id`,
+        async ({ request, params }) => {
+          const body = (await request.json()) as Omit<UpdateEventRequest, "id">;
+          capturedBody = {
+            id: params.id as string,
+            ...body,
+          } as UpdateEventRequest;
+
+          const updatedEvent: CalendarEvent = {
+            id: params.id as string,
+            title: body.title,
+            startTime: body.startTime,
+            endTime: body.endTime,
+            date: new Date(body.date),
+            memberId: body.memberId,
+            isAllDay: body.isAllDay,
+            location: body.location,
+          };
+
+          return HttpResponse.json({
+            data: updatedEvent,
+            message: "Event updated",
+          });
+        },
+      ),
+    );
+
+    const updateRequest = createUpdateRequest(original, {
+      title: "Updated Title",
+    });
+
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: createTestWrapper(),
+    });
+
+    result.current.mutate(updateRequest);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // Verify the request body contains ALL original fields
+    expect(capturedBody).not.toBeNull();
+    expect(capturedBody!.title).toBe("Updated Title");
+    expect(capturedBody!.startTime).toBe("9:00 AM");
+    expect(capturedBody!.endTime).toBe("10:00 AM");
+    expect(capturedBody!.memberId).toBe(testMembers[0].id);
+    expect(capturedBody!.location).toBe("Office");
+    expect(capturedBody!.isAllDay).toBe(false);
+
+    // Verify the response preserved fields
+    const responseEvent = result.current.data?.data;
+    expect(responseEvent?.title).toBe("Updated Title");
+    expect(responseEvent?.location).toBe("Office");
+    expect(responseEvent?.isAllDay).toBe(false);
+  });
+
+  it("clears location when sent as undefined (not silently preserved)", async () => {
+    const original = createTestEvent({
+      id: "event-put-2",
+      title: "Meeting",
+      location: "Conference Room B",
+      isAllDay: false,
+      memberId: testMembers[0].id,
+    });
+    seedMockEvents([original]);
+
+    testQueryClient.setQueryData(calendarKeys.eventList(), {
+      data: [original],
+    } satisfies ApiResponse<CalendarEvent[]>);
+
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.put(
+        `${API_BASE}/calendar/events/:id`,
+        async ({ request, params }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+
+          // Respond with true PUT semantics: use request values directly
+          const updatedEvent: CalendarEvent = {
+            id: params.id as string,
+            title: capturedBody.title as string,
+            startTime: capturedBody.startTime as string,
+            endTime: capturedBody.endTime as string,
+            date: new Date(capturedBody.date as string),
+            memberId: capturedBody.memberId as string,
+            isAllDay: capturedBody.isAllDay as boolean | undefined,
+            location: capturedBody.location as string | undefined,
+          };
+
+          return HttpResponse.json({
+            data: updatedEvent,
+            message: "Event updated",
+          });
+        },
+      ),
+    );
+
+    // Send update with location explicitly undefined
+    const updateRequest = createUpdateRequest(original, {
+      location: undefined,
+    });
+
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: createTestWrapper(),
+    });
+
+    result.current.mutate(updateRequest);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    // The key assertion: location should NOT be "Conference Room B"
+    // With true PUT semantics, the mock uses the request value (undefined), not the old value
+    const responseEvent = result.current.data?.data;
+    expect(responseEvent?.location).toBeUndefined();
+  });
+
+  it("preserves isAllDay=true when only title is updated", async () => {
+    const original = createTestEvent({
+      id: "event-put-3",
+      title: "All Day Conference",
+      isAllDay: true,
+      memberId: testMembers[1].id,
+    });
+    seedMockEvents([original]);
+
+    testQueryClient.setQueryData(calendarKeys.eventList(), {
+      data: [original],
+    } satisfies ApiResponse<CalendarEvent[]>);
+
+    const updateRequest = createUpdateRequest(original, {
+      title: "All Day Workshop",
+    });
+
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: createTestWrapper(),
+    });
+
+    result.current.mutate(updateRequest);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const responseEvent = result.current.data?.data;
+    expect(responseEvent?.title).toBe("All Day Workshop");
+    expect(responseEvent?.isAllDay).toBe(true);
+  });
+
+  it("preserves time values when only title is updated", async () => {
+    const original = createTestEvent({
+      id: "event-put-4",
+      title: "Afternoon Session",
+      startTime: "2:00 PM",
+      endTime: "3:30 PM",
+      memberId: testMembers[0].id,
+    });
+    seedMockEvents([original]);
+
+    testQueryClient.setQueryData(calendarKeys.eventList(), {
+      data: [original],
+    } satisfies ApiResponse<CalendarEvent[]>);
+
+    const updateRequest = createUpdateRequest(original, {
+      title: "Extended Session",
+    });
+
+    const { result } = renderHook(() => useUpdateEvent(), {
+      wrapper: createTestWrapper(),
+    });
+
+    result.current.mutate(updateRequest);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const responseEvent = result.current.data?.data;
+    expect(responseEvent?.title).toBe("Extended Session");
+    expect(responseEvent?.startTime).toBe("2:00 PM");
+    expect(responseEvent?.endTime).toBe("3:30 PM");
+  });
+});

--- a/src/api/mocks/calendar.mock.ts
+++ b/src/api/mocks/calendar.mock.ts
@@ -258,8 +258,8 @@ export const calendarMockHandlers = {
       endTime: request.endTime,
       date: parseLocalDate(request.date),
       memberId: request.memberId,
-      isAllDay: request.isAllDay ?? mockEvents[index].isAllDay,
-      location: request.location ?? mockEvents[index].location,
+      isAllDay: request.isAllDay,
+      location: request.location,
     };
 
     mockEvents = [

--- a/src/test/fixtures/calendar.ts
+++ b/src/test/fixtures/calendar.ts
@@ -1,4 +1,8 @@
-import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
+import type {
+  CalendarEvent,
+  CreateEventRequest,
+  UpdateEventRequest,
+} from "@/lib/types";
 import { testMembers } from "./family";
 
 /**
@@ -115,6 +119,31 @@ export function createEventRequest(
     endTime: "3:00 PM",
     date,
     memberId: testMembers[0].id,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a valid UpdateEventRequest for API testing.
+ * Builds from an existing CalendarEvent, converting the date to a string.
+ */
+export function createUpdateRequest(
+  event: CalendarEvent,
+  overrides: Partial<UpdateEventRequest> = {},
+): UpdateEventRequest {
+  const year = event.date.getFullYear();
+  const month = String(event.date.getMonth() + 1).padStart(2, "0");
+  const day = String(event.date.getDate()).padStart(2, "0");
+
+  return {
+    id: event.id,
+    title: event.title,
+    startTime: event.startTime,
+    endTime: event.endTime,
+    date: `${year}-${month}-${day}`,
+    memberId: event.memberId,
+    isAllDay: event.isAllDay,
+    location: event.location,
     ...overrides,
   };
 }

--- a/src/test/fixtures/calendar.ts
+++ b/src/test/fixtures/calendar.ts
@@ -1,3 +1,4 @@
+import { formatLocalDate } from "@/lib/time-utils";
 import type {
   CalendarEvent,
   CreateEventRequest,
@@ -112,7 +113,7 @@ export function createTestEvent(
 export function createEventRequest(
   overrides: Partial<CreateEventRequest> = {},
 ): CreateEventRequest {
-  const date = overrides.date ?? today.toISOString().split("T")[0];
+  const date = overrides.date ?? formatLocalDate(today);
   return {
     title: "New Event",
     startTime: "2:00 PM",
@@ -131,16 +132,12 @@ export function createUpdateRequest(
   event: CalendarEvent,
   overrides: Partial<UpdateEventRequest> = {},
 ): UpdateEventRequest {
-  const year = event.date.getFullYear();
-  const month = String(event.date.getMonth() + 1).padStart(2, "0");
-  const day = String(event.date.getDate()).padStart(2, "0");
-
   return {
     id: event.id,
     title: event.title,
     startTime: event.startTime,
     endTime: event.endTime,
-    date: `${year}-${month}-${day}`,
+    date: formatLocalDate(event.date),
     memberId: event.memberId,
     isAllDay: event.isAllDay,
     location: event.location,

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -4,6 +4,7 @@
 export {
   createEventRequest,
   createTestEvent,
+  createUpdateRequest,
   createWeekOfEvents,
   getRelativeDate,
   testEvent,

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -197,8 +197,8 @@ export const handlers = [
       endTime: body.endTime,
       date: parseLocalDate(body.date),
       memberId: body.memberId,
-      isAllDay: body.isAllDay ?? mockEvents[index].isAllDay,
-      location: body.location ?? mockEvents[index].location,
+      isAllDay: body.isAllDay,
+      location: body.location,
     };
 
     mockEvents = [


### PR DESCRIPTION
## Summary

- **Fixed mock handlers** in both MSW (`handlers.ts`) and dev mock (`calendar.mock.ts`) that used `??` fallback for `isAllDay` and `location` — PATCH semantics masquerading as PUT. Now uses request values directly, matching the real API contract.
- **Added `createUpdateRequest()` fixture helper** that builds a complete `UpdateEventRequest` from an existing `CalendarEvent`, ensuring all fields are included.
- **Added 4 PUT verification tests** (`use-calendar-put.test.tsx`) covering: title-only edits preserving all fields, clearing optional fields, `isAllDay` round-trip, and time format preservation.
- **Added integration test** in `calendar-module.test.tsx` verifying the full UI edit flow (detail → edit → save) sends all optional fields in the PUT request body.

## Test plan

- [x] `npm run test -- --run` — all 424 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — type-check passes