### PR TITLE
fix(validations): align FE schemas with backend constraints

### DIFF
--- a/src/lib/validations/auth.test.ts
+++ b/src/lib/validations/auth.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { usernameSchema } from "./auth";
+
+describe("auth validations", () => {
+  describe("usernameSchema", () => {
+    it("accepts username at exactly 20 characters", () => {
+      const result = usernameSchema.safeParse("a".repeat(20));
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects username at 21 characters", () => {
+      const result = usernameSchema.safeParse("a".repeat(21));
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Username must be 20 characters or less",
+        );
+      }
+    });
+
+    it("accepts username at exactly 3 characters", () => {
+      const result = usernameSchema.safeParse("abc");
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects username at 2 characters", () => {
+      const result = usernameSchema.safeParse("ab");
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          "Username must be at least 3 characters",
+        );
+      }
+    });
+  });
+});

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 /**
  * Schema for username validation.
- * - 3-30 characters
+ * - 3-20 characters
  * - Lowercase alphanumeric and underscores only
  * - Automatically trimmed and lowercased
  */
@@ -13,7 +13,7 @@ export const usernameSchema = z
     z
       .string()
       .min(3, "Username must be at least 3 characters")
-      .max(30, "Username must be 30 characters or less")
+      .max(20, "Username must be 20 characters or less")
       .regex(
         /^[a-z0-9_]+$/,
         "Username can only contain letters, numbers, and underscores",

--- a/src/lib/validations/calendar.test.ts
+++ b/src/lib/validations/calendar.test.ts
@@ -365,6 +365,23 @@ describe("calendar validations", () => {
         }
       });
 
+      it("accepts location at exactly 255 characters", () => {
+        const data = createValidEventData({ location: "a".repeat(255) });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("rejects location at 256 characters", () => {
+        const data = createValidEventData({ location: "a".repeat(256) });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.error.issues[0].message).toBe(
+            "Location must be 255 characters or less",
+          );
+        }
+      });
+
       it("accepts empty string for location", () => {
         const data = createValidEventData({ location: "" });
         const result = eventFormSchema.safeParse(data);

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -41,7 +41,10 @@ export const eventFormSchema = z
       .min(1, "End time is required")
       .regex(TIME_24H_FORMAT_REGEX, "Invalid time format"),
     memberId: z.string().min(1, "Please select a family member"),
-    location: z.string().optional(),
+    location: z
+      .string()
+      .max(255, "Location must be 255 characters or less")
+      .optional(),
     isAllDay: z.boolean().optional(),
   })
   .refine(


### PR DESCRIPTION
## Summary
- Reduce username max length from 30 → 20 to match backend `@Size(max = 20)` constraint
- Add `max(255)` validation to event location field to match backend `@Size(max = 255)` constraint
- Add tests for location max length boundary

## Test plan
- [x] All 426 existing tests pass
- [x] New location boundary tests (255 accepted, 256 rejected)
- [x] Lint clean
- [x] Build succeeds