### PR TITLE
feat: add multi-day event support (Phase B)

### DIFF
--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -106,6 +106,9 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
                     ...event,
                     ...updatedEvent,
                     date: parseLocalDate(updatedEvent.date),
+                    endDate: updatedEvent.endDate
+                      ? parseLocalDate(updatedEvent.endDate)
+                      : undefined,
                   }
                 : event,
             ),

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -14,7 +14,11 @@ import type {
  * Centralizes date parsing so components always work with proper Date objects.
  */
 function toCalendarEvent(raw: CalendarEventResponse): CalendarEvent {
-  return { ...raw, date: parseLocalDate(raw.date) };
+  return {
+    ...raw,
+    date: parseLocalDate(raw.date),
+    endDate: raw.endDate ? parseLocalDate(raw.endDate) : undefined,
+  };
 }
 
 function mapEventResponse(

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -177,6 +177,7 @@ export function CalendarModule() {
       startTime: format24hTo12h(formData.startTime),
       endTime: format24hTo12h(formData.endTime),
       date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
+      endDate: formData.endDate ?? null, // null explicitly clears endDate on update
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
@@ -189,6 +190,7 @@ export function CalendarModule() {
       startTime: format24hTo12h(formData.startTime),
       endTime: format24hTo12h(formData.endTime),
       date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
+      endDate: formData.endDate ?? null,
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -62,7 +62,9 @@ function EventDetailModal({
 
   // Format date for display — multi-day shows range, single-day shows full date
   const formattedDate = event.endDate
-    ? `${format(event.date, "MMMM d")} – ${format(event.endDate, "MMMM d, yyyy")}`
+    ? event.date.getFullYear() !== event.endDate.getFullYear()
+      ? `${format(event.date, "MMMM d, yyyy")} – ${format(event.endDate, "MMMM d, yyyy")}`
+      : `${format(event.date, "MMMM d")} – ${format(event.endDate, "MMMM d, yyyy")}`
     : format(event.date, "EEEE, MMMM d, yyyy");
 
   return (

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -60,8 +60,10 @@ function EventDetailModal({
     onDelete();
   };
 
-  // Format date for display (e.g., "Monday, December 23, 2025")
-  const formattedDate = format(event.date, "EEEE, MMMM d, yyyy");
+  // Format date for display — multi-day shows range, single-day shows full date
+  const formattedDate = event.endDate
+    ? `${format(event.date, "MMMM d")} – ${format(event.endDate, "MMMM d, yyyy")}`
+    : format(event.date, "EEEE, MMMM d, yyyy");
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -27,6 +27,7 @@ function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
   return {
     title: event.title,
     date: formatLocalDate(event.date),
+    endDate: event.endDate ? formatLocalDate(event.endDate) : undefined,
     startTime: format12hTo24h(event.startTime),
     endTime: format12hTo24h(event.endTime),
     memberId: event.memberId,

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -488,6 +488,178 @@ describe("EventForm", () => {
     });
   });
 
+  describe("End Date (Multi-Day)", () => {
+    it("shows end date picker when all-day is toggled on", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // End date not visible initially
+      expect(screen.queryByText("End Date")).not.toBeInTheDocument();
+
+      // Toggle all-day on
+      await user.click(screen.getByRole("switch"));
+
+      // End date picker should appear
+      expect(screen.getByText("End Date")).toBeInTheDocument();
+    });
+
+    it("hides end date picker when all-day is toggled off", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Toggle on then off
+      await user.click(screen.getByRole("switch"));
+      expect(screen.getByText("End Date")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("switch"));
+      expect(screen.queryByText("End Date")).not.toBeInTheDocument();
+    });
+
+    it("clears endDate when toggling all-day off", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{
+            memberId: testMembers[0].id,
+            isAllDay: true,
+            startTime: "00:00",
+            endTime: "23:59",
+            endDate: "2026-03-12",
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      // Toggle off
+      await user.click(screen.getByRole("switch"));
+
+      // Toggle back on and submit — endDate should have been cleared
+      await user.click(screen.getByRole("switch"));
+
+      await waitForMemberSelected(testMembers[0].name);
+      const titleInput = screen.getByLabelText(/event name/i);
+      await typeAndWait(user, titleInput, "Test Event");
+
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(
+        () => {
+          expect(mockOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              isAllDay: true,
+            }),
+          );
+          // endDate should not be present (was cleared on toggle off)
+          expect(mockOnSubmit.mock.calls[0][0].endDate).toBeUndefined();
+        },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+      );
+    });
+
+    it("submits with endDate when set", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{
+            memberId: testMembers[0].id,
+            isAllDay: true,
+            startTime: "00:00",
+            endTime: "23:59",
+            endDate: "2026-03-12",
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await waitForMemberSelected(testMembers[0].name);
+      const titleInput = screen.getByLabelText(/event name/i);
+      await typeAndWait(user, titleInput, "Family Vacation");
+
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(
+        () => {
+          expect(mockOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: "Family Vacation",
+              isAllDay: true,
+              endDate: "2026-03-12",
+            }),
+          );
+        },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+      );
+    });
+
+    it("submits without endDate when not set", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{
+            memberId: testMembers[0].id,
+            isAllDay: true,
+            startTime: "00:00",
+            endTime: "23:59",
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await waitForMemberSelected(testMembers[0].name);
+      const titleInput = screen.getByLabelText(/event name/i);
+      await typeAndWait(user, titleInput, "Single Day Event");
+
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(
+        () => {
+          expect(mockOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title: "Single Day Event",
+              isAllDay: true,
+            }),
+          );
+          expect(mockOnSubmit.mock.calls[0][0].endDate).toBeUndefined();
+        },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+      );
+    });
+
+    it("renders end date picker in edit mode for multi-day event", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{
+            title: "Vacation",
+            date: "2026-03-08",
+            endDate: "2026-03-12",
+            startTime: "00:00",
+            endTime: "23:59",
+            memberId: testMembers[0].id,
+            isAllDay: true,
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      expect(screen.getByText("End Date")).toBeInTheDocument();
+    });
+  });
+
   describe("Member Selection", () => {
     it("allows changing selected family member", async () => {
       // Pass explicit defaultValues to avoid async initialization race condition

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -132,7 +132,11 @@ function EventForm({
         <DatePicker
           value={dateAsDate}
           onChange={(date) => {
-            setValue("date", date ? format(date, "yyyy-MM-dd") : "");
+            const newDate = date ? format(date, "yyyy-MM-dd") : "";
+            setValue("date", newDate);
+            if (endDateValue && newDate > endDateValue) {
+              setValue("endDate", undefined);
+            }
           }}
           placeholder="Pick a date"
           error={!!errors.date}

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -72,6 +72,7 @@ function EventForm({
 
   // Watch values for controlled components
   const dateValue = watch("date");
+  const endDateValue = watch("endDate");
   const startTimeValue = watch("startTime");
   const endTimeValue = watch("endTime");
   const memberIdValue = watch("memberId");
@@ -97,12 +98,14 @@ function EventForm({
       const { startTime, endTime } = getSmartDefaultTimes();
       setValue("startTime", startTime);
       setValue("endTime", endTime);
+      setValue("endDate", undefined);
     }
   };
 
-  // Convert date string to Date object for DatePicker display
+  // Convert date strings to Date objects for DatePicker display
   // Use parseLocalDate to ensure consistent local timezone handling
   const dateAsDate = dateValue ? parseLocalDate(dateValue) : undefined;
+  const endDateAsDate = endDateValue ? parseLocalDate(endDateValue) : undefined;
 
   const isAdd = mode === "add";
   const submitText = isAdd ? "Add Event" : "Save Changes";
@@ -160,6 +163,26 @@ function EventForm({
           All day
         </Label>
       </div>
+
+      {/* End Date (multi-day all-day events) */}
+      {isAllDayValue && (
+        <div className="space-y-2">
+          <Label>End Date</Label>
+          <DatePicker
+            value={endDateAsDate}
+            onChange={(date) => {
+              setValue(
+                "endDate",
+                date ? format(date, "yyyy-MM-dd") : undefined,
+              );
+            }}
+            placeholder="Same day (optional)"
+            error={!!errors.endDate}
+            fromDate={dateAsDate}
+          />
+          <FormError message={errors.endDate?.message} />
+        </div>
+      )}
 
       {/* Start/End Time */}
       {!isAllDayValue && (

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -4,6 +4,7 @@ import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
   getTimeInMinutes,
+  isEventOnDate,
   parseTime,
 } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
@@ -146,9 +147,7 @@ export function DailyCalendar({
   const dayEvents = useMemo(() => {
     return events
       .filter((event) => {
-        const eventDate = new Date(event.date);
-        const dateMatches =
-          eventDate.toDateString() === currentDate.toDateString();
+        const dateMatches = isEventOnDate(event, currentDate);
         const memberMatches = filter.selectedMembers.includes(event.memberId);
         const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
         return dateMatches && memberMatches && allDayMatches;

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useFamilyMembers } from "@/api";
 import { useIsMobile } from "@/hooks";
-import { compareEventsAllDayFirst } from "@/lib/time-utils";
+import { compareEventsAllDayFirst, isEventOnDate } from "@/lib/time-utils";
 import {
   type CalendarEvent,
   colorMap,
@@ -87,18 +87,16 @@ export function MonthlyCalendar({
       data.set(day.toDateString(), { events: [], members: [] });
     }
 
-    // Single pass through events - filter and group by date
+    // Iterate events against all days to support multi-day events
     for (const event of events) {
-      const eventDate = new Date(event.date);
-      const dateKey = eventDate.toDateString();
-      const dayInfo = data.get(dateKey);
+      const memberMatches = filter.selectedMembers.includes(event.memberId);
+      const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
+      if (!memberMatches || !allDayMatches) continue;
 
-      if (dayInfo) {
-        const memberMatches = filter.selectedMembers.includes(event.memberId);
-        const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
-        if (memberMatches && allDayMatches) {
-          dayInfo.events.push(event);
-        }
+      for (const day of days) {
+        if (!isEventOnDate(event, day)) continue;
+        const dayInfo = data.get(day.toDateString());
+        dayInfo?.events.push(event);
       }
     }
 

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -2,7 +2,11 @@ import { Clock, MapPin } from "lucide-react";
 import type React from "react";
 import { useMemo } from "react";
 import { useFamilyMembers } from "@/api";
-import { compareEventsAllDayFirst, formatLocalDate } from "@/lib/time-utils";
+import {
+  compareEventsAllDayFirst,
+  formatLocalDate,
+  isEventOnDate,
+} from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { FilterState } from "../components/calendar-filter";
@@ -34,8 +38,7 @@ export function ScheduleCalendar({
 
       const dayEvents = events
         .filter((event) => {
-          const eventDate = new Date(event.date);
-          const dateMatches = eventDate.toDateString() === date.toDateString();
+          const dateMatches = isEventOnDate(event, date);
           const memberMatches = filter.selectedMembers.includes(event.memberId);
           const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
           return dateMatches && memberMatches && allDayMatches;

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -3,6 +3,7 @@ import { useFamilyMembers } from "@/api";
 import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
+  isEventOnDate,
   parseTime,
 } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
@@ -83,19 +84,21 @@ export function WeeklyCalendar({
       allDay.set(day.toDateString(), []);
     }
 
-    // Single pass through events - filter and group by date
+    // Iterate events against all 7 days to support multi-day events
     for (const event of events) {
-      const eventDate = new Date(event.date);
-      const dateKey = eventDate.toDateString();
-
       const memberMatches = filter.selectedMembers.includes(event.memberId);
       const allDayMatches = filter.showAllDayEvents || !event.isAllDay;
       if (!memberMatches || !allDayMatches) continue;
 
-      if (event.isAllDay) {
-        allDay.get(dateKey)?.push(event);
-      } else {
-        timed.get(dateKey)?.push(event);
+      for (const day of weekDays) {
+        if (!isEventOnDate(event, day)) continue;
+        const dateKey = day.toDateString();
+        // Multi-day events are always all-day, so route to allDay map
+        if (event.isAllDay) {
+          allDay.get(dateKey)?.push(event);
+        } else {
+          timed.get(dateKey)?.push(event);
+        }
       }
     }
 

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -17,6 +17,7 @@ interface DatePickerProps {
   disabled?: boolean;
   error?: boolean;
   className?: string;
+  fromDate?: Date;
 }
 
 function DatePicker({
@@ -26,6 +27,7 @@ function DatePicker({
   disabled = false,
   error = false,
   className,
+  fromDate,
 }: DatePickerProps) {
   const [open, setOpen] = useState(false);
 
@@ -57,6 +59,7 @@ function DatePicker({
           selected={value}
           onSelect={handleSelect}
           initialFocus
+          disabled={fromDate ? { before: fromDate } : undefined}
         />
       </PopoverContent>
     </Popover>

--- a/src/lib/time-utils.test.ts
+++ b/src/lib/time-utils.test.ts
@@ -10,6 +10,7 @@ import {
   formatLocalDate,
   getSmartDefaultTimes,
   getTimeInMinutes,
+  isEventOnDate,
   parseLocalDate,
   parseTime,
 } from "./time-utils";
@@ -223,6 +224,58 @@ describe("time-utils", () => {
       expect(compareEventsAllDayFirst(allDay, timed)).toBeLessThan(0);
       expect(compareEventsAllDayFirst(timed, allDay)).toBeGreaterThan(0);
       expect(compareEventsAllDayFirst(allDay, allDay2)).toBe(0);
+    });
+  });
+
+  describe("isEventOnDate", () => {
+    it("matches single-day event on its own date", () => {
+      const event = { date: new Date(2026, 2, 8) };
+      expect(isEventOnDate(event, new Date(2026, 2, 8))).toBe(true);
+    });
+
+    it("does not match single-day event on a different date", () => {
+      const event = { date: new Date(2026, 2, 8) };
+      expect(isEventOnDate(event, new Date(2026, 2, 9))).toBe(false);
+    });
+
+    it("matches multi-day event on start date", () => {
+      const event = {
+        date: new Date(2026, 2, 8),
+        endDate: new Date(2026, 2, 12),
+      };
+      expect(isEventOnDate(event, new Date(2026, 2, 8))).toBe(true);
+    });
+
+    it("matches multi-day event on middle date", () => {
+      const event = {
+        date: new Date(2026, 2, 8),
+        endDate: new Date(2026, 2, 12),
+      };
+      expect(isEventOnDate(event, new Date(2026, 2, 10))).toBe(true);
+    });
+
+    it("matches multi-day event on end date", () => {
+      const event = {
+        date: new Date(2026, 2, 8),
+        endDate: new Date(2026, 2, 12),
+      };
+      expect(isEventOnDate(event, new Date(2026, 2, 12))).toBe(true);
+    });
+
+    it("does not match multi-day event before start date", () => {
+      const event = {
+        date: new Date(2026, 2, 8),
+        endDate: new Date(2026, 2, 12),
+      };
+      expect(isEventOnDate(event, new Date(2026, 2, 7))).toBe(false);
+    });
+
+    it("does not match multi-day event after end date", () => {
+      const event = {
+        date: new Date(2026, 2, 8),
+        endDate: new Date(2026, 2, 12),
+      };
+      expect(isEventOnDate(event, new Date(2026, 2, 13))).toBe(false);
     });
   });
 

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -110,6 +110,20 @@ export function parseLocalDate(dateStr: string): Date {
 }
 
 /**
+ * Check if an event falls on a given date.
+ * Handles both single-day events (exact date match) and multi-day events (date range).
+ */
+export function isEventOnDate(
+  event: { date: Date; endDate?: Date },
+  targetDate: Date,
+): boolean {
+  const target = targetDate.toDateString();
+  if (event.date.toDateString() === target) return true;
+  if (!event.endDate) return false;
+  return targetDate >= event.date && targetDate <= event.endDate;
+}
+
+/**
  * Calendar grid visible hours constants.
  * These match the weekly/daily view rendering boundaries.
  */

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -112,15 +112,18 @@ export function parseLocalDate(dateStr: string): Date {
 /**
  * Check if an event falls on a given date.
  * Handles both single-day events (exact date match) and multi-day events (date range).
+ * Normalizes all dates to midnight to avoid time-of-day comparison bugs.
  */
 export function isEventOnDate(
   event: { date: Date; endDate?: Date },
   targetDate: Date,
 ): boolean {
-  const target = targetDate.toDateString();
-  if (event.date.toDateString() === target) return true;
+  const normalize = (d: Date) =>
+    new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const target = normalize(targetDate);
+  if (normalize(event.date) === target) return true;
   if (!event.endDate) return false;
-  return targetDate >= event.date && targetDate <= event.endDate;
+  return target >= normalize(event.date) && target <= normalize(event.endDate);
 }
 
 /**

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -4,6 +4,7 @@ export interface CalendarEvent {
   startTime: string;
   endTime: string;
   date: Date;
+  endDate?: Date;
   memberId: string;
   isAllDay?: boolean;
   location?: string;
@@ -14,8 +15,9 @@ export interface CalendarEvent {
  * `date` is a "yyyy-MM-dd" string — the service layer maps this
  * to a `CalendarEvent` with a proper Date via `toCalendarEvent()`.
  */
-export type CalendarEventResponse = Omit<CalendarEvent, "date"> & {
+export type CalendarEventResponse = Omit<CalendarEvent, "date" | "endDate"> & {
   date: string;
+  endDate?: string;
 };
 
 export type CalendarViewType = "daily" | "weekly" | "monthly" | "schedule";
@@ -31,6 +33,7 @@ export interface CreateEventRequest {
   startTime: string;
   endTime: string;
   date: string; // ISO string for API transport
+  endDate?: string | null;
   memberId: string;
   isAllDay?: boolean;
   location?: string;
@@ -41,6 +44,7 @@ export interface UpdateEventRequest {
   startTime: string;
   endTime: string;
   date: string;
+  endDate?: string | null;
   memberId: string;
   isAllDay?: boolean;
   location?: string;

--- a/src/lib/validations/calendar.test.ts
+++ b/src/lib/validations/calendar.test.ts
@@ -438,6 +438,105 @@ describe("calendar validations", () => {
       });
     });
 
+    describe("endDate field", () => {
+      it("accepts valid endDate format", () => {
+        const data = createValidEventData({
+          isAllDay: true,
+          startTime: "00:00",
+          endTime: "23:59",
+          endDate: "2025-12-25",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("rejects invalid endDate format", () => {
+        const data = createValidEventData({
+          isAllDay: true,
+          startTime: "00:00",
+          endTime: "23:59",
+          endDate: "12-25-2025",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+      });
+
+      it("accepts endDate equal to date", () => {
+        const data = createValidEventData({
+          isAllDay: true,
+          startTime: "00:00",
+          endTime: "23:59",
+          date: "2025-12-23",
+          endDate: "2025-12-23",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("accepts endDate after date", () => {
+        const data = createValidEventData({
+          isAllDay: true,
+          startTime: "00:00",
+          endTime: "23:59",
+          date: "2025-12-23",
+          endDate: "2025-12-28",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+
+      it("rejects endDate before date", () => {
+        const data = createValidEventData({
+          isAllDay: true,
+          startTime: "00:00",
+          endTime: "23:59",
+          date: "2025-12-23",
+          endDate: "2025-12-20",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const endDateError = result.error.issues.find(
+            (issue) => issue.path[0] === "endDate",
+          );
+          expect(endDateError?.message).toBe(
+            "End date must be on or after start date",
+          );
+        }
+      });
+
+      it("rejects endDate when isAllDay is false", () => {
+        const data = createValidEventData({
+          isAllDay: false,
+          endDate: "2025-12-25",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          const endDateError = result.error.issues.find(
+            (issue) =>
+              issue.path[0] === "endDate" &&
+              issue.message === "End date is only valid for all-day events",
+          );
+          expect(endDateError).toBeDefined();
+        }
+      });
+
+      it("rejects endDate when isAllDay is undefined", () => {
+        const data = createValidEventData({
+          endDate: "2025-12-25",
+        });
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(false);
+      });
+
+      it("accepts omitted endDate", () => {
+        const data = createValidEventData();
+        const result = eventFormSchema.safeParse(data);
+        expect(result.success).toBe(true);
+      });
+    });
+
     describe("complete validation scenarios", () => {
       it("validates complete valid event data", () => {
         const data: EventFormData = {

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -50,6 +50,10 @@ export const eventFormSchema = z
       .max(255, "Location must be 255 characters or less")
       .optional(),
     isAllDay: z.boolean().optional(),
+    endDate: z
+      .string()
+      .regex(DATE_FORMAT_REGEX, "Invalid date format")
+      .optional(),
   })
   .refine(
     (data) =>
@@ -59,7 +63,15 @@ export const eventFormSchema = z
       message: "End time must be after start time",
       path: ["endTime"],
     },
-  );
+  )
+  .refine((data) => !data.endDate || data.endDate >= data.date, {
+    message: "End date must be on or after start date",
+    path: ["endDate"],
+  })
+  .refine((data) => !data.endDate || data.isAllDay, {
+    message: "End date is only valid for all-day events",
+    path: ["endDate"],
+  });
 
 /**
  * TypeScript type inferred from the schema


### PR DESCRIPTION
## Summary

- Add `endDate` field to calendar event types, service mapping, Zod validation, and form UI
- Add `isEventOnDate()` utility for multi-day range checking used by all 4 calendar views
- Multi-day events render as repeated all-day badges on each day in the range (daily, weekly, monthly, schedule views)
- End date picker appears only when "All day" toggle is on, with `fromDate` constraint preventing selection before start date
- Event detail modal shows date range (e.g., "March 8 – March 12, 2026") for multi-day events
- Optimistic updates include `endDate` mapping; `null` sent to API to explicitly clear endDate

## Test plan

- [x] `npm run build` passes (type-check + build)
- [x] `npm run test -- --run` passes (467 tests, including new multi-day tests)
- [x] Manual: create multi-day all-day event, verify it appears on each day in all 4 views
- [x] Manual: edit multi-day event, toggle isAllDay off, verify endDate clears
- [x] Manual: verify end date picker prevents selecting dates before start date