### PR TITLE
feat(calendar): add recurring events support

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -1,6 +1,6 @@
 # Technical Debt & Deferred Improvements
 
-**Last Updated:** Feb 4, 2026
+**Last Updated:** Mar 13, 2026
 
 This document tracks known technical debt, deferred improvements, and future enhancements identified during code reviews. Items are prioritized and linked to relevant sprints.
 
@@ -29,6 +29,38 @@ When a member is deleted:
 - Count assigned events before delete
 - Show confirmation dialog: "This member has X events. Delete anyway?"
 - Consider cascade delete or reassignment to "Unassigned" member
+
+---
+
+## Medium-Low Priority (Follow-up PRs)
+
+### 1. E2E Tests for Recurring Events
+**Source:** PR #117 Review
+**Files:** `e2e/`
+**Status:** Testing gap
+
+**Problem:**
+No E2E test coverage for the recurring events flow — creating, editing (this/all), and deleting (this/all) recurring events are only covered by unit tests.
+
+**Suggested Fix:**
+- Add E2E tests covering: create recurring event, edit single instance, edit all events, delete single instance, delete all events
+- Verify RecurrencePicker interactions (frequency selection, custom days, end date)
+- Verify EditScopeDialog behavior for both edit and delete actions
+
+---
+
+### 2. `CalendarEvent.id` Null Safety
+**Source:** PR #117 Review
+**Files:** `src/lib/types/calendar.ts`, consumers of `CalendarEvent`
+**Status:** Key spots guarded, wider audit needed
+
+**Problem:**
+`CalendarEvent.id` changed from `string` to `string | null` to support virtual recurring instances (which have no database ID). The key code paths in `calendar-module.tsx` now have runtime guards, but other consumers across the codebase may still assume `id` is non-null.
+
+**Suggested Fix:**
+- Audit all usages of `CalendarEvent.id` outside `calendar-module.tsx`
+- Add runtime guards or type narrowing where needed
+- Consider a branded type or discriminated union (`VirtualInstance | PersistedEvent`) to make the null case explicit at the type level
 
 ---
 

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -15,7 +15,9 @@ export {
   useCalendarEvents,
   useCreateEvent,
   useDeleteEvent,
+  useDeleteInstance,
   useUpdateEvent,
+  useUpdateInstance,
 } from "./use-calendar";
 
 export {

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -3,7 +3,12 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { calendarService } from "@/api/services";
 import { parseLocalDate } from "@/lib/time-utils";
-import type { ApiResponse, CalendarEvent, GetEventsParams } from "@/lib/types";
+import type {
+  ApiResponse,
+  CalendarEvent,
+  GetEventsParams,
+  UpdateEventRequest,
+} from "@/lib/types";
 
 // Query keys factory for type-safe cache management
 export const calendarKeys = {
@@ -17,7 +22,7 @@ export const calendarKeys = {
 // Queries
 
 export function useCalendarEvents(
-  params?: GetEventsParams,
+  params: GetEventsParams,
   options?: Omit<
     UseQueryOptions<ApiResponse<CalendarEvent[]>, ApiException>,
     "queryKey" | "queryFn"
@@ -104,6 +109,7 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
                     endDate: updatedEvent.endDate
                       ? parseLocalDate(updatedEvent.endDate)
                       : undefined,
+                    recurrenceRule: updatedEvent.recurrenceRule ?? undefined,
                   }
                 : event,
             ),
@@ -195,14 +201,10 @@ export function useUpdateInstance(callbacks?: UpdateInstanceCallbacks) {
   return useMutation({
     mutationFn: ({
       parentId,
-      date,
+      instanceDate,
       ...body
-    }: { parentId: string; date: string } & Record<string, unknown>) =>
-      calendarService.updateInstance(
-        parentId,
-        date,
-        body as Parameters<typeof calendarService.updateInstance>[2],
-      ),
+    }: { parentId: string; instanceDate: string } & UpdateEventRequest) =>
+      calendarService.updateInstance(parentId, instanceDate, body),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: calendarKeys.events() });
     },

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -3,12 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { calendarService } from "@/api/services";
 import { parseLocalDate } from "@/lib/time-utils";
-import type {
-  ApiResponse,
-  CalendarEvent,
-  GetEventsParams,
-  UpdateEventRequest,
-} from "@/lib/types";
+import type { ApiResponse, CalendarEvent, GetEventsParams } from "@/lib/types";
 
 // Query keys factory for type-safe cache management
 export const calendarKeys = {
@@ -183,6 +178,62 @@ export function useDeleteEvent(callbacks?: DeleteEventCallbacks) {
     },
     onSuccess: () => {
       callbacks?.onSuccess?.();
+    },
+  });
+}
+
+// Instance mutations (for recurring events — "edit/delete this event")
+
+interface UpdateInstanceCallbacks {
+  onSuccess?: (data: ApiResponse<CalendarEvent>) => void;
+  onError?: (error: ApiException) => void;
+}
+
+export function useUpdateInstance(callbacks?: UpdateInstanceCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      parentId,
+      date,
+      ...body
+    }: { parentId: string; date: string } & Record<string, unknown>) =>
+      calendarService.updateInstance(
+        parentId,
+        date,
+        body as Parameters<typeof calendarService.updateInstance>[2],
+      ),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: calendarKeys.events() });
+    },
+    onSuccess: (data) => {
+      callbacks?.onSuccess?.(data);
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+interface DeleteInstanceCallbacks {
+  onSuccess?: () => void;
+  onError?: (error: ApiException) => void;
+}
+
+export function useDeleteInstance(callbacks?: DeleteInstanceCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ parentId, date }: { parentId: string; date: string }) =>
+      calendarService.deleteInstance(parentId, date),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: calendarKeys.events() });
+    },
+    onSuccess: () => {
+      callbacks?.onSuccess?.();
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
     },
   });
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,6 +24,7 @@ export {
   useCreateEvent,
   useDeleteEvent,
   useDeleteFamily,
+  useDeleteInstance,
   useFamily,
   useFamilyData,
   useFamilyLoading,
@@ -39,6 +40,7 @@ export {
   useUnusedColors,
   useUpdateEvent,
   useUpdateFamily,
+  useUpdateInstance,
   useUpdateMember,
 } from "./hooks";
 // Services

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -79,4 +79,21 @@ export const calendarService = {
   async deleteEvent(id: string): Promise<void> {
     return httpClient.delete(`/calendar/events/${id}`);
   },
+
+  async updateInstance(
+    parentId: string,
+    date: string,
+    request: UpdateEventRequest,
+  ): Promise<ApiResponse<CalendarEvent>> {
+    return mapEventResponse(
+      await httpClient.put<ApiResponse<CalendarEventResponse>>(
+        `/calendar/events/${parentId}/instances/${date}`,
+        request,
+      ),
+    );
+  },
+
+  async deleteInstance(parentId: string, date: string): Promise<void> {
+    return httpClient.delete(`/calendar/events/${parentId}/instances/${date}`);
+  },
 };

--- a/src/api/services/calendar.service.ts
+++ b/src/api/services/calendar.service.ts
@@ -35,12 +35,14 @@ function mapEventsResponse(
 
 export const calendarService = {
   async getEvents(
-    params?: GetEventsParams,
+    params: GetEventsParams,
   ): Promise<ApiResponse<CalendarEvent[]>> {
     return mapEventsResponse(
       await httpClient.get<ApiResponse<CalendarEventResponse[]>>(
         "/calendar/events",
-        { params: params as Record<string, string | undefined> },
+        {
+          params: params as unknown as Record<string, string | undefined>,
+        },
       ),
     );
   },

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -50,7 +50,12 @@ import {
  * - Parents have only id
  */
 function getParentId(event: CalendarEvent): string {
-  return event.recurringEventId ?? event.id!;
+  const id = event.recurringEventId ?? event.id;
+  if (!id)
+    throw new Error(
+      "Cannot resolve parent ID: event has no id or recurringEventId",
+    );
+  return id;
 }
 
 export function CalendarModule() {
@@ -151,18 +156,14 @@ export function CalendarModule() {
     onSuccess: () => {
       closeEditModal();
     },
-    onError: (error) => {
-      console.error("Failed to update event:", error.message);
-    },
+    onError: () => {},
   });
 
   const updateInstance = useUpdateInstance({
     onSuccess: () => {
       closeEditModal();
     },
-    onError: (error) => {
-      console.error("Failed to update instance:", error.message);
-    },
+    onError: () => {},
   });
 
   const deleteInstance = useDeleteInstance({
@@ -192,6 +193,8 @@ export function CalendarModule() {
   }, [eventsResponse, filter]);
 
   const handleEventClick = (event: CalendarEvent) => {
+    deleteEvent.reset();
+    deleteInstance.reset();
     openDetailModal(event);
   };
 
@@ -202,7 +205,8 @@ export function CalendarModule() {
       setScopeAction("delete");
       setScopeDialogOpen(true);
     } else {
-      deleteEvent.mutate(selectedEvent.id!);
+      if (!selectedEvent.id) return;
+      deleteEvent.mutate(selectedEvent.id);
     }
   };
 
@@ -280,8 +284,9 @@ export function CalendarModule() {
       });
     } else {
       // Non-recurring event
+      if (!currentEditingEvent.id) return;
       updateEvent.mutate({
-        id: currentEditingEvent.id!,
+        id: currentEditingEvent.id,
         ...request,
       });
     }

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -6,17 +6,21 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useCalendarEvents,
   useCreateEvent,
   useDeleteEvent,
+  useDeleteInstance,
   useUpdateEvent,
+  useUpdateInstance,
 } from "@/api";
 import {
   AddEventButton,
   CalendarViewSwitcher,
   DailyCalendar,
+  type EditScope,
+  EditScopeDialog,
   EventDetailModal,
   EventFormModal,
   FamilyFilterPills,
@@ -25,7 +29,8 @@ import {
   WeeklyCalendar,
 } from "@/components/calendar";
 import { useIsMobile } from "@/hooks";
-import { format24hTo12h } from "@/lib/time-utils";
+import { buildRRule } from "@/lib/recurrence-utils";
+import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
 import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
@@ -37,6 +42,16 @@ import {
   useHasUserSetView,
   useIsViewingToday,
 } from "@/stores";
+
+/**
+ * Get the parent event ID for recurring event operations.
+ * - Virtual instances have recurringEventId but no id
+ * - Exceptions have both recurringEventId and id
+ * - Parents have only id
+ */
+function getParentId(event: CalendarEvent): string {
+  return event.recurringEventId ?? event.id!;
+}
 
 export function CalendarModule() {
   // Mobile detection for smart view defaulting
@@ -141,6 +156,31 @@ export function CalendarModule() {
     },
   });
 
+  const updateInstance = useUpdateInstance({
+    onSuccess: () => {
+      closeEditModal();
+    },
+    onError: (error) => {
+      console.error("Failed to update instance:", error.message);
+    },
+  });
+
+  const deleteInstance = useDeleteInstance({
+    onSuccess: () => {
+      closeDetailModal();
+      closeScopeDialog();
+    },
+  });
+
+  // Scope dialog state for recurring events
+  const [scopeDialogOpen, setScopeDialogOpen] = useState(false);
+  const [scopeAction, setScopeAction] = useState<"edit" | "delete">("edit");
+  const [editScope, setEditScope] = useState<EditScope | null>(null);
+
+  const closeScopeDialog = () => {
+    setScopeDialogOpen(false);
+  };
+
   // Client-side filtering based on filter state
   const events = useMemo(() => {
     const rawEvents = eventsResponse?.data ?? [];
@@ -156,14 +196,45 @@ export function CalendarModule() {
   };
 
   const handleDeleteEvent = () => {
-    if (selectedEvent) {
-      deleteEvent.mutate(selectedEvent.id);
+    if (!selectedEvent) return;
+
+    if (selectedEvent.isRecurring) {
+      setScopeAction("delete");
+      setScopeDialogOpen(true);
+    } else {
+      deleteEvent.mutate(selectedEvent.id!);
     }
   };
 
   const handleEditClick = () => {
-    if (selectedEvent) {
+    if (!selectedEvent) return;
+
+    if (selectedEvent.isRecurring) {
+      setScopeAction("edit");
+      setScopeDialogOpen(true);
+    } else {
       openEditModal(selectedEvent);
+    }
+  };
+
+  const handleScopeSelect = (scope: EditScope) => {
+    if (!selectedEvent) return;
+    closeScopeDialog();
+
+    if (scopeAction === "edit") {
+      setEditScope(scope);
+      openEditModal(selectedEvent);
+    } else {
+      // Delete
+      const parentId = getParentId(selectedEvent);
+      if (scope === "this") {
+        deleteInstance.mutate({
+          parentId,
+          date: formatLocalDate(selectedEvent.date),
+        });
+      } else {
+        deleteEvent.mutate(parentId);
+      }
     }
   };
 
@@ -171,29 +242,73 @@ export function CalendarModule() {
     const currentEditingEvent = useCalendarStore.getState().editingEvent;
     if (!currentEditingEvent) return;
 
-    updateEvent.mutate({
-      id: currentEditingEvent.id,
+    const request = {
       title: formData.title,
       startTime: format24hTo12h(formData.startTime),
       endTime: format24hTo12h(formData.endTime),
-      date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
-      endDate: formData.endDate ?? null, // null explicitly clears endDate on update
-      memberId: formData.memberId,
-      isAllDay: formData.isAllDay,
-      location: formData.location,
-    });
-  };
-
-  const handleAddEvent = (formData: EventFormData) => {
-    const request: CreateEventRequest = {
-      title: formData.title,
-      startTime: format24hTo12h(formData.startTime),
-      endTime: format24hTo12h(formData.endTime),
-      date: formData.date, // Already "yyyy-MM-dd", pass as-is to avoid timezone shift
+      date: formData.date,
       endDate: formData.endDate ?? null,
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
+    };
+
+    if (currentEditingEvent.isRecurring && editScope === "this") {
+      // "This event" — always use instance endpoint
+      const parentId = getParentId(currentEditingEvent);
+      updateInstance.mutate({
+        parentId,
+        date: formatLocalDate(currentEditingEvent.date),
+        ...request,
+      });
+    } else if (currentEditingEvent.isRecurring && editScope === "all") {
+      // "All events" — update the parent, include recurrence rule
+      const recurrenceRule =
+        buildRRule({
+          frequency: formData.recurrenceFrequency ?? "none",
+          interval: formData.recurrenceInterval ?? 1,
+          weeklyDays: formData.recurrenceWeeklyDays,
+          monthDay: formData.recurrenceMonthDay,
+          endDate: formData.recurrenceEndDate,
+        }) ?? null;
+
+      const parentId = getParentId(currentEditingEvent);
+      updateEvent.mutate({
+        id: parentId,
+        ...request,
+        recurrenceRule,
+      });
+    } else {
+      // Non-recurring event
+      updateEvent.mutate({
+        id: currentEditingEvent.id!,
+        ...request,
+      });
+    }
+
+    setEditScope(null);
+  };
+
+  const handleAddEvent = (formData: EventFormData) => {
+    const recurrenceRule =
+      buildRRule({
+        frequency: formData.recurrenceFrequency ?? "none",
+        interval: formData.recurrenceInterval ?? 1,
+        weeklyDays: formData.recurrenceWeeklyDays,
+        monthDay: formData.recurrenceMonthDay,
+        endDate: formData.recurrenceEndDate,
+      }) ?? null;
+
+    const request: CreateEventRequest = {
+      title: formData.title,
+      startTime: format24hTo12h(formData.startTime),
+      endTime: format24hTo12h(formData.endTime),
+      date: formData.date,
+      endDate: formData.endDate ?? null,
+      memberId: formData.memberId,
+      isAllDay: formData.isAllDay,
+      location: formData.location,
+      recurrenceRule,
     };
     createEvent.mutate(request);
   };
@@ -280,10 +395,14 @@ export function CalendarModule() {
       <EventFormModal
         mode="edit"
         isOpen={isEditModalOpen}
-        onClose={closeEditModal}
+        onClose={() => {
+          closeEditModal();
+          setEditScope(null);
+        }}
         onSubmit={handleUpdateEvent}
-        isPending={updateEvent.isPending}
+        isPending={updateEvent.isPending || updateInstance.isPending}
         event={editingEvent ?? undefined}
+        showRecurrencePicker={editScope !== "this"}
       />
 
       {/* Event Detail Modal */}
@@ -293,8 +412,18 @@ export function CalendarModule() {
         onClose={closeDetailModal}
         onEdit={handleEditClick}
         onDelete={handleDeleteEvent}
-        isDeleting={deleteEvent.isPending}
-        deleteError={deleteEvent.error?.message}
+        isDeleting={deleteEvent.isPending || deleteInstance.isPending}
+        deleteError={
+          deleteEvent.error?.message ?? deleteInstance.error?.message
+        }
+      />
+
+      {/* Scope Dialog for Recurring Events */}
+      <EditScopeDialog
+        isOpen={scopeDialogOpen}
+        onClose={closeScopeDialog}
+        onSelect={handleScopeSelect}
+        action={scopeAction}
       />
     </div>
   );

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -258,7 +258,7 @@ export function CalendarModule() {
       const parentId = getParentId(currentEditingEvent);
       updateInstance.mutate({
         parentId,
-        date: formatLocalDate(currentEditingEvent.date),
+        instanceDate: formatLocalDate(currentEditingEvent.date),
         ...request,
       });
     } else if (currentEditingEvent.isRecurring && editScope === "all") {

--- a/src/components/calendar/components/calendar-event.tsx
+++ b/src/components/calendar/components/calendar-event.tsx
@@ -1,3 +1,4 @@
+import { Repeat } from "lucide-react";
 import { useFamilyMembers } from "@/api";
 import type { CalendarEvent } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
@@ -44,6 +45,9 @@ export function CalendarEventCard({
               {event.isAllDay
                 ? "All day"
                 : `${event.startTime} - ${event.endTime}`}
+              {event.isRecurring && (
+                <Repeat className="w-3 h-3 inline-block ml-1.5 -mt-0.5" />
+              )}
             </p>
             {event.location && (
               <p className="text-sm text-muted-foreground truncate mt-1">
@@ -116,9 +120,14 @@ export function CalendarEventCard({
             </p>
           )}
         </div>
-        <div
-          className={cn("w-2.5 h-2.5 rounded-full shrink-0 mt-1", colors?.bg)}
-        />
+        <div className="flex items-center gap-1 shrink-0 mt-1">
+          {event.isRecurring && (
+            <Repeat
+              className={cn("w-3 h-3", colors?.text || "text-muted-foreground")}
+            />
+          )}
+          <div className={cn("w-2.5 h-2.5 rounded-full", colors?.bg)} />
+        </div>
       </div>
     </button>
   );

--- a/src/components/calendar/components/edit-scope-dialog.test.tsx
+++ b/src/components/calendar/components/edit-scope-dialog.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { EditScopeDialog } from "./edit-scope-dialog";
+
+describe("EditScopeDialog", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSelect: vi.fn(),
+    action: "edit" as const,
+  };
+
+  it("renders edit title and scope options", () => {
+    renderWithUser(<EditScopeDialog {...defaultProps} />);
+
+    expect(screen.getByText("Edit recurring event")).toBeInTheDocument();
+    expect(screen.getByLabelText("This event")).toBeInTheDocument();
+    expect(screen.getByLabelText("All events")).toBeInTheDocument();
+  });
+
+  it("renders delete title when action is delete", () => {
+    renderWithUser(<EditScopeDialog {...defaultProps} action="delete" />);
+
+    expect(screen.getByText("Delete recurring event")).toBeInTheDocument();
+  });
+
+  it("defaults to 'this' scope", () => {
+    renderWithUser(<EditScopeDialog {...defaultProps} />);
+
+    const thisRadio = screen.getByLabelText("This event");
+    expect(thisRadio).toBeChecked();
+  });
+
+  it("calls onSelect with chosen scope when OK clicked", async () => {
+    const onSelect = vi.fn();
+    const { user } = renderWithUser(
+      <EditScopeDialog {...defaultProps} onSelect={onSelect} />,
+    );
+
+    await user.click(screen.getByLabelText("All events"));
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(onSelect).toHaveBeenCalledWith("all");
+  });
+
+  it("calls onClose when Cancel clicked", async () => {
+    const onClose = vi.fn();
+    const { user } = renderWithUser(
+      <EditScopeDialog {...defaultProps} onClose={onClose} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/calendar/components/edit-scope-dialog.tsx
+++ b/src/components/calendar/components/edit-scope-dialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,6 +24,10 @@ function EditScopeDialog({
   action,
 }: EditScopeDialogProps) {
   const [scope, setScope] = useState<EditScope>("this");
+
+  useEffect(() => {
+    if (isOpen) setScope("this");
+  }, [isOpen]);
 
   const title =
     action === "edit" ? "Edit recurring event" : "Delete recurring event";

--- a/src/components/calendar/components/edit-scope-dialog.tsx
+++ b/src/components/calendar/components/edit-scope-dialog.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export type EditScope = "this" | "all";
+
+interface EditScopeDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (scope: EditScope) => void;
+  action: "edit" | "delete";
+}
+
+function EditScopeDialog({
+  isOpen,
+  onClose,
+  onSelect,
+  action,
+}: EditScopeDialogProps) {
+  const [scope, setScope] = useState<EditScope>("this");
+
+  const title =
+    action === "edit" ? "Edit recurring event" : "Delete recurring event";
+
+  const handleConfirm = () => {
+    onSelect(scope);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent aria-describedby={undefined}>
+        <DialogHeader onClose={onClose}>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 py-2">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              name="edit-scope"
+              value="this"
+              checked={scope === "this"}
+              onChange={() => setScope("this")}
+              className="accent-primary"
+            />
+            <span className="text-sm">This event</span>
+          </label>
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="radio"
+              name="edit-scope"
+              value="all"
+              checked={scope === "all"}
+              onChange={() => setScope("all")}
+              className="accent-primary"
+            />
+            <span className="text-sm">All events</span>
+          </label>
+        </div>
+
+        <DialogFooter>
+          <div className="flex gap-3 w-full">
+            <Button
+              variant="outline"
+              onClick={onClose}
+              className="flex-1 min-h-[48px]"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              className="flex-1 min-h-[48px]"
+              variant={action === "delete" ? "destructive" : "default"}
+            >
+              OK
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { EditScopeDialog };
+export type { EditScopeDialogProps };

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -1,5 +1,13 @@
 import { format } from "date-fns";
-import { Calendar, Clock, Loader2, MapPin, Pencil, Trash2 } from "lucide-react";
+import {
+  Calendar,
+  Clock,
+  Loader2,
+  MapPin,
+  Pencil,
+  Repeat,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { useFamilyMembers } from "@/api";
 import { Button } from "@/components/ui/button";
@@ -10,6 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { formatRecurrenceLabel } from "@/lib/recurrence-utils";
 import type { CalendarEvent } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -109,6 +118,18 @@ function EventDetailModal({
                 </span>
               )}
             </div>
+
+            {/* Recurrence (conditional) */}
+            {event.isRecurring && (
+              <div className="flex items-center gap-3 text-muted-foreground">
+                <Repeat className="w-4 h-4 shrink-0" />
+                <span>
+                  {event.recurrenceRule
+                    ? formatRecurrenceLabel(event.recurrenceRule, event.date)
+                    : "Recurring event"}
+                </span>
+              </div>
+            )}
 
             {/* Location (conditional) */}
             {event.location && (

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -4,6 +4,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { parseRRule } from "@/lib/recurrence-utils";
 import { format12hTo24h, formatLocalDate } from "@/lib/time-utils";
 import type { CalendarEvent } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
@@ -17,6 +18,7 @@ interface EventFormModalProps {
   isPending?: boolean;
   /** For edit mode: the event to pre-populate the form with */
   event?: CalendarEvent;
+  showRecurrencePicker?: boolean;
 }
 
 /**
@@ -24,7 +26,7 @@ interface EventFormModalProps {
  * Handles date formatting and time conversion (12h -> 24h)
  */
 function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
-  return {
+  const base: Partial<EventFormData> = {
     title: event.title,
     date: formatLocalDate(event.date),
     endDate: event.endDate ? formatLocalDate(event.endDate) : undefined,
@@ -34,6 +36,17 @@ function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
     location: event.location ?? undefined,
     isAllDay: event.isAllDay,
   };
+
+  if (event.recurrenceRule) {
+    const recurrence = parseRRule(event.recurrenceRule);
+    base.recurrenceFrequency = recurrence.frequency;
+    base.recurrenceInterval = recurrence.interval;
+    base.recurrenceWeeklyDays = recurrence.weeklyDays;
+    base.recurrenceMonthDay = recurrence.monthDay;
+    base.recurrenceEndDate = recurrence.endDate;
+  }
+
+  return base;
 }
 
 function EventFormModal({
@@ -43,6 +56,7 @@ function EventFormModal({
   onSubmit,
   isPending = false,
   event,
+  showRecurrencePicker,
 }: EventFormModalProps) {
   const title = mode === "add" ? "Add Event" : "Edit Event";
 
@@ -61,6 +75,7 @@ function EventFormModal({
           onSubmit={onSubmit}
           onCancel={onClose}
           isPending={isPending}
+          showRecurrencePicker={showRecurrencePicker}
         />
       </DialogContent>
     </Dialog>

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -534,7 +534,8 @@ describe("EventForm", () => {
             isAllDay: true,
             startTime: "00:00",
             endTime: "23:59",
-            endDate: "2026-03-12",
+            date: "2026-12-20",
+            endDate: "2026-12-25",
           }}
           onSubmit={mockOnSubmit}
           onCancel={mockOnCancel}
@@ -576,7 +577,8 @@ describe("EventForm", () => {
             isAllDay: true,
             startTime: "00:00",
             endTime: "23:59",
-            endDate: "2026-03-12",
+            date: "2026-12-20",
+            endDate: "2026-12-25",
           }}
           onSubmit={mockOnSubmit}
           onCancel={mockOnCancel}
@@ -595,7 +597,7 @@ describe("EventForm", () => {
             expect.objectContaining({
               title: "Family Vacation",
               isAllDay: true,
-              endDate: "2026-03-12",
+              endDate: "2026-12-25",
             }),
           );
         },

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -10,9 +10,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MemberSelector } from "@/components/ui/member-selector";
 import { TimePicker } from "@/components/ui/time-picker";
+import type { RecurrenceFrequency } from "@/lib/recurrence-utils";
 import { getSmartDefaultTimes, parseLocalDate } from "@/lib/time-utils";
 import { cn } from "@/lib/utils";
 import { type EventFormData, eventFormSchema } from "@/lib/validations";
+import { RecurrencePicker } from "./recurrence-picker";
 
 interface EventFormProps {
   mode: "add" | "edit";
@@ -20,6 +22,7 @@ interface EventFormProps {
   onSubmit: (data: EventFormData) => void;
   onCancel: () => void;
   isPending?: boolean;
+  showRecurrencePicker?: boolean;
 }
 
 function EventForm({
@@ -28,6 +31,7 @@ function EventForm({
   onSubmit,
   onCancel,
   isPending = false,
+  showRecurrencePicker = true,
 }: EventFormProps) {
   const familyMembers = useFamilyMembers();
 
@@ -77,6 +81,11 @@ function EventForm({
   const endTimeValue = watch("endTime");
   const memberIdValue = watch("memberId");
   const isAllDayValue = watch("isAllDay");
+  const recurrenceFrequency = watch("recurrenceFrequency");
+  const recurrenceInterval = watch("recurrenceInterval");
+  const recurrenceWeeklyDays = watch("recurrenceWeeklyDays");
+  const recurrenceMonthDay = watch("recurrenceMonthDay");
+  const recurrenceEndDate = watch("recurrenceEndDate");
 
   // Reset form when defaultValues change (e.g., switching between events in edit mode)
   useEffect(() => {
@@ -143,6 +152,25 @@ function EventForm({
         />
         <FormError message={errors.date?.message} />
       </div>
+
+      {/* Recurrence Picker */}
+      {showRecurrencePicker && dateValue && (
+        <RecurrencePicker
+          frequency={(recurrenceFrequency as RecurrenceFrequency) ?? "none"}
+          interval={recurrenceInterval ?? 1}
+          weeklyDays={recurrenceWeeklyDays}
+          monthDay={recurrenceMonthDay}
+          endDate={recurrenceEndDate}
+          eventDate={dateValue}
+          onChange={(updates) => {
+            setValue("recurrenceFrequency", updates.frequency);
+            setValue("recurrenceInterval", updates.interval);
+            setValue("recurrenceWeeklyDays", updates.weeklyDays);
+            setValue("recurrenceMonthDay", updates.monthDay);
+            setValue("recurrenceEndDate", updates.endDate);
+          }}
+        />
+      )}
 
       {/* All Day Toggle */}
       <div className="flex items-center gap-3">

--- a/src/components/calendar/components/index.ts
+++ b/src/components/calendar/components/index.ts
@@ -10,3 +10,4 @@ export { EventDetailModal } from "./event-detail-modal";
 export { EventForm } from "./event-form";
 export { EventFormModal } from "./event-form-modal";
 export { FamilyFilterPills } from "./family-filter-pills";
+export { RecurrencePicker } from "./recurrence-picker";

--- a/src/components/calendar/components/index.ts
+++ b/src/components/calendar/components/index.ts
@@ -6,6 +6,8 @@ export { CalendarFilter } from "./calendar-filter";
 export { CalendarNavigation } from "./calendar-navigation";
 export { CalendarViewSwitcher } from "./calendar-view-switcher";
 export { CurrentTimeIndicator } from "./current-time-indicator";
+export type { EditScope } from "./edit-scope-dialog";
+export { EditScopeDialog } from "./edit-scope-dialog";
 export { EventDetailModal } from "./event-detail-modal";
 export { EventForm } from "./event-form";
 export { EventFormModal } from "./event-form-modal";

--- a/src/components/calendar/components/recurrence-picker.test.tsx
+++ b/src/components/calendar/components/recurrence-picker.test.tsx
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { RecurrencePicker } from "./recurrence-picker";
+
+const render = (ui: React.ReactElement) => renderWithUser(ui);
+
+describe("RecurrencePicker", () => {
+  const defaultProps = {
+    frequency: "none" as const,
+    interval: 1,
+    eventDate: "2026-03-11", // Wednesday
+    onChange: vi.fn(),
+  };
+
+  it("renders frequency dropdown with correct options", () => {
+    render(<RecurrencePicker {...defaultProps} />);
+
+    const select = screen.getByRole("combobox");
+    expect(select).toBeInTheDocument();
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(5);
+    expect(options[0]).toHaveTextContent("Does not repeat");
+    expect(options[1]).toHaveTextContent("Daily");
+    expect(options[2]).toHaveTextContent("Weekly on Wednesday");
+    expect(options[3]).toHaveTextContent("Weekly on custom days...");
+    expect(options[4]).toHaveTextContent("Monthly on the 11th");
+  });
+
+  it("updates day name when eventDate changes", () => {
+    render(<RecurrencePicker {...defaultProps} eventDate="2026-03-13" />);
+    // March 13 2026 is a Friday
+    expect(screen.getByText(/Weekly on Friday/)).toBeInTheDocument();
+  });
+
+  it("does not show day toggles or interval when none selected", () => {
+    render(<RecurrencePicker {...defaultProps} />);
+    expect(screen.queryByLabelText("MO")).not.toBeInTheDocument();
+    expect(screen.queryByText("Every")).not.toBeInTheDocument();
+  });
+
+  it("shows interval and end date controls when daily selected", () => {
+    render(<RecurrencePicker {...defaultProps} frequency="daily" />);
+    expect(screen.getByText("Every")).toBeInTheDocument();
+    expect(screen.getByText("Ends")).toBeInTheDocument();
+    expect(screen.getByLabelText("Never")).toBeInTheDocument();
+    expect(screen.getByLabelText("On date")).toBeInTheDocument();
+  });
+
+  it("shows day toggles when weekly-custom is active", () => {
+    render(
+      <RecurrencePicker
+        {...defaultProps}
+        frequency="weekly"
+        weeklyDays={["TU", "TH"]}
+      />,
+    );
+    expect(screen.getByLabelText("MO")).toBeInTheDocument();
+    expect(screen.getByLabelText("TU")).toBeInTheDocument();
+    // TU and TH should be pressed
+    expect(screen.getByLabelText("TU")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("TH")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByLabelText("MO")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("calls onChange when day toggle is clicked", async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <RecurrencePicker
+        {...defaultProps}
+        frequency="weekly"
+        weeklyDays={["TU"]}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("FR"));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frequency: "weekly",
+        weeklyDays: ["TU", "FR"],
+      }),
+    );
+  });
+
+  it("shows end date picker when 'On date' is selected", async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <RecurrencePicker
+        {...defaultProps}
+        frequency="daily"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("On date"));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endDate: "2026-03-11", // defaults to eventDate
+      }),
+    );
+  });
+
+  it("shows date picker when endDate is set", () => {
+    render(
+      <RecurrencePicker
+        {...defaultProps}
+        frequency="daily"
+        endDate="2026-06-15"
+      />,
+    );
+    // The DatePicker renders the formatted date as a button
+    expect(screen.getByText("June 15th, 2026")).toBeInTheDocument();
+  });
+
+  it("clears endDate when 'Never' is selected", async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <RecurrencePicker
+        {...defaultProps}
+        frequency="daily"
+        endDate="2026-06-15"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText("Never"));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endDate: undefined,
+      }),
+    );
+  });
+});

--- a/src/components/calendar/components/recurrence-picker.tsx
+++ b/src/components/calendar/components/recurrence-picker.tsx
@@ -1,8 +1,12 @@
 import { format } from "date-fns";
+import { useState } from "react";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Label } from "@/components/ui/label";
-import type { RecurrenceFrequency } from "@/lib/recurrence-utils";
-import { parseLocalDate } from "@/lib/time-utils";
+import {
+  getOrdinalSuffix,
+  type RecurrenceFrequency,
+} from "@/lib/recurrence-utils";
+import { formatLocalDate, parseLocalDate } from "@/lib/time-utils";
 import { cn } from "@/lib/utils";
 
 const DAY_BUTTONS = [
@@ -51,16 +55,6 @@ function getEventMonthDay(dateStr: string): number {
   return parseLocalDate(dateStr).getDate();
 }
 
-function getOrdinalSuffix(n: number): string {
-  const lastTwo = n % 100;
-  if (lastTwo >= 11 && lastTwo <= 13) return `${n}th`;
-  const lastOne = n % 10;
-  if (lastOne === 1) return `${n}st`;
-  if (lastOne === 2) return `${n}nd`;
-  if (lastOne === 3) return `${n}rd`;
-  return `${n}th`;
-}
-
 function deriveOption(
   frequency: RecurrenceFrequency,
   weeklyDays?: string[],
@@ -92,10 +86,17 @@ function RecurrencePicker({
   eventDate,
   onChange,
 }: RecurrencePickerProps) {
-  const selectedOption = deriveOption(frequency, weeklyDays, eventDate);
+  // Track when user explicitly picks "weekly-custom" — deriveOption can't
+  // distinguish it from "weekly-on-day" when only the event's day is selected.
+  const [forceCustom, setForceCustom] = useState(false);
+  const selectedOption =
+    forceCustom && frequency === "weekly"
+      ? "weekly-custom"
+      : deriveOption(frequency, weeklyDays, eventDate);
   const isRepeating = frequency !== "none";
 
   const handleOptionChange = (option: RecurrenceOption) => {
+    setForceCustom(option === "weekly-custom");
     switch (option) {
       case "none":
         onChange({
@@ -310,7 +311,7 @@ function RecurrencePicker({
                   interval,
                   weeklyDays,
                   monthDay,
-                  endDate: date ? format(date, "yyyy-MM-dd") : undefined,
+                  endDate: date ? formatLocalDate(date) : undefined,
                 });
               }}
               placeholder="Pick end date"

--- a/src/components/calendar/components/recurrence-picker.tsx
+++ b/src/components/calendar/components/recurrence-picker.tsx
@@ -1,0 +1,327 @@
+import { format } from "date-fns";
+import { DatePicker } from "@/components/ui/date-picker";
+import { Label } from "@/components/ui/label";
+import type { RecurrenceFrequency } from "@/lib/recurrence-utils";
+import { parseLocalDate } from "@/lib/time-utils";
+import { cn } from "@/lib/utils";
+
+const DAY_BUTTONS = [
+  { key: "MO", label: "M" },
+  { key: "TU", label: "T" },
+  { key: "WE", label: "W" },
+  { key: "TH", label: "T" },
+  { key: "FR", label: "F" },
+  { key: "SA", label: "S" },
+  { key: "SU", label: "S" },
+] as const;
+
+type RecurrenceOption =
+  | "none"
+  | "daily"
+  | "weekly-on-day"
+  | "weekly-custom"
+  | "monthly";
+
+interface RecurrencePickerProps {
+  frequency: RecurrenceFrequency;
+  interval: number;
+  weeklyDays?: string[];
+  monthDay?: number;
+  endDate?: string;
+  eventDate: string; // yyyy-MM-dd — used to derive day name
+  onChange: (updates: {
+    frequency: RecurrenceFrequency;
+    interval: number;
+    weeklyDays?: string[];
+    monthDay?: number;
+    endDate?: string;
+  }) => void;
+}
+
+function getEventDayAbbr(dateStr: string): string {
+  const date = parseLocalDate(dateStr);
+  return format(date, "EEEEEE").toUpperCase().slice(0, 2);
+}
+
+function getEventDayName(dateStr: string): string {
+  return format(parseLocalDate(dateStr), "EEEE");
+}
+
+function getEventMonthDay(dateStr: string): number {
+  return parseLocalDate(dateStr).getDate();
+}
+
+function getOrdinalSuffix(n: number): string {
+  const lastTwo = n % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) return `${n}th`;
+  const lastOne = n % 10;
+  if (lastOne === 1) return `${n}st`;
+  if (lastOne === 2) return `${n}nd`;
+  if (lastOne === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+function deriveOption(
+  frequency: RecurrenceFrequency,
+  weeklyDays?: string[],
+  eventDate?: string,
+): RecurrenceOption {
+  if (frequency === "none") return "none";
+  if (frequency === "daily") return "daily";
+  if (frequency === "monthly") return "monthly";
+  if (frequency === "weekly") {
+    if (!weeklyDays || weeklyDays.length === 0) return "weekly-on-day";
+    if (
+      eventDate &&
+      weeklyDays.length === 1 &&
+      weeklyDays[0] === getEventDayAbbr(eventDate)
+    ) {
+      return "weekly-on-day";
+    }
+    return "weekly-custom";
+  }
+  return "none";
+}
+
+function RecurrencePicker({
+  frequency,
+  interval,
+  weeklyDays,
+  monthDay,
+  endDate,
+  eventDate,
+  onChange,
+}: RecurrencePickerProps) {
+  const selectedOption = deriveOption(frequency, weeklyDays, eventDate);
+  const isRepeating = frequency !== "none";
+
+  const handleOptionChange = (option: RecurrenceOption) => {
+    switch (option) {
+      case "none":
+        onChange({
+          frequency: "none",
+          interval: 1,
+          weeklyDays: undefined,
+          monthDay: undefined,
+          endDate: undefined,
+        });
+        break;
+      case "daily":
+        onChange({
+          frequency: "daily",
+          interval,
+          weeklyDays: undefined,
+          monthDay: undefined,
+          endDate,
+        });
+        break;
+      case "weekly-on-day":
+        onChange({
+          frequency: "weekly",
+          interval,
+          weeklyDays: [getEventDayAbbr(eventDate)],
+          monthDay: undefined,
+          endDate,
+        });
+        break;
+      case "weekly-custom":
+        onChange({
+          frequency: "weekly",
+          interval,
+          weeklyDays: weeklyDays?.length
+            ? weeklyDays
+            : [getEventDayAbbr(eventDate)],
+          monthDay: undefined,
+          endDate,
+        });
+        break;
+      case "monthly":
+        onChange({
+          frequency: "monthly",
+          interval,
+          weeklyDays: undefined,
+          monthDay: monthDay || getEventMonthDay(eventDate),
+          endDate,
+        });
+        break;
+    }
+  };
+
+  const toggleDay = (day: string) => {
+    const current = weeklyDays ?? [];
+    const next = current.includes(day)
+      ? current.filter((d) => d !== day)
+      : [...current, day];
+    onChange({
+      frequency: "weekly",
+      interval,
+      weeklyDays: next.length > 0 ? next : undefined,
+      monthDay: undefined,
+      endDate,
+    });
+  };
+
+  const endDateAsDate = endDate ? parseLocalDate(endDate) : undefined;
+
+  return (
+    <div className="space-y-3">
+      {/* Frequency dropdown */}
+      <div className="space-y-2">
+        <Label>Repeat</Label>
+        <select
+          value={selectedOption}
+          onChange={(e) =>
+            handleOptionChange(e.target.value as RecurrenceOption)
+          }
+          className="flex h-10 w-full rounded-md border border-input bg-input px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <option value="none">Does not repeat</option>
+          <option value="daily">Daily</option>
+          <option value="weekly-on-day">
+            Weekly on {getEventDayName(eventDate)}
+          </option>
+          <option value="weekly-custom">Weekly on custom days...</option>
+          <option value="monthly">
+            Monthly on the {getOrdinalSuffix(getEventMonthDay(eventDate))}
+          </option>
+        </select>
+      </div>
+
+      {/* Day-of-week toggles for custom weekly */}
+      {selectedOption === "weekly-custom" && (
+        <div className="space-y-2">
+          <Label className="text-xs text-muted-foreground">Repeat on</Label>
+          <div className="flex gap-1.5">
+            {DAY_BUTTONS.map(({ key, label }) => {
+              const isSelected = weeklyDays?.includes(key) ?? false;
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => toggleDay(key)}
+                  className={cn(
+                    "w-9 h-9 rounded-full text-sm font-medium transition-colors",
+                    isSelected
+                      ? "bg-primary text-white"
+                      : "bg-muted text-muted-foreground hover:bg-muted/80",
+                  )}
+                  aria-label={key}
+                  aria-pressed={isSelected}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Interval selector */}
+      {isRepeating && (
+        <div className="flex items-center gap-2">
+          <Label className="text-xs text-muted-foreground shrink-0">
+            Every
+          </Label>
+          <input
+            type="number"
+            min={1}
+            max={99}
+            value={interval}
+            onChange={(e) => {
+              const val = Math.max(1, Number.parseInt(e.target.value, 10) || 1);
+              onChange({
+                frequency,
+                interval: val,
+                weeklyDays,
+                monthDay,
+                endDate,
+              });
+            }}
+            className="w-16 h-8 rounded-md border border-input bg-input px-2 text-sm text-center"
+          />
+          <span className="text-xs text-muted-foreground">
+            {frequency === "daily"
+              ? interval === 1
+                ? "day"
+                : "days"
+              : frequency === "weekly"
+                ? interval === 1
+                  ? "week"
+                  : "weeks"
+                : interval === 1
+                  ? "month"
+                  : "months"}
+          </span>
+        </div>
+      )}
+
+      {/* End date */}
+      {isRepeating && (
+        <div className="space-y-2">
+          <div className="flex items-center gap-4">
+            <Label className="text-xs text-muted-foreground">Ends</Label>
+            <div className="flex items-center gap-3">
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="recurrence-end"
+                  checked={!endDate}
+                  onChange={() =>
+                    onChange({
+                      frequency,
+                      interval,
+                      weeklyDays,
+                      monthDay,
+                      endDate: undefined,
+                    })
+                  }
+                  className="accent-primary"
+                />
+                Never
+              </label>
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="radio"
+                  name="recurrence-end"
+                  checked={!!endDate}
+                  onChange={() => {
+                    if (!endDate) {
+                      onChange({
+                        frequency,
+                        interval,
+                        weeklyDays,
+                        monthDay,
+                        endDate: eventDate,
+                      });
+                    }
+                  }}
+                  className="accent-primary"
+                />
+                On date
+              </label>
+            </div>
+          </div>
+          {endDate && (
+            <DatePicker
+              value={endDateAsDate}
+              onChange={(date) => {
+                onChange({
+                  frequency,
+                  interval,
+                  weeklyDays,
+                  monthDay,
+                  endDate: date ? format(date, "yyyy-MM-dd") : undefined,
+                });
+              }}
+              placeholder="Pick end date"
+              fromDate={parseLocalDate(eventDate)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { RecurrencePicker };
+export type { RecurrencePickerProps };

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -3,6 +3,7 @@ import { useFamilyMembers } from "@/api";
 import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
+  getEventKey,
   getTimeInMinutes,
   isEventOnDate,
   parseTime,
@@ -250,7 +251,7 @@ export function DailyCalendar({
               return (
                 <button
                   type="button"
-                  key={event.id}
+                  key={getEventKey(event)}
                   onClick={() => onEventClick?.(event)}
                   title={event.title}
                   aria-label={`${event.title} - All day event`}
@@ -324,7 +325,7 @@ export function DailyCalendar({
 
             return (
               <div
-                key={event.id}
+                key={getEventKey(event)}
                 className="absolute overflow-hidden rounded-xl"
                 style={{
                   top: `${top}px`,

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from "react";
 import { useFamilyMembers } from "@/api";
 import { useIsMobile } from "@/hooks";
-import { compareEventsAllDayFirst, isEventOnDate } from "@/lib/time-utils";
+import {
+  compareEventsAllDayFirst,
+  getEventKey,
+  isEventOnDate,
+} from "@/lib/time-utils";
 import {
   type CalendarEvent,
   colorMap,
@@ -221,7 +225,7 @@ export function MonthlyCalendar({
                   return (
                     <button
                       type="button"
-                      key={event.id}
+                      key={getEventKey(event)}
                       onClick={(e) => {
                         e.stopPropagation();
                         onEventClick?.(event);

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -5,6 +5,7 @@ import { useFamilyMembers } from "@/api";
 import {
   compareEventsAllDayFirst,
   formatLocalDate,
+  getEventKey,
   isEventOnDate,
 } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
@@ -122,7 +123,7 @@ export function ScheduleCalendar({
                   return (
                     <button
                       type="button"
-                      key={event.id}
+                      key={getEventKey(event)}
                       onClick={() => onEventClick?.(event)}
                       className={cn(
                         "flex flex-col p-3 rounded-lg cursor-pointer text-left w-full",

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -3,6 +3,7 @@ import { useFamilyMembers } from "@/api";
 import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
+  getEventKey,
   isEventOnDate,
   parseTime,
 } from "@/lib/time-utils";
@@ -283,7 +284,7 @@ export function WeeklyCalendar({
                   return (
                     <button
                       type="button"
-                      key={event.id}
+                      key={getEventKey(event)}
                       onClick={() => onEventClick?.(event)}
                       title={event.title}
                       aria-label={`${event.title} - All day event`}
@@ -354,7 +355,7 @@ export function WeeklyCalendar({
                       );
                       return (
                         <div
-                          key={event.id}
+                          key={getEventKey(event)}
                           className="absolute left-0.5 right-0.5 overflow-hidden rounded-xl"
                           style={{ top: `${top}px`, height: `${height}px` }}
                         >

--- a/src/lib/recurrence-utils.test.ts
+++ b/src/lib/recurrence-utils.test.ts
@@ -14,7 +14,7 @@ describe("recurrence-utils", () => {
 
     it("builds daily RRULE", () => {
       expect(buildRRule({ frequency: "daily", interval: 1 })).toBe(
-        "RRULE:FREQ=DAILY",
+        "FREQ=DAILY",
       );
     });
 
@@ -25,7 +25,7 @@ describe("recurrence-utils", () => {
           interval: 1,
           weeklyDays: ["TU", "TH", "FR"],
         }),
-      ).toBe("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR");
+      ).toBe("FREQ=WEEKLY;BYDAY=TU,TH,FR");
     });
 
     it("sorts weekly days in standard order", () => {
@@ -35,24 +35,24 @@ describe("recurrence-utils", () => {
           interval: 1,
           weeklyDays: ["FR", "MO", "WE"],
         }),
-      ).toBe("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR");
+      ).toBe("FREQ=WEEKLY;BYDAY=MO,WE,FR");
     });
 
     it("builds weekly RRULE without explicit days", () => {
       expect(buildRRule({ frequency: "weekly", interval: 1 })).toBe(
-        "RRULE:FREQ=WEEKLY",
+        "FREQ=WEEKLY",
       );
     });
 
     it("builds monthly RRULE with day of month", () => {
       expect(
         buildRRule({ frequency: "monthly", interval: 1, monthDay: 15 }),
-      ).toBe("RRULE:FREQ=MONTHLY;BYMONTHDAY=15");
+      ).toBe("FREQ=MONTHLY;BYMONTHDAY=15");
     });
 
     it("includes INTERVAL when > 1", () => {
       expect(buildRRule({ frequency: "daily", interval: 3 })).toBe(
-        "RRULE:FREQ=DAILY;INTERVAL=3",
+        "FREQ=DAILY;INTERVAL=3",
       );
     });
 
@@ -68,7 +68,7 @@ describe("recurrence-utils", () => {
           interval: 1,
           endDate: "2026-08-15",
         }),
-      ).toBe("RRULE:FREQ=DAILY;UNTIL=20260815");
+      ).toBe("FREQ=DAILY;UNTIL=20260815");
     });
 
     it("combines interval, days, and until", () => {
@@ -79,13 +79,13 @@ describe("recurrence-utils", () => {
           weeklyDays: ["MO", "FR"],
           endDate: "2026-06-15",
         }),
-      ).toBe("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR;UNTIL=20260615");
+      ).toBe("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR;UNTIL=20260615");
     });
   });
 
   describe("parseRRule", () => {
     it("parses daily RRULE", () => {
-      const result = parseRRule("RRULE:FREQ=DAILY");
+      const result = parseRRule("FREQ=DAILY");
       expect(result).toEqual({
         frequency: "daily",
         interval: 1,
@@ -96,34 +96,34 @@ describe("recurrence-utils", () => {
     });
 
     it("parses weekly RRULE with days", () => {
-      const result = parseRRule("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR");
+      const result = parseRRule("FREQ=WEEKLY;BYDAY=TU,TH,FR");
       expect(result.frequency).toBe("weekly");
       expect(result.weeklyDays).toEqual(["TU", "TH", "FR"]);
     });
 
     it("parses monthly RRULE with BYMONTHDAY", () => {
-      const result = parseRRule("RRULE:FREQ=MONTHLY;BYMONTHDAY=15");
+      const result = parseRRule("FREQ=MONTHLY;BYMONTHDAY=15");
       expect(result.frequency).toBe("monthly");
       expect(result.monthDay).toBe(15);
     });
 
     it("parses INTERVAL", () => {
-      const result = parseRRule("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO");
+      const result = parseRRule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO");
       expect(result.interval).toBe(2);
     });
 
     it("defaults interval to 1 when not present", () => {
-      const result = parseRRule("RRULE:FREQ=DAILY");
+      const result = parseRRule("FREQ=DAILY");
       expect(result.interval).toBe(1);
     });
 
     it("parses UNTIL to yyyy-MM-dd", () => {
-      const result = parseRRule("RRULE:FREQ=DAILY;UNTIL=20260815");
+      const result = parseRRule("FREQ=DAILY;UNTIL=20260815");
       expect(result.endDate).toBe("2026-08-15");
     });
 
     it('returns frequency "none" for unknown FREQ', () => {
-      const result = parseRRule("RRULE:FREQ=YEARLY");
+      const result = parseRRule("FREQ=YEARLY");
       expect(result.frequency).toBe("none");
     });
   });
@@ -156,71 +156,71 @@ describe("recurrence-utils", () => {
     const date = new Date(2026, 2, 11); // Wednesday March 11, 2026
 
     it("formats daily", () => {
-      expect(formatRecurrenceLabel("RRULE:FREQ=DAILY", date)).toBe("Daily");
+      expect(formatRecurrenceLabel("FREQ=DAILY", date)).toBe("Daily");
     });
 
     it("formats daily with interval", () => {
-      expect(formatRecurrenceLabel("RRULE:FREQ=DAILY;INTERVAL=3", date)).toBe(
+      expect(formatRecurrenceLabel("FREQ=DAILY;INTERVAL=3", date)).toBe(
         "Every 3 days",
       );
     });
 
     it("formats weekly with specific days", () => {
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR", date),
-      ).toBe("Weekly on Tue, Thu, Fri");
+      expect(formatRecurrenceLabel("FREQ=WEEKLY;BYDAY=TU,TH,FR", date)).toBe(
+        "Weekly on Tue, Thu, Fri",
+      );
     });
 
     it("formats weekly without days (uses event date)", () => {
-      expect(formatRecurrenceLabel("RRULE:FREQ=WEEKLY", date)).toBe(
+      expect(formatRecurrenceLabel("FREQ=WEEKLY", date)).toBe(
         "Weekly on Wednesday",
       );
     });
 
     it("formats weekly with interval", () => {
       expect(
-        formatRecurrenceLabel("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", date),
+        formatRecurrenceLabel("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", date),
       ).toBe("Every 2 weeks on Mon");
     });
 
     it("formats monthly with BYMONTHDAY", () => {
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=15", date),
-      ).toBe("Monthly on the 15th");
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=15", date)).toBe(
+        "Monthly on the 15th",
+      );
     });
 
     it("formats monthly without BYMONTHDAY (uses event date)", () => {
-      expect(formatRecurrenceLabel("RRULE:FREQ=MONTHLY", date)).toBe(
+      expect(formatRecurrenceLabel("FREQ=MONTHLY", date)).toBe(
         "Monthly on the 11th",
       );
     });
 
     it("formats ordinal suffixes correctly", () => {
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=1", date),
-      ).toBe("Monthly on the 1st");
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=2", date),
-      ).toBe("Monthly on the 2nd");
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=3", date),
-      ).toBe("Monthly on the 3rd");
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=11", date),
-      ).toBe("Monthly on the 11th");
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=21", date),
-      ).toBe("Monthly on the 21st");
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=1", date)).toBe(
+        "Monthly on the 1st",
+      );
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=2", date)).toBe(
+        "Monthly on the 2nd",
+      );
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=3", date)).toBe(
+        "Monthly on the 3rd",
+      );
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=11", date)).toBe(
+        "Monthly on the 11th",
+      );
+      expect(formatRecurrenceLabel("FREQ=MONTHLY;BYMONTHDAY=21", date)).toBe(
+        "Monthly on the 21st",
+      );
     });
 
     it("appends until date", () => {
-      expect(
-        formatRecurrenceLabel("RRULE:FREQ=DAILY;UNTIL=20260615", date),
-      ).toBe("Daily until Jun 15, 2026");
+      expect(formatRecurrenceLabel("FREQ=DAILY;UNTIL=20260615", date)).toBe(
+        "Daily until Jun 15, 2026",
+      );
     });
 
     it('returns "Does not repeat" for unknown frequency', () => {
-      expect(formatRecurrenceLabel("RRULE:FREQ=YEARLY", date)).toBe(
+      expect(formatRecurrenceLabel("FREQ=YEARLY", date)).toBe(
         "Does not repeat",
       );
     });

--- a/src/lib/recurrence-utils.test.ts
+++ b/src/lib/recurrence-utils.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRRule,
+  formatRecurrenceLabel,
+  parseRRule,
+  type RecurrenceFormState,
+} from "./recurrence-utils";
+
+describe("recurrence-utils", () => {
+  describe("buildRRule", () => {
+    it('returns null for frequency "none"', () => {
+      expect(buildRRule({ frequency: "none", interval: 1 })).toBeNull();
+    });
+
+    it("builds daily RRULE", () => {
+      expect(buildRRule({ frequency: "daily", interval: 1 })).toBe(
+        "RRULE:FREQ=DAILY",
+      );
+    });
+
+    it("builds weekly RRULE with days", () => {
+      expect(
+        buildRRule({
+          frequency: "weekly",
+          interval: 1,
+          weeklyDays: ["TU", "TH", "FR"],
+        }),
+      ).toBe("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR");
+    });
+
+    it("sorts weekly days in standard order", () => {
+      expect(
+        buildRRule({
+          frequency: "weekly",
+          interval: 1,
+          weeklyDays: ["FR", "MO", "WE"],
+        }),
+      ).toBe("RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR");
+    });
+
+    it("builds weekly RRULE without explicit days", () => {
+      expect(buildRRule({ frequency: "weekly", interval: 1 })).toBe(
+        "RRULE:FREQ=WEEKLY",
+      );
+    });
+
+    it("builds monthly RRULE with day of month", () => {
+      expect(
+        buildRRule({ frequency: "monthly", interval: 1, monthDay: 15 }),
+      ).toBe("RRULE:FREQ=MONTHLY;BYMONTHDAY=15");
+    });
+
+    it("includes INTERVAL when > 1", () => {
+      expect(buildRRule({ frequency: "daily", interval: 3 })).toBe(
+        "RRULE:FREQ=DAILY;INTERVAL=3",
+      );
+    });
+
+    it("omits INTERVAL when 1", () => {
+      const result = buildRRule({ frequency: "daily", interval: 1 });
+      expect(result).not.toContain("INTERVAL");
+    });
+
+    it("includes UNTIL when endDate provided", () => {
+      expect(
+        buildRRule({
+          frequency: "daily",
+          interval: 1,
+          endDate: "2026-08-15",
+        }),
+      ).toBe("RRULE:FREQ=DAILY;UNTIL=20260815");
+    });
+
+    it("combines interval, days, and until", () => {
+      expect(
+        buildRRule({
+          frequency: "weekly",
+          interval: 2,
+          weeklyDays: ["MO", "FR"],
+          endDate: "2026-06-15",
+        }),
+      ).toBe("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,FR;UNTIL=20260615");
+    });
+  });
+
+  describe("parseRRule", () => {
+    it("parses daily RRULE", () => {
+      const result = parseRRule("RRULE:FREQ=DAILY");
+      expect(result).toEqual({
+        frequency: "daily",
+        interval: 1,
+        weeklyDays: undefined,
+        monthDay: undefined,
+        endDate: undefined,
+      });
+    });
+
+    it("parses weekly RRULE with days", () => {
+      const result = parseRRule("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR");
+      expect(result.frequency).toBe("weekly");
+      expect(result.weeklyDays).toEqual(["TU", "TH", "FR"]);
+    });
+
+    it("parses monthly RRULE with BYMONTHDAY", () => {
+      const result = parseRRule("RRULE:FREQ=MONTHLY;BYMONTHDAY=15");
+      expect(result.frequency).toBe("monthly");
+      expect(result.monthDay).toBe(15);
+    });
+
+    it("parses INTERVAL", () => {
+      const result = parseRRule("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO");
+      expect(result.interval).toBe(2);
+    });
+
+    it("defaults interval to 1 when not present", () => {
+      const result = parseRRule("RRULE:FREQ=DAILY");
+      expect(result.interval).toBe(1);
+    });
+
+    it("parses UNTIL to yyyy-MM-dd", () => {
+      const result = parseRRule("RRULE:FREQ=DAILY;UNTIL=20260815");
+      expect(result.endDate).toBe("2026-08-15");
+    });
+
+    it('returns frequency "none" for unknown FREQ', () => {
+      const result = parseRRule("RRULE:FREQ=YEARLY");
+      expect(result.frequency).toBe("none");
+    });
+  });
+
+  describe("buildRRule / parseRRule round-trip", () => {
+    const cases: RecurrenceFormState[] = [
+      { frequency: "daily", interval: 1 },
+      { frequency: "daily", interval: 3, endDate: "2026-08-15" },
+      { frequency: "weekly", interval: 1, weeklyDays: ["TU", "TH", "FR"] },
+      {
+        frequency: "weekly",
+        interval: 2,
+        weeklyDays: ["MO", "FR"],
+        endDate: "2026-06-15",
+      },
+      { frequency: "monthly", interval: 1, monthDay: 15 },
+    ];
+
+    for (const state of cases) {
+      it(`round-trips: ${JSON.stringify(state)}`, () => {
+        const rrule = buildRRule(state)!;
+        const parsed = parseRRule(rrule);
+        // Re-build from parsed to check equivalence
+        expect(buildRRule(parsed)).toBe(rrule);
+      });
+    }
+  });
+
+  describe("formatRecurrenceLabel", () => {
+    const date = new Date(2026, 2, 11); // Wednesday March 11, 2026
+
+    it("formats daily", () => {
+      expect(formatRecurrenceLabel("RRULE:FREQ=DAILY", date)).toBe("Daily");
+    });
+
+    it("formats daily with interval", () => {
+      expect(formatRecurrenceLabel("RRULE:FREQ=DAILY;INTERVAL=3", date)).toBe(
+        "Every 3 days",
+      );
+    });
+
+    it("formats weekly with specific days", () => {
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=WEEKLY;BYDAY=TU,TH,FR", date),
+      ).toBe("Weekly on Tue, Thu, Fri");
+    });
+
+    it("formats weekly without days (uses event date)", () => {
+      expect(formatRecurrenceLabel("RRULE:FREQ=WEEKLY", date)).toBe(
+        "Weekly on Wednesday",
+      );
+    });
+
+    it("formats weekly with interval", () => {
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=MO", date),
+      ).toBe("Every 2 weeks on Mon");
+    });
+
+    it("formats monthly with BYMONTHDAY", () => {
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=15", date),
+      ).toBe("Monthly on the 15th");
+    });
+
+    it("formats monthly without BYMONTHDAY (uses event date)", () => {
+      expect(formatRecurrenceLabel("RRULE:FREQ=MONTHLY", date)).toBe(
+        "Monthly on the 11th",
+      );
+    });
+
+    it("formats ordinal suffixes correctly", () => {
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=1", date),
+      ).toBe("Monthly on the 1st");
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=2", date),
+      ).toBe("Monthly on the 2nd");
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=3", date),
+      ).toBe("Monthly on the 3rd");
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=11", date),
+      ).toBe("Monthly on the 11th");
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=MONTHLY;BYMONTHDAY=21", date),
+      ).toBe("Monthly on the 21st");
+    });
+
+    it("appends until date", () => {
+      expect(
+        formatRecurrenceLabel("RRULE:FREQ=DAILY;UNTIL=20260615", date),
+      ).toBe("Daily until Jun 15, 2026");
+    });
+
+    it('returns "Does not repeat" for unknown frequency', () => {
+      expect(formatRecurrenceLabel("RRULE:FREQ=YEARLY", date)).toBe(
+        "Does not repeat",
+      );
+    });
+  });
+});

--- a/src/lib/recurrence-utils.ts
+++ b/src/lib/recurrence-utils.ts
@@ -1,0 +1,180 @@
+/**
+ * Utilities for converting between RecurrenceFormState and RRULE strings.
+ * RRULE follows RFC 5545 format — the same format Google Calendar uses.
+ */
+
+import { format } from "date-fns";
+
+export type RecurrenceFrequency = "none" | "daily" | "weekly" | "monthly";
+
+export interface RecurrenceFormState {
+  frequency: RecurrenceFrequency;
+  interval: number;
+  weeklyDays?: string[];
+  monthDay?: number;
+  endDate?: string; // yyyy-MM-dd
+}
+
+const FREQ_MAP: Record<Exclude<RecurrenceFrequency, "none">, string> = {
+  daily: "DAILY",
+  weekly: "WEEKLY",
+  monthly: "MONTHLY",
+};
+
+const DAY_ABBR_TO_FULL: Record<string, string> = {
+  MO: "Mon",
+  TU: "Tue",
+  WE: "Wed",
+  TH: "Thu",
+  FR: "Fri",
+  SA: "Sat",
+  SU: "Sun",
+};
+
+const DAY_ORDER = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"];
+
+function getOrdinalSuffix(n: number): string {
+  const lastTwo = n % 100;
+  if (lastTwo >= 11 && lastTwo <= 13) return `${n}th`;
+  const lastOne = n % 10;
+  if (lastOne === 1) return `${n}st`;
+  if (lastOne === 2) return `${n}nd`;
+  if (lastOne === 3) return `${n}rd`;
+  return `${n}th`;
+}
+
+/**
+ * Convert RecurrenceFormState to an RRULE string.
+ * Returns null for frequency "none".
+ */
+export function buildRRule(state: RecurrenceFormState): string | null {
+  if (state.frequency === "none") return null;
+
+  const parts: string[] = [`FREQ=${FREQ_MAP[state.frequency]}`];
+
+  if (state.interval > 1) {
+    parts.push(`INTERVAL=${state.interval}`);
+  }
+
+  if (
+    state.frequency === "weekly" &&
+    state.weeklyDays &&
+    state.weeklyDays.length > 0
+  ) {
+    const sorted = [...state.weeklyDays].sort(
+      (a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b),
+    );
+    parts.push(`BYDAY=${sorted.join(",")}`);
+  }
+
+  if (state.frequency === "monthly" && state.monthDay) {
+    parts.push(`BYMONTHDAY=${state.monthDay}`);
+  }
+
+  if (state.endDate) {
+    const until = state.endDate.replace(/-/g, "");
+    parts.push(`UNTIL=${until}`);
+  }
+
+  return `RRULE:${parts.join(";")}`;
+}
+
+/**
+ * Parse an RRULE string back into RecurrenceFormState.
+ * Used when editing a recurring event in "edit all" mode.
+ */
+export function parseRRule(rrule: string): RecurrenceFormState {
+  const rule = rrule.replace(/^RRULE:/, "");
+  const params = new Map<string, string>();
+
+  for (const part of rule.split(";")) {
+    const eqIdx = part.indexOf("=");
+    if (eqIdx > 0) {
+      params.set(part.slice(0, eqIdx), part.slice(eqIdx + 1));
+    }
+  }
+
+  const freqRaw = params.get("FREQ");
+  let frequency: RecurrenceFrequency = "none";
+  if (freqRaw === "DAILY") frequency = "daily";
+  else if (freqRaw === "WEEKLY") frequency = "weekly";
+  else if (freqRaw === "MONTHLY") frequency = "monthly";
+
+  const interval = params.has("INTERVAL")
+    ? Number.parseInt(params.get("INTERVAL")!, 10)
+    : 1;
+
+  const weeklyDays = params.has("BYDAY")
+    ? params.get("BYDAY")!.split(",")
+    : undefined;
+
+  const monthDay = params.has("BYMONTHDAY")
+    ? Number.parseInt(params.get("BYMONTHDAY")!, 10)
+    : undefined;
+
+  let endDate: string | undefined;
+  if (params.has("UNTIL")) {
+    const until = params.get("UNTIL")!;
+    // Convert yyyyMMdd to yyyy-MM-dd
+    endDate = `${until.slice(0, 4)}-${until.slice(4, 6)}-${until.slice(6, 8)}`;
+  }
+
+  return { frequency, interval, weeklyDays, monthDay, endDate };
+}
+
+/**
+ * Format an RRULE into a human-readable label for display.
+ * Examples: "Daily", "Weekly on Tue, Thu, Fri", "Every 2 weeks on Mon",
+ *           "Monthly on the 15th", "Daily until Jun 15, 2026"
+ */
+export function formatRecurrenceLabel(rrule: string, eventDate: Date): string {
+  const state = parseRRule(rrule);
+
+  const intervalPrefix = state.interval > 1 ? `Every ${state.interval} ` : "";
+
+  let base: string;
+
+  switch (state.frequency) {
+    case "daily":
+      base = intervalPrefix ? `${intervalPrefix}days` : "Daily";
+      break;
+    case "weekly": {
+      const unit = intervalPrefix ? `${intervalPrefix}weeks` : "Weekly";
+      if (state.weeklyDays && state.weeklyDays.length > 0) {
+        const sorted = [...state.weeklyDays].sort(
+          (a, b) => DAY_ORDER.indexOf(a) - DAY_ORDER.indexOf(b),
+        );
+        const dayNames = sorted.map((d) => DAY_ABBR_TO_FULL[d] ?? d);
+        base = `${unit} on ${dayNames.join(", ")}`;
+      } else {
+        const dayName = format(eventDate, "EEEE");
+        base = `${unit} on ${dayName}`;
+      }
+      break;
+    }
+    case "monthly": {
+      const unit = intervalPrefix ? `${intervalPrefix}months` : "Monthly";
+      if (state.monthDay) {
+        base = `${unit} on the ${getOrdinalSuffix(state.monthDay)}`;
+      } else {
+        const day = eventDate.getDate();
+        base = `${unit} on the ${getOrdinalSuffix(day)}`;
+      }
+      break;
+    }
+    default:
+      return "Does not repeat";
+  }
+
+  if (state.endDate) {
+    const endDate = new Date(
+      Number.parseInt(state.endDate.slice(0, 4)),
+      Number.parseInt(state.endDate.slice(5, 7)) - 1,
+      Number.parseInt(state.endDate.slice(8, 10)),
+    );
+    const formatted = format(endDate, "MMM d, yyyy");
+    return `${base} until ${formatted}`;
+  }
+
+  return base;
+}

--- a/src/lib/recurrence-utils.ts
+++ b/src/lib/recurrence-utils.ts
@@ -33,7 +33,7 @@ const DAY_ABBR_TO_FULL: Record<string, string> = {
 
 const DAY_ORDER = ["MO", "TU", "WE", "TH", "FR", "SA", "SU"];
 
-function getOrdinalSuffix(n: number): string {
+export function getOrdinalSuffix(n: number): string {
   const lastTwo = n % 100;
   if (lastTwo >= 11 && lastTwo <= 13) return `${n}th`;
   const lastOne = n % 10;
@@ -76,7 +76,7 @@ export function buildRRule(state: RecurrenceFormState): string | null {
     parts.push(`UNTIL=${until}`);
   }
 
-  return `RRULE:${parts.join(";")}`;
+  return parts.join(";");
 }
 
 /**
@@ -84,7 +84,7 @@ export function buildRRule(state: RecurrenceFormState): string | null {
  * Used when editing a recurring event in "edit all" mode.
  */
 export function parseRRule(rrule: string): RecurrenceFormState {
-  const rule = rrule.replace(/^RRULE:/, "");
+  const rule = rrule;
   const params = new Map<string, string>();
 
   for (const part of rule.split(";")) {

--- a/src/lib/time-utils.test.ts
+++ b/src/lib/time-utils.test.ts
@@ -8,6 +8,7 @@ import {
   format12hTo24h,
   format24hTo12h,
   formatLocalDate,
+  getEventKey,
   getSmartDefaultTimes,
   getTimeInMinutes,
   isEventOnDate,
@@ -620,6 +621,38 @@ describe("time-utils", () => {
       expect(CALENDAR_START_HOUR).toBe(6);
       expect(CALENDAR_END_HOUR).toBe(22);
       expect(DEFAULT_EVENT_HOUR).toBe(9);
+    });
+  });
+
+  describe("getEventKey", () => {
+    it("returns id for regular events", () => {
+      const event = { id: "uuid-123", date: new Date(2026, 2, 11) };
+      expect(getEventKey(event)).toBe("uuid-123");
+    });
+
+    it("returns id for exception instances (has both id and recurringEventId)", () => {
+      const event = {
+        id: "uuid-exception",
+        recurringEventId: "uuid-parent",
+        date: new Date(2026, 2, 11),
+      };
+      expect(getEventKey(event)).toBe("uuid-exception");
+    });
+
+    it("returns composite key for expanded instances (id is null)", () => {
+      const event = {
+        id: null,
+        recurringEventId: "uuid-parent",
+        date: new Date(2026, 2, 11),
+      };
+      expect(getEventKey(event)).toBe("uuid-parent_2026-03-11");
+    });
+
+    it("produces different keys for different dates of same parent", () => {
+      const base = { id: null, recurringEventId: "uuid-parent" };
+      const key1 = getEventKey({ ...base, date: new Date(2026, 2, 11) });
+      const key2 = getEventKey({ ...base, date: new Date(2026, 2, 13) });
+      expect(key1).not.toBe(key2);
     });
   });
 

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -127,6 +127,19 @@ export function isEventOnDate(
 }
 
 /**
+ * Get a stable key for any calendar event (regular, parent, instance, or exception).
+ * Regular/parent/exception events have a real UUID id.
+ * Expanded instances have id: null and use recurringEventId + date as composite key.
+ */
+export function getEventKey(event: {
+  id: string | null;
+  recurringEventId?: string;
+  date: Date;
+}): string {
+  return event.id ?? `${event.recurringEventId}_${formatLocalDate(event.date)}`;
+}
+
+/**
  * Calendar grid visible hours constants.
  * These match the weekly/daily view rendering boundaries.
  */

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -1,5 +1,5 @@
 export interface CalendarEvent {
-  id: string;
+  id: string | null;
   title: string;
   startTime: string;
   endTime: string;
@@ -8,6 +8,9 @@ export interface CalendarEvent {
   memberId: string;
   isAllDay: boolean;
   location?: string;
+  recurrenceRule?: string;
+  recurringEventId?: string;
+  isRecurring?: boolean;
 }
 
 /**
@@ -37,6 +40,7 @@ export interface CreateEventRequest {
   memberId: string;
   isAllDay?: boolean;
   location?: string;
+  recurrenceRule?: string | null;
 }
 
 export interface UpdateEventRequest {
@@ -48,11 +52,12 @@ export interface UpdateEventRequest {
   memberId: string;
   isAllDay?: boolean;
   location?: string;
+  recurrenceRule?: string | null;
 }
 
 export interface GetEventsParams {
-  startDate?: string;
-  endDate?: string;
+  startDate: string;
+  endDate: string;
   memberId?: string;
 }
 

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -54,6 +54,16 @@ export const eventFormSchema = z
       .string()
       .regex(DATE_FORMAT_REGEX, "Invalid date format")
       .optional(),
+    recurrenceFrequency: z
+      .enum(["none", "daily", "weekly", "monthly"])
+      .optional(),
+    recurrenceInterval: z.number().min(1).optional(),
+    recurrenceWeeklyDays: z.array(z.string()).optional(),
+    recurrenceMonthDay: z.number().min(1).max(31).optional(),
+    recurrenceEndDate: z
+      .string()
+      .regex(DATE_FORMAT_REGEX, "Invalid date format")
+      .optional(),
   })
   .refine(
     (data) =>
@@ -71,7 +81,18 @@ export const eventFormSchema = z
   .refine((data) => !data.endDate || data.isAllDay, {
     message: "End date is only valid for all-day events",
     path: ["endDate"],
-  });
+  })
+  .refine(
+    (data) => {
+      if (data.recurrenceFrequency !== "weekly") return true;
+      if (!data.recurrenceWeeklyDays) return true;
+      return data.recurrenceWeeklyDays.length > 0;
+    },
+    {
+      message: "Select at least one day for weekly recurrence",
+      path: ["recurrenceWeeklyDays"],
+    },
+  );
 
 /**
  * TypeScript type inferred from the schema


### PR DESCRIPTION
## Summary

- **Types:** `CalendarEvent.id` is now `string | null` for expanded instances; added `recurrenceRule`, `recurringEventId`, `isRecurring` fields; `GetEventsParams` date fields now required
- **RRULE utilities:** `buildRRule()`, `parseRRule()`, `formatRecurrenceLabel()` — pure functions for RFC 5545 RRULE conversion, no client-side expansion
- **RecurrencePicker component:** frequency dropdown (none/daily/weekly/monthly), day-of-week toggles, interval selector, optional end date
- **EventForm integration:** RecurrencePicker between Date and All Day toggle, hidden in "edit this event" scope
- **EditScopeDialog:** "This event" / "All events" radio dialog for edit/delete on recurring events
- **Instance API endpoints:** `updateInstance()` and `deleteInstance()` service methods + hooks for `PUT/DELETE /{parentId}/instances/{date}`
- **CalendarModule routing:** scope dialog → correct API endpoint; `handleAddEvent` includes `recurrenceRule`; `getParentId()` helper for consistent parent ID resolution
- **Display:** repeat icon on event cards, recurrence label in detail modal (full label for parents, "Recurring event" fallback for instances)

## Key Design Decisions

- **Server-side expansion** — BE expands RRULE into flat event list, FE receives and renders as today
- **`getEventKey()`** — stable React key: `event.id ?? \`${recurringEventId}_${date}\``
- **Instance endpoint always for "this event"** — even for exceptions with real IDs, never falls through to regular `PUT /events/{id}`
- **Explicit `recurrenceRule: null`** — sent on updates to clear recurrence, not omitted
- **No optimistic updates for instance mutations** — invalidate-only, avoids composite key complexity

## Test plan

- [x] `npm run build` passes (type-check + Vite)
- [x] `npm run test` — 517 tests pass (46 new)
- [ ] `npm run test:e2e` — requires BE with recurrence support running
- [ ] Manual: create "Preschool T/Th/F" → verify instances on weekly view → edit one → delete series

Depends on: BE recurring events ([PR #20](https://github.com/joe-bor/family-hub-api/pull/20))