### PR TITLE
Update VITE_USE_MOCK_API docs in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,13 +17,13 @@
 #   - "http://localhost:3001/api" for local backend development
 VITE_API_BASE_URL=/api
 
-# Enable mock API (localStorage-based, no backend required)
-# Default: true (mock enabled)
-# Set to "false" to use real HTTP client against VITE_API_BASE_URL
+# Enable mock API (no backend required)
+# Default: true — all API calls use local mock handlers with localStorage persistence
+# Set to "false" — all API calls use real backend via httpClient + VITE_API_BASE_URL
 #
-# IMPORTANT: Currently only calendar events go through this toggle.
-# Family data always uses localStorage via Zustand persist.
-# See docs/TECHNICAL-DEBT.md for the familyService migration plan.
+# Affected services: auth, calendar, family
+# When mocks are off, localStorage is still used as a cache seed for instant startup
+# (not as the source of truth — the real backend is).
 VITE_USE_MOCK_API=true
 
 # -----------------------------------------------------------------------------
@@ -39,7 +39,7 @@ VITE_USE_MOCK_API=true
 # -----------------------------------------------------------------------------
 # localStorage Keys Reference
 # -----------------------------------------------------------------------------
-# family-hub-family           - Family data (Zustand persist)
+# family-hub-family           - Family data (TanStack Query cache seed)
 # family-hub-calendar-events  - Calendar events (mock API)
 # family-hub-calendar-ui      - Calendar UI preferences (Zustand persist)
 
@@ -48,5 +48,5 @@ VITE_USE_MOCK_API=true
 # -----------------------------------------------------------------------------
 # See docs/TECHNICAL-DEBT.md for full backend migration checklist.
 #
-# Calendar Events: Set VITE_USE_MOCK_API=false, implement endpoints
-# Family Data: Requires familyService refactor first (HIGH PRIORITY debt)
+# All services (auth, calendar, family) already respect VITE_USE_MOCK_API.
+# Set VITE_USE_MOCK_API=false and implement backend endpoints to migrate.


### PR DESCRIPTION
## Summary

- Updated the `VITE_USE_MOCK_API` comment block in `.env.example` to reflect the current architecture
- The old comment claimed only calendar events respected the toggle and that family data lived in Zustand persist — both are outdated
- All three services (auth, calendar, family) now respect the toggle, and family data lives in TanStack Query with localStorage as a cache seed
- Also updated the localStorage keys reference and backend migration sections for consistency

## What changed

**`VITE_USE_MOCK_API` comment (lines 20-27):**
- Removed incorrect claim that "only calendar events go through this toggle"
- Removed incorrect claim that "family data always uses localStorage via Zustand persist"
- Added accurate description: `true` → mock handlers with localStorage persistence; `false` → real backend via httpClient
- Listed all affected services: auth, calendar, family
- Clarified localStorage role when mocks are off: cache seed for instant startup, not source of truth

**localStorage keys reference (line 42):**
- Changed `family-hub-family` description from "Zustand persist" to "TanStack Query cache seed"

**Backend migration section (lines 51-52):**
- Replaced outdated per-service migration notes with accurate statement that all services already respect the toggle

## Verification

- Confirmed all three service files use `USE_MOCK_API`: `auth.service.ts` (3 methods), `calendar.service.ts` (5 methods), `family.service.ts` (6 methods)
- Confirmed `family-store.ts` is hydration gate only — no data storage
- `npm run lint` passes

## Test plan

- [x] Read `.env.example` and verify comments are accurate and concise
- [x] Confirm no functional code was changed (docs-only PR)