### PR TITLE
test(e2e): run E2E tests against real backend in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,16 @@ jobs:
       - run: npx playwright install --with-deps
       - run: npm run lint
       - run: npm run test:coverage
-      - run: npm run test:e2e
+      - name: Start backend container
+        run: docker compose -f docker-compose.e2e.yml up -d --wait
+      - name: Run E2E tests (real backend)
+        run: npm run test:e2e
+        env:
+          VITE_USE_MOCK_API: "false"
+          E2E_REAL_API: "true"
+      - name: Stop backend container
+        if: always()
+        run: docker compose -f docker-compose.e2e.yml down
       - run: npm run build
       - name: Run Lighthouse CI
         run: npx lhci autorun

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
       - run: npx playwright install --with-deps
       - run: npm run lint
       - run: npm run test:coverage
+      - name: Run E2E tests (mock)
+        run: npm run test:e2e
       - name: Start backend container
         run: docker compose -f docker-compose.e2e.yml up -d --wait
       - name: Run E2E tests (real backend)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
       - run: npx playwright install --with-deps
       - run: npm run lint
       - run: npm run test:coverage
-      - name: Run E2E tests (mock)
-        run: npm run test:e2e
       - name: Start backend container
         run: docker compose -f docker-compose.e2e.yml up -d --wait
       - name: Run E2E tests (real backend)

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,15 @@
+services:
+  family-hub-api:
+    image: ghcr.io/joe-bor/family-hub-api:latest
+    platform: linux/amd64
+    ports:
+      - "8080:8080"
+    environment:
+      - JWT_SECRET=dGVzdC1zZWNyZXQta2V5LXRoYXQtaXMtbG9uZy1lbm91Z2gtZm9yLWhtYWMtc2hhLTI1Ng==
+      - SPRING_PROFILES_ACTIVE=dev
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s

--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
   createTestMember,
@@ -6,29 +7,32 @@ import {
   seedAuth,
   seedEmptyCalendar,
   seedFamily,
+  USE_REAL_API,
   waitForCalendarReady,
   waitForDialogReady,
   waitForHydration,
 } from "./helpers/test-helpers";
 
 test.describe("Calendar Event CRUD", () => {
-  test.beforeEach(async ({ page }) => {
-    // Clear storage and seed a family
+  test.beforeEach(async ({ page, request }) => {
     await page.goto("/");
     await clearStorage(page);
-    // Seed auth token to bypass login screen
-    await seedAuth(page);
 
-    // Seed family with one member
-    await seedFamily(page, {
-      name: "Test Family",
-      members: [createTestMember("Alice", "coral")],
-    });
+    if (USE_REAL_API) {
+      const reg = await registerFamily(request, {
+        familyName: "Test Family",
+        members: [{ name: "Alice", color: "coral" }],
+      });
+      await seedBrowserAuth(page, reg);
+    } else {
+      await seedAuth(page);
+      await seedFamily(page, {
+        name: "Test Family",
+        members: [createTestMember("Alice", "coral")],
+      });
+      await seedEmptyCalendar(page);
+    }
 
-    // Prevent random mock events from overlapping with test-created events
-    await seedEmptyCalendar(page);
-
-    // Navigate and wait for app
     await page.reload();
     await waitForHydration(page);
     await waitForCalendarReady(page);

--- a/e2e/calendar-navigation.spec.ts
+++ b/e2e/calendar-navigation.spec.ts
@@ -1,30 +1,40 @@
 import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
   createTestMember,
   safeClick,
   seedAuth,
   seedFamily,
+  USE_REAL_API,
   waitForCalendarReady,
   waitForHydration,
 } from "./helpers/test-helpers";
 
 test.describe("Calendar View Navigation", () => {
-  test.beforeEach(async ({ page }) => {
-    // Clear storage and seed a family with 2 members for filtering
+  test.beforeEach(async ({ page, request }) => {
     await page.goto("/");
     await clearStorage(page);
-    // Seed auth token to bypass login screen
-    await seedAuth(page);
 
-    // Seed family with two members
-    await seedFamily(page, {
-      name: "Test Family",
-      members: [
-        createTestMember("Alice", "coral"),
-        createTestMember("Bob", "teal"),
-      ],
-    });
+    if (USE_REAL_API) {
+      const reg = await registerFamily(request, {
+        familyName: "Test Family",
+        members: [
+          { name: "Alice", color: "coral" },
+          { name: "Bob", color: "teal" },
+        ],
+      });
+      await seedBrowserAuth(page, reg);
+    } else {
+      await seedAuth(page);
+      await seedFamily(page, {
+        name: "Test Family",
+        members: [
+          createTestMember("Alice", "coral"),
+          createTestMember("Bob", "teal"),
+        ],
+      });
+    }
 
     await page.reload();
     await waitForHydration(page);

--- a/e2e/family-management.spec.ts
+++ b/e2e/family-management.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
   createTestMember,
   seedAuth,
   seedFamily,
+  USE_REAL_API,
   waitForCalendarReady,
   waitForDialogClosed,
   waitForDialogReady,
@@ -11,18 +13,23 @@ import {
 } from "./helpers/test-helpers";
 
 test.describe("Family Member Management", () => {
-  test.beforeEach(async ({ page }) => {
-    // Clear storage and seed a family with one member
+  test.beforeEach(async ({ page, request }) => {
     await page.goto("/");
     await clearStorage(page);
-    // Seed auth token to bypass login screen
-    await seedAuth(page);
 
-    // Seed family with one member
-    await seedFamily(page, {
-      name: "Test Family",
-      members: [createTestMember("Alice", "coral")],
-    });
+    if (USE_REAL_API) {
+      const reg = await registerFamily(request, {
+        familyName: "Test Family",
+        members: [{ name: "Alice", color: "coral" }],
+      });
+      await seedBrowserAuth(page, reg);
+    } else {
+      await seedAuth(page);
+      await seedFamily(page, {
+        name: "Test Family",
+        members: [createTestMember("Alice", "coral")],
+      });
+    }
 
     await page.reload();
     await waitForHydration(page);

--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -70,3 +70,30 @@ export async function seedBrowserAuth(
     );
   }, registration);
 }
+
+/**
+ * Create a calendar event via the real backend API.
+ */
+export async function createEventViaApi(
+  request: APIRequestContext,
+  token: string,
+  eventData: {
+    title: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    memberId: string;
+  },
+): Promise<void> {
+  const response = await request.post(`${API_BASE}/calendar/events`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data: eventData,
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Create event failed (${response.status()}): ${body}`);
+  }
+}

--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -26,7 +26,9 @@ export async function registerFamily(
   request: APIRequestContext,
   options: RegisterOptions,
 ): Promise<RegistrationResult> {
-  const username = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  // BE validates: lowercase letters, numbers, underscores only, 3-20 chars
+  const unique = Math.random().toString(36).slice(2, 10);
+  const username = `t_${unique}`;
 
   const response = await request.post(`${API_BASE}/auth/register`, {
     data: {

--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -70,30 +70,3 @@ export async function seedBrowserAuth(
     );
   }, registration);
 }
-
-/**
- * Create a calendar event via the real backend API.
- */
-export async function createEventViaApi(
-  request: APIRequestContext,
-  token: string,
-  eventData: {
-    title: string;
-    date: string;
-    startTime: string;
-    endTime: string;
-    memberId: string;
-  },
-): Promise<void> {
-  const response = await request.post(`${API_BASE}/calendar/events`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-    data: eventData,
-  });
-
-  if (!response.ok()) {
-    const body = await response.text();
-    throw new Error(`Create event failed (${response.status()}): ${body}`);
-  }
-}

--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -1,0 +1,97 @@
+import type { APIRequestContext, Page } from "@playwright/test";
+import type { FamilyColor } from "../../src/lib/types/family";
+
+const API_BASE = "http://localhost:8080/api";
+
+interface RegisterOptions {
+  familyName: string;
+  members: Array<{ name: string; color: FamilyColor }>;
+}
+
+interface RegistrationResult {
+  token: string;
+  family: {
+    id: string;
+    name: string;
+    members: Array<{ id: string; name: string; color: FamilyColor }>;
+    createdAt: string;
+  };
+}
+
+/**
+ * Register a new family via the real backend API.
+ * Generates a unique username per call to avoid conflicts.
+ */
+export async function registerFamily(
+  request: APIRequestContext,
+  options: RegisterOptions,
+): Promise<RegistrationResult> {
+  const username = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const response = await request.post(`${API_BASE}/auth/register`, {
+    data: {
+      username,
+      password: "TestPassword123!",
+      familyName: options.familyName,
+      members: options.members,
+    },
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Registration failed (${response.status()}): ${body}`);
+  }
+
+  const json = await response.json();
+  return json.data;
+}
+
+/**
+ * Seed browser localStorage with real auth token and family data.
+ * Must be called after page.goto() but before reload.
+ */
+export async function seedBrowserAuth(
+  page: Page,
+  registration: RegistrationResult,
+): Promise<void> {
+  await page.evaluate(({ token, family }) => {
+    // Auth token — same key the app reads
+    localStorage.setItem("family-hub-auth-token", token);
+
+    // Family data — Zustand persist format
+    localStorage.setItem(
+      "family-hub-family",
+      JSON.stringify({
+        state: { family, _hasHydrated: true },
+        version: 0,
+      }),
+    );
+  }, registration);
+}
+
+/**
+ * Create a calendar event via the real backend API.
+ */
+export async function createEventViaApi(
+  request: APIRequestContext,
+  token: string,
+  eventData: {
+    title: string;
+    date: string;
+    startTime: string;
+    endTime: string;
+    memberId: string;
+  },
+): Promise<void> {
+  const response = await request.post(`${API_BASE}/calendar/events`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data: eventData,
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Create event failed (${response.status()}): ${body}`);
+  }
+}

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -1,6 +1,8 @@
 import { expect, type Locator, type Page } from "@playwright/test";
 import type { FamilyColor, FamilyMember } from "../../src/lib/types/family";
 
+export const USE_REAL_API = process.env.E2E_REAL_API === "true";
+
 /**
  * Family data structure matching Zustand persist format
  */

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -102,7 +102,7 @@ test.describe("First-Time User Onboarding", () => {
 
     // Fill in credentials (unique username for real API to avoid conflicts)
     const username = USE_REAL_API
-      ? `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      ? `t_${Math.random().toString(36).slice(2, 10)}`
       : "testuser";
     await page.getByLabel("Username").fill(username);
     await page.getByLabel("Password", { exact: true }).fill("password123");

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -2,19 +2,27 @@ import { expect, test } from "@playwright/test";
 import {
   clearStorage,
   seedAuth,
+  USE_REAL_API,
   waitForCalendarReady,
   waitForHydration,
 } from "./helpers/test-helpers";
 
 test.describe("First-Time User Onboarding", () => {
   test.beforeEach(async ({ page }) => {
-    // Ensure clean state - no existing family data
     await page.goto("/");
     await clearStorage(page);
-    // Seed auth token to bypass login screen
-    await seedAuth(page);
-    await page.reload();
-    await waitForHydration(page);
+
+    if (USE_REAL_API) {
+      // No seeding — app shows login screen
+      await page.reload();
+      await waitForHydration(page);
+      // Navigate from login to onboarding
+      await page.getByRole("button", { name: "Create an account" }).click();
+    } else {
+      await seedAuth(page);
+      await page.reload();
+      await waitForHydration(page);
+    }
   });
 
   test("completes full onboarding flow and persists data", async ({ page }) => {
@@ -92,8 +100,11 @@ test.describe("First-Time User Onboarding", () => {
     ).toBeVisible();
     await expect(page.getByText("Step 3 of 3")).toBeVisible();
 
-    // Fill in credentials
-    await page.getByLabel("Username").fill("testuser");
+    // Fill in credentials (unique username for real API to avoid conflicts)
+    const username = USE_REAL_API
+      ? `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      : "testuser";
+    await page.getByLabel("Username").fill(username);
     await page.getByLabel("Password", { exact: true }).fill("password123");
     await page.getByLabel("Confirm Password").fill("password123");
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:real": "VITE_USE_MOCK_API=false E2E_REAL_API=true playwright test",
     "test:e2e:ui": "playwright test --ui",
     "analyze": "npm run build && echo 'Bundle analysis available at dist/stats.html'",
     "lighthouse": "npm run build && lhci autorun"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     env: {
       VITE_E2E: "true",
+      // Default to mock mode; real backend sets VITE_USE_MOCK_API=false
+      VITE_USE_MOCK_API: process.env.VITE_USE_MOCK_API ?? "true",
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,114 +2,129 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
 const { version } = JSON.parse(readFileSync("package.json", "utf-8"));
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    react({
-      babel: {
-        plugins: ["babel-plugin-react-compiler"],
-      },
-    }),
-    VitePWA({
-      registerType: "autoUpdate",
-      includeAssets: ["favicon.ico", "apple-touch-icon.png", "icons/*.png"],
-      manifest: {
-        name: "FamilyHub",
-        short_name: "FamilyHub",
-        description: "Your family's command center",
-        id: "/",
-        scope: "/",
-        start_url: "/",
-        display: "standalone",
-        orientation: "portrait",
-        background_color: "#faf8f5",
-        theme_color: "#faf8f5",
-        icons: [
-          {
-            src: "/icons/icon-192.png",
-            sizes: "192x192",
-            type: "image/png",
-          },
-          {
-            src: "/icons/icon-512.png",
-            sizes: "512x512",
-            type: "image/png",
-          },
-          {
-            src: "/icons/icon-maskable-512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
-          },
-        ],
-      },
-      workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff,woff2}"],
-        navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api/],
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "google-fonts-cache",
-              expiration: {
-                maxEntries: 10,
-                maxAgeSeconds: 60 * 60 * 24 * 365,
-              },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "VITE_");
+  const useRealApi = env.VITE_USE_MOCK_API === "false";
+
+  return {
+    plugins: [
+      react({
+        babel: {
+          plugins: ["babel-plugin-react-compiler"],
+        },
+      }),
+      VitePWA({
+        registerType: "autoUpdate",
+        includeAssets: ["favicon.ico", "apple-touch-icon.png", "icons/*.png"],
+        manifest: {
+          name: "FamilyHub",
+          short_name: "FamilyHub",
+          description: "Your family's command center",
+          id: "/",
+          scope: "/",
+          start_url: "/",
+          display: "standalone",
+          orientation: "portrait",
+          background_color: "#faf8f5",
+          theme_color: "#faf8f5",
+          icons: [
+            {
+              src: "/icons/icon-192.png",
+              sizes: "192x192",
+              type: "image/png",
             },
-          },
-          {
-            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "gstatic-fonts-cache",
-              expiration: {
-                maxEntries: 10,
-                maxAgeSeconds: 60 * 60 * 24 * 365,
-              },
+            {
+              src: "/icons/icon-512.png",
+              sizes: "512x512",
+              type: "image/png",
             },
-          },
-        ],
-      },
-    }),
-    visualizer({
-      filename: "dist/stats.html",
-      open: false,
-      gzipSize: true,
-      brotliSize: true,
-    }),
-  ],
-  define: {
-    __APP_VERSION__: JSON.stringify(version),
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          "react-vendor": ["react", "react-dom"],
-          "query-vendor": ["@tanstack/react-query"],
-          "date-vendor": ["date-fns", "react-day-picker"],
-          "radix-vendor": [
-            "@radix-ui/react-dialog",
-            "@radix-ui/react-popover",
-            "@radix-ui/react-scroll-area",
-            "@radix-ui/react-tabs",
-            "@radix-ui/react-slot",
-            "@radix-ui/react-label",
+            {
+              src: "/icons/icon-maskable-512.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "maskable",
+            },
           ],
+        },
+        workbox: {
+          globPatterns: ["**/*.{js,css,html,ico,png,svg,woff,woff2}"],
+          navigateFallback: "/index.html",
+          navigateFallbackDenylist: [/^\/api/],
+          runtimeCaching: [
+            {
+              urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+              handler: "CacheFirst",
+              options: {
+                cacheName: "google-fonts-cache",
+                expiration: {
+                  maxEntries: 10,
+                  maxAgeSeconds: 60 * 60 * 24 * 365,
+                },
+              },
+            },
+            {
+              urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+              handler: "CacheFirst",
+              options: {
+                cacheName: "gstatic-fonts-cache",
+                expiration: {
+                  maxEntries: 10,
+                  maxAgeSeconds: 60 * 60 * 24 * 365,
+                },
+              },
+            },
+          ],
+        },
+      }),
+      visualizer({
+        filename: "dist/stats.html",
+        open: false,
+        gzipSize: true,
+        brotliSize: true,
+      }),
+    ],
+    define: {
+      __APP_VERSION__: JSON.stringify(version),
+    },
+    server: {
+      proxy: useRealApi
+        ? {
+            "/api": {
+              target: "http://localhost:8080",
+              changeOrigin: true,
+            },
+          }
+        : undefined,
+    },
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            "react-vendor": ["react", "react-dom"],
+            "query-vendor": ["@tanstack/react-query"],
+            "date-vendor": ["date-fns", "react-day-picker"],
+            "radix-vendor": [
+              "@radix-ui/react-dialog",
+              "@radix-ui/react-popover",
+              "@radix-ui/react-scroll-area",
+              "@radix-ui/react-tabs",
+              "@radix-ui/react-slot",
+              "@radix-ui/react-label",
+            ],
+          },
         },
       },
     },
-  },
+  };
 });


### PR DESCRIPTION
## Summary

- Add `docker-compose.e2e.yml` to run the real backend container (GHCR image) for E2E testing
- CI workflow starts the container with `--wait` (healthcheck-based), runs E2E against it, and tears down with `if: always()`
- Vite dev server conditionally proxies `/api` → `localhost:8080` when `VITE_USE_MOCK_API=false` (dev server only, no deployment impact)
- Playwright config defaults to mock mode (`VITE_USE_MOCK_API=true`) unless explicitly overridden
- New `e2e/helpers/api-helpers.ts` with `registerFamily()`, `seedBrowserAuth()`, and `createEventViaApi()` for real-backend seeding
- All 4 spec files updated with dual-mode `beforeEach` — test bodies are unchanged (UI interactions are identical regardless of backend)
- Onboarding spec navigates from login screen → "Create an account" in real API mode
- Mock mode is fully preserved — `npm run test:e2e` works exactly as before

## Test plan

- [x] `npm run lint` passes
- [x] `npm run test:coverage` — 432 unit tests pass (no mock layer changes)
- [x] `npm run test:e2e -- --project=chromium` — 4 E2E tests pass in mock mode
- [ ] CI pipeline: verify backend container starts, E2E runs against real API, container cleans up
- [ ] Local real mode: `docker compose -f docker-compose.e2e.yml up -d` then `npm run test:e2e:real`