### PR TITLE
fix(calendar): detect stale member IDs in persisted filter

### DIFF
--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -17,12 +17,22 @@ export function FamilyFilterPills() {
     initializeSelectedMembers,
   } = useFilterPillsState();
 
-  // Initialize selected members when family members load
+  // Initialize selected members on first load or when persisted filter is stale
   useEffect(() => {
-    if (familyMembers.length > 0) {
-      initializeSelectedMembers(familyMembers.map((m) => m.id));
+    if (familyMembers.length === 0) return;
+
+    const currentMemberIds = familyMembers.map((m) => m.id);
+
+    // Check if any selected member still exists in the actual family
+    const hasValidSelection = filter.selectedMembers.some((id) =>
+      currentMemberIds.includes(id),
+    );
+
+    if (filter.selectedMembers.length === 0 || !hasValidSelection) {
+      // First load or all selected members are stale → select all
+      initializeSelectedMembers(currentMemberIds);
     }
-  }, [familyMembers, initializeSelectedMembers]);
+  }, [familyMembers, filter.selectedMembers, initializeSelectedMembers]);
 
   const allSelected = filter.selectedMembers.length === familyMembers.length;
   const noneSelected = filter.selectedMembers.length === 0;

--- a/src/stores/calendar-store.test.ts
+++ b/src/stores/calendar-store.test.ts
@@ -606,7 +606,7 @@ describe("CalendarStore", () => {
       ]);
     });
 
-    it("does not override if already set", () => {
+    it("overwrites existing selection when called", () => {
       useCalendarStore.setState({
         filter: { selectedMembers: ["m1"], showAllDayEvents: true },
       });
@@ -614,7 +614,8 @@ describe("CalendarStore", () => {
       useCalendarStore.getState().initializeSelectedMembers(["m2", "m3"]);
 
       expect(useCalendarStore.getState().filter.selectedMembers).toEqual([
-        "m1",
+        "m2",
+        "m3",
       ]);
     });
 

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -191,12 +191,9 @@ export const useCalendarStore = create<CalendarState>()(
 
       initializeSelectedMembers: (memberIds) => {
         const { filter } = get();
-        // Only initialize if empty (first load or after reset)
-        if (filter.selectedMembers.length === 0) {
-          set({
-            filter: { ...filter, selectedMembers: memberIds },
-          });
-        }
+        set({
+          filter: { ...filter, selectedMembers: memberIds },
+        });
       },
 
       toggleAllDayEvents: () => {


### PR DESCRIPTION
## Summary

- Fix calendar showing no events when localStorage contains stale member IDs from a previous backend/session
- The `initializeSelectedMembers` guard only re-initialized when `selectedMembers` was empty, but stale IDs kept it non-empty — so initialization was skipped and all events were filtered out
- Move guard logic to `FamilyFilterPills` useEffect which now validates persisted IDs against actual family members, re-initializing when all are stale

## Test plan

- [x] All 430 unit tests pass
- [x] Lint clean
- [ ] Clear localStorage, start fresh: create family → add members → create event → event appears
- [ ] Existing session with valid filter: selections preserved (no reset)
- [ ] Switch between mock/real backend: filter auto-resets to show all members