### PR TITLE
fix(api): resolve relative base URL in HTTP client

### DIFF
--- a/src/api/client/http-client.test.ts
+++ b/src/api/client/http-client.test.ts
@@ -55,3 +55,34 @@ describe("createHttpClient URL resolution", () => {
     expect(result.data).toBe("ok");
   });
 });
+
+describe("createHttpClient relative base URL resolution", () => {
+  // jsdom origin is http://localhost:3000 (from vitest.config.ts),
+  // so "/api" resolves to "http://localhost:3000/api/"
+
+  it("resolves relative base URL against window.location.origin", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/family", () => {
+        return HttpResponse.json({ data: "ok" });
+      }),
+    );
+
+    const client = createHttpClient({ baseUrl: "/api" });
+
+    const result = await client.get<{ data: string }>("/family");
+    expect(result.data).toBe("ok");
+  });
+
+  it("resolves relative base URL with trailing slash", async () => {
+    server.use(
+      http.get("http://localhost:3000/api/family", () => {
+        return HttpResponse.json({ data: "ok" });
+      }),
+    );
+
+    const client = createHttpClient({ baseUrl: "/api/" });
+
+    const result = await client.get<{ data: string }>("/family");
+    expect(result.data).toBe("ok");
+  });
+});

--- a/src/api/client/http-client.ts
+++ b/src/api/client/http-client.ts
@@ -66,6 +66,12 @@ export function createHttpClient(config: HttpClientConfig) {
   // Without this, new URL("/events", "http://host/api") drops the /api prefix.
   const normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
 
+  // Resolve relative base URLs (e.g. "/api") against the current origin
+  // so that new URL(endpoint, base) doesn't throw TypeError: Invalid base URL.
+  const resolvedBaseUrl = normalizedBaseUrl.startsWith("http")
+    ? normalizedBaseUrl
+    : new URL(normalizedBaseUrl, window.location.origin).toString();
+
   async function request<T>(
     endpoint: string,
     options: RequestConfig & { body?: unknown } = {},
@@ -76,7 +82,7 @@ export function createHttpClient(config: HttpClientConfig) {
     const cleanEndpoint = endpoint.startsWith("/")
       ? endpoint.slice(1)
       : endpoint;
-    const url = new URL(cleanEndpoint, normalizedBaseUrl);
+    const url = new URL(cleanEndpoint, resolvedBaseUrl);
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
         if (value !== undefined) {


### PR DESCRIPTION
## Summary

- `new URL(endpoint, baseUrl)` requires an absolute base URL, but production uses `VITE_API_BASE_URL=/api` (a relative path via nginx proxy). This caused `TypeError: Invalid base URL` on every API call in production.
- Resolve relative base URLs against `window.location.origin` before passing to `new URL()`. Absolute URLs (including protocol-relative `//`) are unchanged.

## Test plan

- [x] 2 new tests verify relative base URL resolution (`/api` and `/api/`)
- [x] 3 existing absolute URL tests still pass (no regression)
- [x] Full test suite passes (432 tests)
- [x] Lint passes