### PR TITLE
fix: render all-day events correctly across all calendar views

### DIFF
--- a/src/components/calendar/components/calendar-event.tsx
+++ b/src/components/calendar/components/calendar-event.tsx
@@ -41,7 +41,9 @@ export function CalendarEventCard({
               {event.title}
             </h4>
             <p className="text-sm text-muted-foreground mt-1">
-              {event.startTime} - {event.endTime}
+              {event.isAllDay
+                ? "All day"
+                : `${event.startTime} - ${event.endTime}`}
             </p>
             {event.location && (
               <p className="text-sm text-muted-foreground truncate mt-1">
@@ -104,7 +106,9 @@ export function CalendarEventCard({
             {event.title}
           </h4>
           <p className="text-xs text-muted-foreground mt-0.5">
-            {event.startTime} - {event.endTime}
+            {event.isAllDay
+              ? "All day"
+              : `${event.startTime} - ${event.endTime}`}
           </p>
           {event.location && (
             <p className="text-xs text-muted-foreground truncate mt-0.5">

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -375,6 +375,119 @@ describe("EventForm", () => {
     });
   });
 
+  describe("All Day Toggle", () => {
+    it("renders the all-day toggle switch", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      expect(screen.getByRole("switch")).toBeInTheDocument();
+      expect(screen.getByText("All day")).toBeInTheDocument();
+    });
+
+    it("hides time pickers when all-day is toggled on", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Time pickers visible initially
+      expect(screen.getByText("Start Time")).toBeInTheDocument();
+      expect(screen.getByText("End Time")).toBeInTheDocument();
+
+      // Toggle all-day on
+      await user.click(screen.getByRole("switch"));
+
+      // Time pickers should be hidden
+      expect(screen.queryByText("Start Time")).not.toBeInTheDocument();
+      expect(screen.queryByText("End Time")).not.toBeInTheDocument();
+    });
+
+    it("shows time pickers again when all-day is toggled off", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Toggle on then off
+      await user.click(screen.getByRole("switch"));
+      expect(screen.queryByText("Start Time")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("switch"));
+      expect(screen.getByText("Start Time")).toBeInTheDocument();
+      expect(screen.getByText("End Time")).toBeInTheDocument();
+    });
+
+    it("submits with isAllDay true when toggled on", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{ memberId: testMembers[0].id }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await waitForMemberSelected(testMembers[0].name);
+
+      // Toggle all-day on
+      await user.click(screen.getByRole("switch"));
+
+      // Fill title
+      const titleInput = screen.getByLabelText(/event name/i);
+      await typeAndWait(user, titleInput, "Family Picnic");
+
+      // Submit
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(
+        () => {
+          expect(mockOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: "Family Picnic",
+              isAllDay: true,
+              startTime: "00:00",
+              endTime: "23:59",
+            }),
+          );
+        },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+      );
+    });
+
+    it("renders with all-day toggle on in edit mode when event is all-day", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{
+            title: "Holiday",
+            date: "2026-03-07",
+            startTime: "00:00",
+            endTime: "23:59",
+            memberId: testMembers[0].id,
+            isAllDay: true,
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      const toggle = screen.getByRole("switch");
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+      expect(screen.queryByText("Start Time")).not.toBeInTheDocument();
+    });
+  });
+
   describe("Member Selection", () => {
     it("allows changing selected family member", async () => {
       // Pass explicit defaultValues to avoid async initialization race condition

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -75,6 +75,7 @@ function EventForm({
   const startTimeValue = watch("startTime");
   const endTimeValue = watch("endTime");
   const memberIdValue = watch("memberId");
+  const isAllDayValue = watch("isAllDay");
 
   // Reset form when defaultValues change (e.g., switching between events in edit mode)
   useEffect(() => {
@@ -84,6 +85,19 @@ function EventForm({
   const handleFormSubmit = (data: EventFormData) => {
     if (isPending) return;
     onSubmit(data);
+  };
+
+  const toggleAllDay = () => {
+    const next = !isAllDayValue;
+    setValue("isAllDay", next);
+    if (next) {
+      setValue("startTime", "00:00");
+      setValue("endTime", "23:59");
+    } else {
+      const { startTime, endTime } = getSmartDefaultTimes();
+      setValue("startTime", startTime);
+      setValue("endTime", endTime);
+    }
   };
 
   // Convert date string to Date object for DatePicker display
@@ -123,29 +137,55 @@ function EventForm({
         <FormError message={errors.date?.message} />
       </div>
 
-      {/* Start/End Time */}
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label>Start Time</Label>
-          <TimePicker
-            value={startTimeValue}
-            onChange={(time) => setValue("startTime", time)}
-            placeholder="Start time"
-            error={!!errors.startTime}
+      {/* All Day Toggle */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          role="switch"
+          aria-checked={!!isAllDayValue}
+          onClick={toggleAllDay}
+          className={cn(
+            "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+            isAllDayValue ? "bg-primary" : "bg-muted",
+          )}
+        >
+          <span
+            className={cn(
+              "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform",
+              isAllDayValue ? "translate-x-5" : "translate-x-0",
+            )}
           />
-          <FormError message={errors.startTime?.message} />
-        </div>
-        <div className="space-y-2">
-          <Label>End Time</Label>
-          <TimePicker
-            value={endTimeValue}
-            onChange={(time) => setValue("endTime", time)}
-            placeholder="End time"
-            error={!!errors.endTime}
-          />
-          <FormError message={errors.endTime?.message} />
-        </div>
+        </button>
+        <Label className="cursor-pointer" onClick={toggleAllDay}>
+          All day
+        </Label>
       </div>
+
+      {/* Start/End Time */}
+      {!isAllDayValue && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label>Start Time</Label>
+            <TimePicker
+              value={startTimeValue}
+              onChange={(time) => setValue("startTime", time)}
+              placeholder="Start time"
+              error={!!errors.startTime}
+            />
+            <FormError message={errors.startTime?.message} />
+          </div>
+          <div className="space-y-2">
+            <Label>End Time</Label>
+            <TimePicker
+              value={endTimeValue}
+              onChange={(time) => setValue("endTime", time)}
+              placeholder="End time"
+              error={!!errors.endTime}
+            />
+            <FormError message={errors.endTime?.message} />
+          </div>
+        </div>
+      )}
 
       {/* Family Member */}
       <div className="space-y-2">

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -6,7 +6,7 @@ import {
   getTimeInMinutes,
   parseTime,
 } from "@/lib/time-utils";
-import { type CalendarEvent, colorMap } from "@/lib/types";
+import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { CalendarEventCard } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
@@ -156,10 +156,20 @@ export function DailyCalendar({
       .sort(compareEventsByTime);
   }, [events, currentDate, filter.selectedMembers, filter.showAllDayEvents]);
 
+  const allDayEvents = useMemo(
+    () => dayEvents.filter((e) => e.isAllDay),
+    [dayEvents],
+  );
+
+  const timedEvents = useMemo(
+    () => dayEvents.filter((e) => !e.isAllDay),
+    [dayEvents],
+  );
+
   // Memoize the O(n²) column layout calculation
   const eventsWithLayout = useMemo(
-    () => calculateEventColumns(dayEvents),
-    [dayEvents],
+    () => calculateEventColumns(timedEvents),
+    [timedEvents],
   );
 
   const timeSlots = [
@@ -225,6 +235,36 @@ export function DailyCalendar({
           </div>
         </div>
       </div>
+
+      {/* All-day events section */}
+      {allDayEvents.length > 0 && (
+        <div className="flex border-b border-border bg-card shrink-0">
+          <div className="w-12 sm:w-16 shrink-0 flex items-center justify-end pr-2">
+            <span className="text-xs text-muted-foreground font-medium">
+              All Day
+            </span>
+          </div>
+          <div className="flex-1 flex flex-wrap gap-1.5 p-2">
+            {allDayEvents.map((event) => {
+              const member = getFamilyMember(familyMembers, event.memberId);
+              const colors = member ? colorMap[member.color] : colorMap.coral;
+              return (
+                <button
+                  type="button"
+                  key={event.id}
+                  onClick={() => onEventClick?.(event)}
+                  className={cn(
+                    "text-xs font-medium px-2.5 py-1 rounded-full text-white transition-all hover:scale-105 hover:shadow-sm",
+                    colors?.bg || "bg-muted",
+                  )}
+                >
+                  {event.title}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Calendar grid */}
       <div className="flex-1 flex overflow-y-auto" ref={scrollContainerRef}>

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -253,6 +253,8 @@ export function DailyCalendar({
                   type="button"
                   key={event.id}
                   onClick={() => onEventClick?.(event)}
+                  title={event.title}
+                  aria-label={`${event.title} - All day event`}
                   className={cn(
                     "text-xs font-medium px-2.5 py-1 rounded-full text-white transition-all hover:scale-105 hover:shadow-sm",
                     colors?.bg || "bg-muted",

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useFamilyMembers } from "@/api";
 import { useIsMobile } from "@/hooks";
+import { compareEventsAllDayFirst } from "@/lib/time-utils";
 import {
   type CalendarEvent,
   colorMap,
@@ -99,6 +100,11 @@ export function MonthlyCalendar({
           dayInfo.events.push(event);
         }
       }
+    }
+
+    // Sort each day's events: all-day first, then by start time
+    for (const dayInfo of data.values()) {
+      dayInfo.events.sort(compareEventsAllDayFirst);
     }
 
     // Compute unique members for each day using O(1) lookup
@@ -228,7 +234,7 @@ export function MonthlyCalendar({
                         "text-white font-medium",
                       )}
                     >
-                      {event.title}
+                      {event.isAllDay ? `● ${event.title}` : event.title}
                     </button>
                   );
                 })}

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -2,7 +2,7 @@ import { Clock, MapPin } from "lucide-react";
 import type React from "react";
 import { useMemo } from "react";
 import { useFamilyMembers } from "@/api";
-import { compareEventsByTime, formatLocalDate } from "@/lib/time-utils";
+import { compareEventsAllDayFirst, formatLocalDate } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { FilterState } from "../components/calendar-filter";
@@ -40,7 +40,7 @@ export function ScheduleCalendar({
           const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
           return dateMatches && memberMatches && allDayMatches;
         })
-        .sort(compareEventsByTime); // Fixed: use proper time comparison
+        .sort(compareEventsAllDayFirst);
 
       if (dayEvents.length > 0) {
         grouped.push({ date, events: dayEvents });
@@ -139,7 +139,9 @@ export function ScheduleCalendar({
                         <div className="flex items-center gap-1">
                           <Clock className="w-3.5 h-3.5" />
                           <span>
-                            {event.startTime} - {event.endTime}
+                            {event.isAllDay
+                              ? "All day"
+                              : `${event.startTime} - ${event.endTime}`}
                           </span>
                         </div>
                         {event.location && (

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -5,7 +5,7 @@ import {
   compareEventsByTime,
   parseTime,
 } from "@/lib/time-utils";
-import { type CalendarEvent, colorMap } from "@/lib/types";
+import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { CalendarEventCard } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
@@ -73,35 +73,50 @@ export function WeeklyCalendar({
   }, [currentDate]);
 
   // Pre-compute events for all 7 days in a single pass (was 14+ calls to getEventsForDay)
-  const eventsByDay = useMemo(() => {
-    const byDay = new Map<string, CalendarEvent[]>();
+  const { timedByDay, allDayByDay, hasAnyAllDayEvents } = useMemo(() => {
+    const timed = new Map<string, CalendarEvent[]>();
+    const allDay = new Map<string, CalendarEvent[]>();
 
     // Initialize all 7 days
     for (const day of weekDays) {
-      byDay.set(day.toDateString(), []);
+      timed.set(day.toDateString(), []);
+      allDay.set(day.toDateString(), []);
     }
 
     // Single pass through events - filter and group by date
     for (const event of events) {
       const eventDate = new Date(event.date);
       const dateKey = eventDate.toDateString();
-      const dayEvents = byDay.get(dateKey);
 
-      if (dayEvents) {
-        const memberMatches = filter.selectedMembers.includes(event.memberId);
-        const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
-        if (memberMatches && allDayMatches) {
-          dayEvents.push(event);
-        }
+      const memberMatches = filter.selectedMembers.includes(event.memberId);
+      const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
+      if (!memberMatches || !allDayMatches) continue;
+
+      if (event.isAllDay) {
+        allDay.get(dateKey)?.push(event);
+      } else {
+        timed.get(dateKey)?.push(event);
       }
     }
 
-    // Sort each day's events by start time
-    for (const dayEvents of byDay.values()) {
+    // Sort timed events by start time
+    for (const dayEvents of timed.values()) {
       dayEvents.sort(compareEventsByTime);
     }
 
-    return byDay;
+    let anyAllDay = false;
+    for (const dayEvents of allDay.values()) {
+      if (dayEvents.length > 0) {
+        anyAllDay = true;
+        break;
+      }
+    }
+
+    return {
+      timedByDay: timed,
+      allDayByDay: allDay,
+      hasAnyAllDayEvents: anyAllDay,
+    };
   }, [events, weekDays, filter.selectedMembers, filter.showAllDayEvents]);
 
   const formatWeekLabel = () => {
@@ -131,9 +146,13 @@ export function WeeklyCalendar({
     return date.toDateString() === today.toDateString();
   };
 
-  // Helper to get events for a day from pre-computed map
+  // Helper to get events for a day from pre-computed maps
   const getEventsForDay = (date: Date) => {
-    return eventsByDay.get(date.toDateString()) ?? [];
+    return timedByDay.get(date.toDateString()) ?? [];
+  };
+
+  const getAllDayEventsForDay = (date: Date) => {
+    return allDayByDay.get(date.toDateString()) ?? [];
   };
 
   const timeSlots = [
@@ -212,9 +231,11 @@ export function WeeklyCalendar({
             )}
             <div className="flex justify-center gap-1 mt-1.5">
               {familyMembers.slice(0, 4).map((member) => {
-                const hasEvent = getEventsForDay(date).some(
-                  (e) => e.memberId === member.id,
-                );
+                const hasEvent =
+                  getEventsForDay(date).some((e) => e.memberId === member.id) ||
+                  getAllDayEventsForDay(date).some(
+                    (e) => e.memberId === member.id,
+                  );
                 return hasEvent ? (
                   <div
                     key={member.id}
@@ -229,6 +250,52 @@ export function WeeklyCalendar({
           </div>
         ))}
       </div>
+
+      {/* All-day events row */}
+      {hasAnyAllDayEvents && (
+        <div
+          className="grid border-b border-border bg-card shrink-0"
+          style={{ gridTemplateColumns }}
+        >
+          <div className="border-r border-border flex items-center justify-end pr-2">
+            <span className="text-xs text-muted-foreground font-medium">
+              All Day
+            </span>
+          </div>
+          {weekDays.map((date, index) => {
+            const dayAllDayEvents = getAllDayEventsForDay(date);
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "border-l border-border p-1 flex flex-wrap gap-1 min-h-[36px]",
+                  isToday(date) && "bg-primary/5",
+                )}
+              >
+                {dayAllDayEvents.map((event) => {
+                  const member = getFamilyMember(familyMembers, event.memberId);
+                  const colors = member
+                    ? colorMap[member.color]
+                    : colorMap.coral;
+                  return (
+                    <button
+                      type="button"
+                      key={event.id}
+                      onClick={() => onEventClick?.(event)}
+                      className={cn(
+                        "text-[10px] font-medium px-1.5 py-0.5 rounded-full text-white truncate max-w-full transition-all hover:scale-105",
+                        colors?.bg || "bg-muted",
+                      )}
+                    >
+                      {event.title}
+                    </button>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* Calendar grid with events */}
       <div className="flex-1 overflow-auto" ref={scrollContainerRef}>

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -268,7 +268,7 @@ export function WeeklyCalendar({
               <div
                 key={index}
                 className={cn(
-                  "border-l border-border p-1 flex flex-wrap gap-1 min-h-[36px]",
+                  "border-l border-border p-1 flex flex-col gap-1 min-h-[36px]",
                   isToday(date) && "bg-primary/5",
                 )}
               >
@@ -285,7 +285,7 @@ export function WeeklyCalendar({
                       title={event.title}
                       aria-label={`${event.title} - All day event`}
                       className={cn(
-                        "text-[10px] font-medium px-2 py-1 min-h-[28px] rounded-full text-white truncate max-w-full transition-all hover:scale-105",
+                        "text-[10px] font-medium px-2 py-1 min-h-[28px] rounded-md text-white truncate w-full text-left transition-all hover:brightness-110",
                         colors?.bg || "bg-muted",
                       )}
                     >

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -282,8 +282,10 @@ export function WeeklyCalendar({
                       type="button"
                       key={event.id}
                       onClick={() => onEventClick?.(event)}
+                      title={event.title}
+                      aria-label={`${event.title} - All day event`}
                       className={cn(
-                        "text-[10px] font-medium px-1.5 py-0.5 rounded-full text-white truncate max-w-full transition-all hover:scale-105",
+                        "text-[10px] font-medium px-2 py-1 min-h-[28px] rounded-full text-white truncate max-w-full transition-all hover:scale-105",
                         colors?.bg || "bg-muted",
                       )}
                     >

--- a/src/lib/time-utils.test.ts
+++ b/src/lib/time-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   CALENDAR_END_HOUR,
   CALENDAR_START_HOUR,
+  compareEventsAllDayFirst,
   compareEventsByTime,
   DEFAULT_EVENT_HOUR,
   format12hTo24h,
@@ -153,6 +154,75 @@ describe("time-utils", () => {
       expect(compareEventsByTime(early, late)).toBeLessThan(0);
       expect(compareEventsByTime(late, early)).toBeGreaterThan(0);
       expect(compareEventsByTime(early, same)).toBe(0);
+    });
+  });
+
+  describe("compareEventsAllDayFirst", () => {
+    it("sorts all-day events before timed events", () => {
+      const events = [
+        { startTime: "9:00 AM", title: "Morning", isAllDay: false },
+        { startTime: "12:00 AM", title: "All Day", isAllDay: true },
+        { startTime: "2:00 PM", title: "Afternoon", isAllDay: false },
+      ];
+
+      const sorted = [...events].sort(compareEventsAllDayFirst);
+
+      expect(sorted[0].title).toBe("All Day");
+      expect(sorted[1].title).toBe("Morning");
+      expect(sorted[2].title).toBe("Afternoon");
+    });
+
+    it("preserves order among multiple all-day events", () => {
+      const events = [
+        { startTime: "12:00 AM", title: "Second All Day", isAllDay: true },
+        { startTime: "12:00 AM", title: "First All Day", isAllDay: true },
+      ];
+
+      const sorted = [...events].sort(compareEventsAllDayFirst);
+
+      // Stable sort preserves original order for equal elements
+      expect(sorted[0].title).toBe("Second All Day");
+      expect(sorted[1].title).toBe("First All Day");
+    });
+
+    it("sorts timed events by start time after all-day events", () => {
+      const events = [
+        { startTime: "3:00 PM", title: "Late", isAllDay: false },
+        { startTime: "12:00 AM", title: "Holiday", isAllDay: true },
+        { startTime: "9:00 AM", title: "Early", isAllDay: false },
+        { startTime: "12:00 AM", title: "Birthday", isAllDay: true },
+      ];
+
+      const sorted = [...events].sort(compareEventsAllDayFirst);
+
+      expect(sorted.map((e) => e.title)).toEqual([
+        "Holiday",
+        "Birthday",
+        "Early",
+        "Late",
+      ]);
+    });
+
+    it("handles undefined isAllDay as timed event", () => {
+      const events = [
+        { startTime: "9:00 AM", title: "No Flag" },
+        { startTime: "12:00 AM", title: "All Day", isAllDay: true },
+      ];
+
+      const sorted = [...events].sort(compareEventsAllDayFirst);
+
+      expect(sorted[0].title).toBe("All Day");
+      expect(sorted[1].title).toBe("No Flag");
+    });
+
+    it("returns correct comparison values", () => {
+      const allDay = { startTime: "12:00 AM", isAllDay: true };
+      const timed = { startTime: "9:00 AM", isAllDay: false };
+      const allDay2 = { startTime: "12:00 AM", isAllDay: true };
+
+      expect(compareEventsAllDayFirst(allDay, timed)).toBeLessThan(0);
+      expect(compareEventsAllDayFirst(timed, allDay)).toBeGreaterThan(0);
+      expect(compareEventsAllDayFirst(allDay, allDay2)).toBe(0);
     });
   });
 

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -57,6 +57,20 @@ export function compareEventsByTime(
 }
 
 /**
+ * Compare events with all-day events sorted first, then by start time.
+ * Use in views where all-day events should appear above/before timed events.
+ */
+export function compareEventsAllDayFirst(
+  a: { startTime: string; isAllDay?: boolean },
+  b: { startTime: string; isAllDay?: boolean },
+): number {
+  if (a.isAllDay && !b.isAllDay) return -1;
+  if (!a.isAllDay && b.isAllDay) return 1;
+  if (a.isAllDay && b.isAllDay) return 0;
+  return getTimeInMinutes(a.startTime) - getTimeInMinutes(b.startTime);
+}
+
+/**
  * Convert 24-hour time format to 12-hour format with AM/PM.
  * Example: "16:00" -> "4:00 PM", "09:30" -> "9:30 AM"
  */

--- a/src/lib/validations/calendar.test.ts
+++ b/src/lib/validations/calendar.test.ts
@@ -389,6 +389,55 @@ describe("calendar validations", () => {
       });
     });
 
+    describe("all-day event time validation bypass", () => {
+      it("skips end-after-start check when isAllDay is true", () => {
+        const data = createValidEventData({
+          startTime: "00:00",
+          endTime: "00:00",
+          isAllDay: true,
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("allows endTime before startTime when isAllDay is true", () => {
+        const data = createValidEventData({
+          startTime: "23:00",
+          endTime: "01:00",
+          isAllDay: true,
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("still enforces end-after-start when isAllDay is false", () => {
+        const data = createValidEventData({
+          startTime: "14:00",
+          endTime: "09:00",
+          isAllDay: false,
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const endTimeError = result.error.issues.find(
+            (issue) => issue.path[0] === "endTime",
+          );
+          expect(endTimeError?.message).toBe(
+            "End time must be after start time",
+          );
+        }
+      });
+
+      it("still enforces end-after-start when isAllDay is undefined", () => {
+        const data = createValidEventData({
+          startTime: "14:00",
+          endTime: "09:00",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+      });
+    });
+
     describe("complete validation scenarios", () => {
       it("validates complete valid event data", () => {
         const data: EventFormData = {

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -52,7 +52,9 @@ export const eventFormSchema = z
     isAllDay: z.boolean().optional(),
   })
   .refine(
-    (data) => getTimeInMinutes(data.endTime) > getTimeInMinutes(data.startTime),
+    (data) =>
+      data.isAllDay ||
+      getTimeInMinutes(data.endTime) > getTimeInMinutes(data.startTime),
     {
       message: "End time must be after start time",
       path: ["endTime"],


### PR DESCRIPTION
## Summary

- **Event cards**: Show "All day" instead of broken time range for all-day events (large and default variants)
- **Schedule view**: Display "All day" label and sort all-day events before timed events
- **Monthly view**: All-day events sort first within day cells, shown with `●` prefix for visual distinction
- **Daily view**: All-day events render as colored pills in a dedicated section above the time grid (no longer positioned off-screen at 12:00 AM)
- **Weekly view**: All-day events render as full-width bars in a dedicated row between day headers and the time grid
- **Event form**: New "All day" toggle hides time pickers and sets appropriate defaults
- **Utility**: New `compareEventsAllDayFirst` comparator in `time-utils.ts` for shared sorting logic
- **Accessibility**: `title` and `aria-label` on all-day pill buttons, improved touch targets in weekly view
- **Tests**: 14 new tests covering the comparator, validation bypass, and form toggle behavior

## Screenshots

| View | Screenshot |
|------|-----------|
| Daily view (all-day section) | ![daily-view-allday](https://github.com/user-attachments/assets/72e06e3b-5c03-45e7-ab52-a9f3fa8f6fa7) |
| Weekly view (all-day row) | ![weekly-view-allday](https://github.com/user-attachments/assets/5ddbc6fc-b814-412a-9d42-ae967d72e90d) |
| Monthly view (● prefix) | ![monthly-view-allday](https://github.com/user-attachments/assets/fe04c8b6-e979-499e-abac-b2a5f66aa5f6) |
| Schedule view ("All day" label) | ![schedule-view-allday](https://github.com/user-attachments/assets/0e5aa7cd-bcfe-4ed3-bab5-2e2dc1811fbe) |
| Mobile viewport | ![mobile-daily-view-allday](https://github.com/user-attachments/assets/a3a5fc08-58d6-4d98-b35e-46a6fce06cdd) |

## Test plan

- [x] `npm run build` — type-check passes
- [x] `npm run lint` — no lint errors
- [x] `npm run test` — all 446 tests pass (14 new)
- [ ] Create an all-day event via the form toggle → verify it appears in the all-day section (daily/weekly), shows "All day" (schedule/card), has `●` prefix (monthly)
- [ ] Create timed events → verify no regressions in any view
- [ ] Toggle "All Day Events" filter → all-day events hide/show correctly in all views
- [ ] Verify all-day section auto-hides when no all-day events exist (daily/weekly)
- [ ] Click an all-day badge → event detail modal opens
- [ ] Test on mobile viewport (responsive)