### PR TITLE
refactor(api): remove id from update request body types

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -191,7 +191,7 @@ See `.env.example` for environment variable documentation.
 GET    /calendar/events          params: startDate, endDate, memberId
 GET    /calendar/events/:id
 POST   /calendar/events          body: CreateEventRequest
-PUT    /calendar/events/:id      body: UpdateEventRequest
+PUT    /calendar/events/:id      body: UpdateEventRequest (no id in body)
 DELETE /calendar/events/:id
 ```
 Types: `src/lib/types/calendar.ts`
@@ -203,7 +203,7 @@ POST   /family                   body: CreateFamilyRequest
 PATCH  /family                   body: UpdateFamilyRequest
 DELETE /family
 POST   /family/members           body: AddMemberRequest
-PATCH  /family/members/:id       body: UpdateMemberRequest
+PATCH  /family/members/:id       body: UpdateMemberRequest (no id in body)
 DELETE /family/members/:id
 ```
 Types: `src/lib/types/family.ts`

--- a/src/api/hooks/use-calendar-put.test.tsx
+++ b/src/api/hooks/use-calendar-put.test.tsx
@@ -86,16 +86,16 @@ describe("PUT full-replacement semantics", () => {
     } satisfies ApiResponse<CalendarEvent[]>);
 
     // Intercept the PUT request to capture the body and respond
-    let capturedBody: UpdateEventRequest | null = null;
+    let capturedBody: ({ id: string } & UpdateEventRequest) | null = null;
     server.use(
       http.put(
         `${API_BASE}/calendar/events/:id`,
         async ({ request, params }) => {
-          const body = (await request.json()) as Omit<UpdateEventRequest, "id">;
+          const body = (await request.json()) as UpdateEventRequest;
           capturedBody = {
             id: params.id as string,
             ...body,
-          } as UpdateEventRequest;
+          };
 
           const updatedEvent: CalendarEventResponse = {
             id: params.id as string,

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -3,7 +3,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { calendarService } from "@/api/services";
 import { parseLocalDate } from "@/lib/time-utils";
-import type { ApiResponse, CalendarEvent, GetEventsParams } from "@/lib/types";
+import type {
+  ApiResponse,
+  CalendarEvent,
+  GetEventsParams,
+  UpdateEventRequest,
+} from "@/lib/types";
 
 // Query keys factory for type-safe cache management
 export const calendarKeys = {
@@ -77,7 +82,8 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: calendarService.updateEvent,
+    mutationFn: ({ id, ...body }: { id: string } & UpdateEventRequest) =>
+      calendarService.updateEvent(id, body),
     // Optimistic update
     onMutate: async (updatedEvent) => {
       await queryClient.cancelQueries({ queryKey: calendarKeys.events() });

--- a/src/api/mocks/calendar.mock.ts
+++ b/src/api/mocks/calendar.mock.ts
@@ -226,21 +226,22 @@ export const calendarMockHandlers = {
   },
 
   async updateEvent(
+    id: string,
     request: UpdateEventRequest,
   ): Promise<ApiResponse<CalendarEventResponse>> {
     await simulateApiCall();
 
-    const index = mockEvents.findIndex((e) => e.id === request.id);
+    const index = mockEvents.findIndex((e) => e.id === id);
     if (index === -1) {
       throw new ApiException({
         code: ApiErrorCode.NOT_FOUND,
-        message: `Event with id "${request.id}" not found`,
+        message: `Event with id "${id}" not found`,
         status: 404,
       });
     }
 
     const updatedEvent: CalendarEventResponse = {
-      id: request.id,
+      id,
       title: request.title,
       startTime: request.startTime,
       endTime: request.endTime,

--- a/src/api/mocks/family.mock.ts
+++ b/src/api/mocks/family.mock.ts
@@ -180,6 +180,7 @@ export const familyMockHandlers = {
    * Update an existing member.
    */
   async updateMember(
+    id: string,
     request: UpdateMemberRequest,
   ): Promise<MemberMutationResponse> {
     await simulateApiCall();
@@ -193,21 +194,17 @@ export const familyMockHandlers = {
       });
     }
 
-    const memberIndex = family.members.findIndex((m) => m.id === request.id);
+    const memberIndex = family.members.findIndex((m) => m.id === id);
     if (memberIndex === -1) {
       throw new ApiException({
         code: ApiErrorCode.NOT_FOUND,
-        message: `Member with id "${request.id}" not found`,
+        message: `Member with id "${id}" not found`,
         status: 404,
       });
     }
 
     // Check for color conflict with other members
-    if (
-      family.members.some(
-        (m) => m.id !== request.id && m.color === request.color,
-      )
-    ) {
+    if (family.members.some((m) => m.id !== id && m.color === request.color)) {
       throw new ApiException({
         code: ApiErrorCode.CONFLICT,
         message: `Color "${request.color}" is already assigned to another member`,

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -71,14 +71,17 @@ export const calendarService = {
   },
 
   async updateEvent(
+    id: string,
     request: UpdateEventRequest,
   ): Promise<ApiResponse<CalendarEvent>> {
     if (USE_MOCK_API) {
-      return mapEventResponse(await calendarMockHandlers.updateEvent(request));
+      return mapEventResponse(
+        await calendarMockHandlers.updateEvent(id, request),
+      );
     }
     return mapEventResponse(
       await httpClient.put<ApiResponse<CalendarEventResponse>>(
-        `/calendar/events/${request.id}`,
+        `/calendar/events/${id}`,
         request,
       ),
     );

--- a/src/api/services/family.service.ts
+++ b/src/api/services/family.service.ts
@@ -47,13 +47,14 @@ export const familyService = {
    * Update an existing member.
    */
   async updateMember(
+    id: string,
     request: UpdateMemberRequest,
   ): Promise<MemberMutationResponse> {
     if (USE_MOCK_API) {
-      return familyMockHandlers.updateMember(request);
+      return familyMockHandlers.updateMember(id, request);
     }
     return httpClient.put<MemberMutationResponse>(
-      `/family/members/${request.id}`,
+      `/family/members/${id}`,
       request,
     );
   },

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -425,7 +425,7 @@ describe("CalendarModule", () => {
       seedMockEvents([event]);
 
       // Intercept the PUT request to capture the body
-      let capturedBody: Omit<UpdateEventRequest, "id"> | null = null;
+      let capturedBody: UpdateEventRequest | null = null;
       server.use(
         http.put(
           `${API_BASE}/calendar/events/:id`,

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -27,11 +27,7 @@ import {
 import { useIsMobile } from "@/hooks";
 import { logProfilerData } from "@/lib/perf-utils";
 import { format24hTo12h } from "@/lib/time-utils";
-import type {
-  CalendarEvent,
-  CreateEventRequest,
-  UpdateEventRequest,
-} from "@/lib/types";
+import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
   useCalendarActions,
@@ -176,7 +172,7 @@ export function CalendarModule() {
     const currentEditingEvent = useCalendarStore.getState().editingEvent;
     if (!currentEditingEvent) return;
 
-    const request: UpdateEventRequest = {
+    updateEvent.mutate({
       id: currentEditingEvent.id,
       title: formData.title,
       startTime: format24hTo12h(formData.startTime),
@@ -185,8 +181,7 @@ export function CalendarModule() {
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
-    };
-    updateEvent.mutate(request);
+    });
   };
 
   const handleAddEvent = (formData: EventFormData) => {

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -37,7 +37,6 @@ export interface CreateEventRequest {
 }
 
 export interface UpdateEventRequest {
-  id: string;
   title: string;
   startTime: string;
   endTime: string;

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -127,7 +127,6 @@ export interface AddMemberRequest {
  * Request to update an existing member.
  */
 export interface UpdateMemberRequest {
-  id: string;
   name: string;
   color: FamilyColor;
   avatarUrl?: string | null;

--- a/src/test/fixtures/calendar.ts
+++ b/src/test/fixtures/calendar.ts
@@ -126,13 +126,14 @@ export function createEventRequest(
 }
 
 /**
- * Create a valid UpdateEventRequest for API testing.
+ * Create a valid update mutation variables object for API testing.
  * Builds from an existing CalendarEvent, converting the date to a string.
+ * Returns `{ id } & UpdateEventRequest` matching the mutation variables shape.
  */
 export function createUpdateRequest(
   event: CalendarEvent,
   overrides: Partial<UpdateEventRequest> = {},
-): UpdateEventRequest {
+): { id: string } & UpdateEventRequest {
   return {
     id: event.id,
     title: event.title,

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -182,7 +182,7 @@ export const handlers = [
   // PUT /calendar/events/:id - Update event (full replacement)
   http.put(`${API_BASE}/calendar/events/:id`, async ({ params, request }) => {
     const { id } = params;
-    const body = (await request.json()) as Omit<UpdateEventRequest, "id">;
+    const body = (await request.json()) as UpdateEventRequest;
 
     const index = mockEvents.findIndex((e) => e.id === id);
     if (index === -1) {
@@ -304,7 +304,7 @@ export const handlers = [
     }
 
     const { id } = params;
-    const body = (await request.json()) as Omit<UpdateMemberRequest, "id">;
+    const body = (await request.json()) as UpdateMemberRequest;
 
     const index = mockFamily.members.findIndex((m) => m.id === id);
     if (index === -1) {


### PR DESCRIPTION
## Summary

- Removed `id` from `UpdateEventRequest` and `UpdateMemberRequest` type interfaces since the resource identifier is already in the URL path (`PUT /resource/:id`)
- Updated service methods (`updateEvent`, `updateMember`) to accept `id` as a separate parameter, sending only the request body over the wire
- Updated mock handlers to match the new two-argument signature
- Mutation hooks destructure `id` from the flat variables object before forwarding to services — call sites are unchanged

## Test plan

- [x] `npm run lint` passes (zero warnings)
- [x] All 430 unit/integration tests pass (`npm test -- --run`)
- [x] E2E failures are pre-existing (missing browser executables + flaky dialog timing) — unrelated to this change
- [x] Verified HTTP body sent by services no longer contains `id`