### PR TITLE
fix(api): CalendarEvent date type safety via service-layer mapper

### DIFF
--- a/src/api/hooks/use-calendar-put.test.tsx
+++ b/src/api/hooks/use-calendar-put.test.tsx
@@ -14,12 +14,14 @@ import {
 import type {
   ApiResponse,
   CalendarEvent,
+  CalendarEventResponse,
   UpdateEventRequest,
 } from "@/lib/types";
 import {
   createTestEvent,
   createUpdateRequest,
   testMembers,
+  toEventResponse,
 } from "@/test/fixtures";
 import {
   API_BASE,
@@ -76,7 +78,7 @@ describe("PUT full-replacement semantics", () => {
       location: "Office",
       isAllDay: false,
     });
-    seedMockEvents([original]);
+    seedMockEvents([toEventResponse(original)]);
 
     // Seed the query cache so optimistic update has data to work with
     testQueryClient.setQueryData(calendarKeys.eventList(), {
@@ -95,12 +97,12 @@ describe("PUT full-replacement semantics", () => {
             ...body,
           } as UpdateEventRequest;
 
-          const updatedEvent: CalendarEvent = {
+          const updatedEvent: CalendarEventResponse = {
             id: params.id as string,
             title: body.title,
             startTime: body.startTime,
             endTime: body.endTime,
-            date: new Date(body.date),
+            date: body.date,
             memberId: body.memberId,
             isAllDay: body.isAllDay,
             location: body.location,
@@ -152,7 +154,7 @@ describe("PUT full-replacement semantics", () => {
       isAllDay: false,
       memberId: testMembers[0].id,
     });
-    seedMockEvents([original]);
+    seedMockEvents([toEventResponse(original)]);
 
     testQueryClient.setQueryData(calendarKeys.eventList(), {
       data: [original],
@@ -166,12 +168,12 @@ describe("PUT full-replacement semantics", () => {
           capturedBody = (await request.json()) as Record<string, unknown>;
 
           // Respond with true PUT semantics: use request values directly
-          const updatedEvent: CalendarEvent = {
+          const updatedEvent: CalendarEventResponse = {
             id: params.id as string,
             title: capturedBody.title as string,
             startTime: capturedBody.startTime as string,
             endTime: capturedBody.endTime as string,
-            date: new Date(capturedBody.date as string),
+            date: capturedBody.date as string,
             memberId: capturedBody.memberId as string,
             isAllDay: capturedBody.isAllDay as boolean | undefined,
             location: capturedBody.location as string | undefined,
@@ -213,7 +215,7 @@ describe("PUT full-replacement semantics", () => {
       isAllDay: true,
       memberId: testMembers[1].id,
     });
-    seedMockEvents([original]);
+    seedMockEvents([toEventResponse(original)]);
 
     testQueryClient.setQueryData(calendarKeys.eventList(), {
       data: [original],
@@ -246,7 +248,7 @@ describe("PUT full-replacement semantics", () => {
       endTime: "3:30 PM",
       memberId: testMembers[0].id,
     });
-    seedMockEvents([original]);
+    seedMockEvents([toEventResponse(original)]);
 
     testQueryClient.setQueryData(calendarKeys.eventList(), {
       data: [original],

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -1,41 +1,72 @@
 import { httpClient } from "@/api/client";
 import { calendarMockHandlers, USE_MOCK_API } from "@/api/mocks";
+import { parseLocalDate } from "@/lib/time-utils";
 import type {
   ApiResponse,
   CalendarEvent,
+  CalendarEventResponse,
   CreateEventRequest,
   GetEventsParams,
   UpdateEventRequest,
 } from "@/lib/types";
+
+/**
+ * Convert a wire-format event response (date as string) to a domain CalendarEvent (date as Date).
+ * Centralizes date parsing so components always work with proper Date objects.
+ */
+function toCalendarEvent(raw: CalendarEventResponse): CalendarEvent {
+  return { ...raw, date: parseLocalDate(raw.date) };
+}
+
+function mapEventResponse(
+  response: ApiResponse<CalendarEventResponse>,
+): ApiResponse<CalendarEvent> {
+  return { ...response, data: toCalendarEvent(response.data) };
+}
+
+function mapEventsResponse(
+  response: ApiResponse<CalendarEventResponse[]>,
+): ApiResponse<CalendarEvent[]> {
+  return { ...response, data: response.data.map(toCalendarEvent) };
+}
 
 export const calendarService = {
   async getEvents(
     params?: GetEventsParams,
   ): Promise<ApiResponse<CalendarEvent[]>> {
     if (USE_MOCK_API) {
-      return calendarMockHandlers.getEvents(params);
+      return mapEventsResponse(await calendarMockHandlers.getEvents(params));
     }
-    return httpClient.get<ApiResponse<CalendarEvent[]>>("/calendar/events", {
-      params: params as Record<string, string | undefined>,
-    });
+    return mapEventsResponse(
+      await httpClient.get<ApiResponse<CalendarEventResponse[]>>(
+        "/calendar/events",
+        { params: params as Record<string, string | undefined> },
+      ),
+    );
   },
 
   async getEventById(id: string): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
-      return calendarMockHandlers.getEventById(id);
+      return mapEventResponse(await calendarMockHandlers.getEventById(id));
     }
-    return httpClient.get<ApiResponse<CalendarEvent>>(`/calendar/events/${id}`);
+    return mapEventResponse(
+      await httpClient.get<ApiResponse<CalendarEventResponse>>(
+        `/calendar/events/${id}`,
+      ),
+    );
   },
 
   async createEvent(
     request: CreateEventRequest,
   ): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
-      return calendarMockHandlers.createEvent(request);
+      return mapEventResponse(await calendarMockHandlers.createEvent(request));
     }
-    return httpClient.post<ApiResponse<CalendarEvent>>(
-      "/calendar/events",
-      request,
+    return mapEventResponse(
+      await httpClient.post<ApiResponse<CalendarEventResponse>>(
+        "/calendar/events",
+        request,
+      ),
     );
   },
 
@@ -43,11 +74,13 @@ export const calendarService = {
     request: UpdateEventRequest,
   ): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
-      return calendarMockHandlers.updateEvent(request);
+      return mapEventResponse(await calendarMockHandlers.updateEvent(request));
     }
-    return httpClient.put<ApiResponse<CalendarEvent>>(
-      `/calendar/events/${request.id}`,
-      request,
+    return mapEventResponse(
+      await httpClient.put<ApiResponse<CalendarEventResponse>>(
+        `/calendar/events/${request.id}`,
+        request,
+      ),
     );
   },
 

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -10,9 +10,13 @@ import {
   it,
   vi,
 } from "vitest";
-import type { UpdateEventRequest } from "@/lib/types";
+import type { CalendarEventResponse, UpdateEventRequest } from "@/lib/types";
 import { useCalendarStore } from "@/stores";
-import { createTestEvent, testEvents, testMembers } from "@/test/fixtures";
+import {
+  createTestEventResponse,
+  testEventResponses,
+  testMembers,
+} from "@/test/fixtures";
 import {
   API_BASE,
   getMockEvents,
@@ -104,7 +108,7 @@ describe("CalendarModule", () => {
     });
 
     it("shows events after successful fetch", async () => {
-      const event = createTestEvent({ title: "Team Meeting" });
+      const event = createTestEventResponse({ title: "Team Meeting" });
       seedMockEvents([event]);
 
       render(<CalendarModule />);
@@ -117,7 +121,7 @@ describe("CalendarModule", () => {
 
   describe("Event Display & Filtering", () => {
     it("displays events for current date range", async () => {
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
 
       render(<CalendarModule />);
 
@@ -135,7 +139,7 @@ describe("CalendarModule", () => {
           showAllDayEvents: true,
         },
       });
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
 
       render(<CalendarModule />);
 
@@ -155,7 +159,7 @@ describe("CalendarModule", () => {
           showAllDayEvents: false,
         },
       });
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
 
       render(<CalendarModule />);
 
@@ -285,7 +289,7 @@ describe("CalendarModule", () => {
 
   describe("View Event Details", () => {
     it("renders events with clickable structure", async () => {
-      const event = createTestEvent({ title: "Clickable Event" });
+      const event = createTestEventResponse({ title: "Clickable Event" });
       seedMockEvents([event]);
 
       render(<CalendarModule />);
@@ -302,7 +306,7 @@ describe("CalendarModule", () => {
 
   describe("Event Detail Modal", () => {
     it("opens detail modal when event is clicked", async () => {
-      const event = createTestEvent({
+      const event = createTestEventResponse({
         title: "Team Standup",
         startTime: "9:00 AM",
         endTime: "9:30 AM",
@@ -335,7 +339,7 @@ describe("CalendarModule", () => {
     });
 
     it("closes detail modal when close button clicked", async () => {
-      const event = createTestEvent({ title: "Closeable Event" });
+      const event = createTestEventResponse({ title: "Closeable Event" });
       seedMockEvents([event]);
 
       const { user } = renderWithUser(<CalendarModule />);
@@ -365,7 +369,7 @@ describe("CalendarModule", () => {
 
   describe("Edit Event Flow", () => {
     it("opens edit modal from detail modal and updates event", async () => {
-      const event = createTestEvent({ title: "Original Title" });
+      const event = createTestEventResponse({ title: "Original Title" });
       seedMockEvents([event]);
 
       const { user } = renderWithUser(<CalendarModule />);
@@ -413,7 +417,7 @@ describe("CalendarModule", () => {
     });
 
     it("sends all fields including optional ones in PUT request", async () => {
-      const event = createTestEvent({
+      const event = createTestEventResponse({
         title: "Office Sync",
         location: "Room 42",
         isAllDay: false,
@@ -432,17 +436,19 @@ describe("CalendarModule", () => {
             >;
             capturedBody = body;
 
+            const updatedEvent: CalendarEventResponse = {
+              id: params.id as string,
+              title: body.title,
+              startTime: body.startTime,
+              endTime: body.endTime,
+              date: body.date,
+              memberId: body.memberId,
+              isAllDay: body.isAllDay,
+              location: body.location,
+            };
+
             return HttpResponse.json({
-              data: {
-                id: params.id as string,
-                title: body.title,
-                startTime: body.startTime,
-                endTime: body.endTime,
-                date: new Date(body.date),
-                memberId: body.memberId,
-                isAllDay: body.isAllDay,
-                location: body.location,
-              },
+              data: updatedEvent,
               message: "Event updated",
             });
           },
@@ -493,7 +499,7 @@ describe("CalendarModule", () => {
 
   describe("Delete Event Flow", () => {
     it("deletes event after confirmation", async () => {
-      const event = createTestEvent({ title: "Event to Delete" });
+      const event = createTestEventResponse({ title: "Event to Delete" });
       seedMockEvents([event]);
 
       const { user } = renderWithUser(<CalendarModule />);
@@ -530,7 +536,7 @@ describe("CalendarModule", () => {
     });
 
     it("cancels delete when cancel button clicked", async () => {
-      const event = createTestEvent({ title: "Keep This Event" });
+      const event = createTestEventResponse({ title: "Keep This Event" });
       seedMockEvents([event]);
 
       const { user } = renderWithUser(<CalendarModule />);
@@ -650,7 +656,7 @@ describe("CalendarModule", () => {
 
   describe("View Switching", () => {
     it("renders weekly view with events", async () => {
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
       seedCalendarStore({ calendarView: "weekly" });
 
       render(<CalendarModule />);
@@ -661,7 +667,7 @@ describe("CalendarModule", () => {
     });
 
     it("renders schedule view with events", async () => {
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
       seedCalendarStore({ calendarView: "schedule" });
 
       render(<CalendarModule />);
@@ -693,7 +699,7 @@ describe("CalendarModule", () => {
           showAllDayEvents: true,
         },
       });
-      seedMockEvents(testEvents);
+      seedMockEvents(testEventResponses);
 
       render(<CalendarModule />);
 

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -24,15 +24,9 @@ interface EventFormModalProps {
  * Handles date formatting and time conversion (12h -> 24h)
  */
 function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
-  // Format date as yyyy-MM-dd string using local timezone (not UTC)
-  const dateStr =
-    event.date instanceof Date
-      ? formatLocalDate(event.date)
-      : String(event.date).split("T")[0];
-
   return {
     title: event.title,
-    date: dateStr,
+    date: formatLocalDate(event.date),
     startTime: format12hTo24h(event.startTime),
     endTime: format12hTo24h(event.endTime),
     memberId: event.memberId,

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -14,16 +14,9 @@ export interface CalendarEvent {
  * `date` is a "yyyy-MM-dd" string — the service layer maps this
  * to a `CalendarEvent` with a proper Date via `toCalendarEvent()`.
  */
-export interface CalendarEventResponse {
-  id: string;
-  title: string;
-  startTime: string;
-  endTime: string;
+export type CalendarEventResponse = Omit<CalendarEvent, "date"> & {
   date: string;
-  memberId: string;
-  isAllDay?: boolean;
-  location?: string;
-}
+};
 
 export type CalendarViewType = "daily" | "weekly" | "monthly" | "schedule";
 

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -9,6 +9,22 @@ export interface CalendarEvent {
   location?: string;
 }
 
+/**
+ * Wire-format type matching the real API JSON response.
+ * `date` is a "yyyy-MM-dd" string — the service layer maps this
+ * to a `CalendarEvent` with a proper Date via `toCalendarEvent()`.
+ */
+export interface CalendarEventResponse {
+  id: string;
+  title: string;
+  startTime: string;
+  endTime: string;
+  date: string;
+  memberId: string;
+  isAllDay?: boolean;
+  location?: string;
+}
+
 export type CalendarViewType = "daily" | "weekly" | "monthly" | "schedule";
 
 export interface FilterState {

--- a/src/test/fixtures/calendar.ts
+++ b/src/test/fixtures/calendar.ts
@@ -1,6 +1,7 @@
 import { formatLocalDate } from "@/lib/time-utils";
 import type {
   CalendarEvent,
+  CalendarEventResponse,
   CreateEventRequest,
   UpdateEventRequest,
 } from "@/lib/types";
@@ -162,3 +163,38 @@ export function createWeekOfEvents(): CalendarEvent[] {
   }
   return events;
 }
+
+// ============================================================================
+// Wire-format fixtures (CalendarEventResponse — date as string)
+// Use these for seeding MSW handlers which simulate the real API JSON format.
+// ============================================================================
+
+/**
+ * Convert a CalendarEvent to a CalendarEventResponse (string date).
+ */
+export function toEventResponse(event: CalendarEvent): CalendarEventResponse {
+  return { ...event, date: formatLocalDate(event.date) };
+}
+
+/**
+ * Create a CalendarEventResponse with string date for MSW handler seeding.
+ */
+export function createTestEventResponse(
+  overrides: Partial<CalendarEventResponse> = {},
+): CalendarEventResponse {
+  return {
+    id: `event-${Date.now()}`,
+    title: "Test Event",
+    startTime: "9:00 AM",
+    endTime: "10:00 AM",
+    date: formatLocalDate(today),
+    memberId: testMembers[0].id,
+    ...overrides,
+  };
+}
+
+/**
+ * Wire-format versions of testEvents for seeding MSW handlers.
+ */
+export const testEventResponses: CalendarEventResponse[] =
+  testEvents.map(toEventResponse);

--- a/src/test/fixtures/index.ts
+++ b/src/test/fixtures/index.ts
@@ -4,12 +4,15 @@
 export {
   createEventRequest,
   createTestEvent,
+  createTestEventResponse,
   createUpdateRequest,
   createWeekOfEvents,
   getRelativeDate,
   testEvent,
+  testEventResponses,
   testEvents,
   today,
+  toEventResponse,
   tomorrowEvent,
   yesterdayEvent,
 } from "./calendar";

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -3,7 +3,7 @@ import { parseLocalDate } from "@/lib/time-utils";
 import type {
   AddMemberRequest,
   ApiResponse,
-  CalendarEvent,
+  CalendarEventResponse,
   CreateEventRequest,
   FamilyData,
   FamilyMember,
@@ -18,7 +18,8 @@ import type {
 } from "@/lib/types";
 
 // In-memory storage for mock calendar events (reset between tests)
-let mockEvents: CalendarEvent[] = [];
+// Uses CalendarEventResponse (string dates) to match real API wire format
+let mockEvents: CalendarEventResponse[] = [];
 
 // In-memory storage for mock family data (reset between tests)
 let mockFamily: FamilyData | null = null;
@@ -39,16 +40,17 @@ export function resetMockEvents(): void {
 }
 
 /**
- * Seed mock events for testing
+ * Seed mock events for testing.
+ * Accepts CalendarEventResponse (string dates) to match real API wire format.
  */
-export function seedMockEvents(events: CalendarEvent[]): void {
+export function seedMockEvents(events: CalendarEventResponse[]): void {
   mockEvents = [...events];
 }
 
 /**
  * Get current mock events (for assertions)
  */
-export function getMockEvents(): CalendarEvent[] {
+export function getMockEvents(): CalendarEventResponse[] {
   return [...mockEvents];
 }
 
@@ -125,11 +127,11 @@ export const handlers = [
     // Apply date range filter (use parseLocalDate for consistent timezone handling)
     if (startDate) {
       const start = parseLocalDate(startDate);
-      events = events.filter((e) => new Date(e.date) >= start);
+      events = events.filter((e) => parseLocalDate(e.date) >= start);
     }
     if (endDate) {
       const end = parseLocalDate(endDate);
-      events = events.filter((e) => new Date(e.date) <= end);
+      events = events.filter((e) => parseLocalDate(e.date) <= end);
     }
 
     // Apply member filter
@@ -159,12 +161,12 @@ export const handlers = [
   http.post(`${API_BASE}/calendar/events`, async ({ request }) => {
     const body = (await request.json()) as CreateEventRequest;
 
-    const newEvent: CalendarEvent = {
+    const newEvent: CalendarEventResponse = {
       id: `event-${Date.now()}`,
       title: body.title,
       startTime: body.startTime,
       endTime: body.endTime,
-      date: parseLocalDate(body.date), // Use parseLocalDate to avoid timezone issues
+      date: body.date,
       memberId: body.memberId,
       isAllDay: body.isAllDay,
       location: body.location,
@@ -190,12 +192,12 @@ export const handlers = [
       );
     }
 
-    const updatedEvent: CalendarEvent = {
+    const updatedEvent: CalendarEventResponse = {
       id: id as string,
       title: body.title,
       startTime: body.startTime,
       endTime: body.endTime,
-      date: parseLocalDate(body.date),
+      date: body.date,
       memberId: body.memberId,
       isAllDay: body.isAllDay,
       location: body.location,


### PR DESCRIPTION
## Summary

- Add `CalendarEventResponse` wire-format type (`date: string`) mirroring JSON from the real API
- Add `toCalendarEvent` mapper in `calendar.service.ts` that converts string dates to `Date` via `parseLocalDate()`
- Update dev mock handlers and MSW test handlers to return string dates (matching real API behavior)
- Add wire-format test fixtures (`createTestEventResponse`, `testEventResponses`, `toEventResponse`)
- Remove dead `instanceof Date` fallback in `event-form-modal.tsx`

## Problem

`CalendarEvent.date` is typed as `Date`, but the real API returns JSON where `date` is a `"yyyy-MM-dd"` string. Both dev mock handlers and MSW test handlers were converting strings to Date objects before returning — masking the bug during development.

When the real API is connected:
- `event-detail-modal.tsx` — `format(event.date, ...)` would crash (date-fns needs a Date)
- Calendar views use `new Date(event.date)` which parses date-only strings as UTC midnight (timezone bug)
- Optimistic updates correctly call `parseLocalDate()`, but server refetch would overwrite with a raw string

## Approach: Service-Layer Response Mapper

The service layer (`calendar.service.ts`) is the API boundary — it now:
1. Types raw responses as `ApiResponse<CalendarEventResponse>` (date as string)
2. Maps through `toCalendarEvent()` which calls `parseLocalDate(raw.date)`
3. Returns `ApiResponse<CalendarEvent>` with proper Date objects

This keeps hooks and components clean — they continue to work with `CalendarEvent` (date as Date).

## Findings

**Option B (Change type to `string`) — Not chosen:**
Would push `parseLocalDate()` calls to every consumption point, creating many spots where a missed conversion would reintroduce the timezone bug.

**Option C (HTTP client interceptor) — Not chosen:**
Overly broad (not all responses have date fields), fragile (relies on field name heuristics), and mixes concerns.

**`isAllDay` optionality — No change needed:**
`isAllDay?: boolean` allows both `undefined` and `false`. No code path distinguishes between them. The Java backend defaults to `false` via primitive `boolean`. Functionally equivalent.

## Test plan

- [x] `npm run lint` — no lint errors
- [x] `npm test -- --run` — all 424 tests pass
- [x] `npm run build` — no type errors
- [x] Manual: run dev server, verify calendar events display correctly across all views