### PR TITLE
fix(validations): close remaining FE validation gaps (round 2)

### DIFF
--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+// BE DTO alignment:
+//   RegisterRequest.java — username: @Size(min=3, max=20), password: @Size(min=8, max=100)
+//   LoginRequest.java    — username: @NotBlank, password: @NotBlank
+
 /**
  * Schema for username validation.
  * - 3-20 characters

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
 
+// BE DTO alignment:
+//   CalendarEventRequest.java — title: @Size(max=100), date: @NotBlank,
+//     startTime/endTime: @NotBlank, memberId: @NotBlank, location: @Size(max=255)
+
 // Time format validation patterns
 const DATE_FORMAT_REGEX = /^\d{4}-\d{2}-\d{2}$/; // yyyy-MM-dd
 const TIME_24H_FORMAT_REGEX = /^([01]?[0-9]|2[0-3]):[0-5][0-9]$/; // HH:mm (24h)

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -134,7 +134,7 @@ export const familyMemberSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).max(30),
   color: familyColorSchema,
-  avatarUrl: z.string().optional(),
+  avatarUrl: z.string().max(254).optional(),
   email: z.string().max(254).email().optional().or(z.literal("")),
 });
 

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+// BE DTO alignment:
+//   FamilyRequest.java      — name: @Size(max=50)
+//   FamilyMemberRequest.java — name: @Size(max=30), email: @Size(max=254) @Email,
+//                              color: @NotBlank, avatarUrl: @Size(max=254)
+
 /**
  * Schema for family name validation.
  * Used in onboarding step 2 and family settings.

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -114,6 +114,7 @@ export const createMemberProfileSchema = (
     color: familyColorSchema,
     email: z
       .string()
+      .max(254, "Email must be 254 characters or less")
       .transform((val) => val.trim())
       .refine(
         (val) => val === "" || z.string().email().safeParse(val).success,
@@ -134,7 +135,7 @@ export const familyMemberSchema = z.object({
   name: z.string().min(1).max(30),
   color: familyColorSchema,
   avatarUrl: z.string().optional(),
-  email: z.string().email().optional().or(z.literal("")),
+  email: z.string().max(254).email().optional().or(z.literal("")),
 });
 
 /**


### PR DESCRIPTION
## Summary
- Add `.max(254)` to email fields in `createMemberProfileSchema` and `familyMemberSchema` to match BE `FamilyMemberRequest` DTO
- Add `.max(254)` to `avatarUrl` in `familyMemberSchema` to match BE DTO
- Add BE DTO alignment comment blocks to `family.ts`, `calendar.ts`, and `auth.ts` validation files to prevent silent drift

## Test plan
- [x] `npm run lint` passes
- [x] `npm test -- --run` passes (432 tests)
- [x] `npm run build` succeeds
- [x] CI passes