### PR TITLE
fix(a11y): suppress Radix dialog description warnings

### DIFF
--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -65,7 +65,7 @@ function EventDetailModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader onClose={onClose}>
           <DialogTitle className="pr-8 truncate">{event.title}</DialogTitle>
         </DialogHeader>

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -50,7 +50,7 @@ function EventFormModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent>
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader onClose={onClose}>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/onboarding/member-form-modal.tsx
+++ b/src/components/onboarding/member-form-modal.tsx
@@ -82,7 +82,10 @@ export function MemberFormModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-full max-w-md mx-4 sm:mx-auto">
+      <DialogContent
+        className="w-full max-w-md mx-4 sm:mx-auto"
+        aria-describedby={undefined}
+      >
         <DialogHeader>
           <DialogTitle>
             {mode === "add" ? "Add Family Member" : "Edit Family Member"}


### PR DESCRIPTION
## Summary
- Add `aria-describedby={undefined}` to three `DialogContent` components that intentionally omit `DialogDescription`
- Eliminates 22 Radix UI console warnings during test runs (`Missing Description or aria-describedby={undefined} for {DialogContent}`)

**Affected components:**
- `event-form-modal.tsx`
- `event-detail-modal.tsx`
- `member-form-modal.tsx`

## Context
Radix UI's Dialog emits a warning when `DialogContent` is rendered without a `DialogDescription` child. Setting `aria-describedby={undefined}` explicitly signals the omission is intentional. These dialogs have a `DialogTitle` which is sufficient for screen readers — a description is not required.

## Test plan
- [x] All 424 tests pass
- [x] Zero console warnings in test output
- [ ] CI passes