### PR TITLE
fix: tech debt cleanup — null safety, avatar feedback, modal tests

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -35,21 +35,6 @@ No E2E test coverage for the recurring events flow — creating, editing (this/a
 
 ---
 
-### 2. `CalendarEvent.id` Null Safety
-**Source:** PR #117 Review
-**Files:** `src/lib/types/calendar.ts`, consumers of `CalendarEvent`
-**Status:** Key spots guarded, wider audit needed
-
-**Problem:**
-`CalendarEvent.id` changed from `string` to `string | null` to support virtual recurring instances (which have no database ID). The key code paths in `calendar-module.tsx` now have runtime guards, but other consumers across the codebase may still assume `id` is non-null.
-
-**Suggested Fix:**
-- Audit all usages of `CalendarEvent.id` outside `calendar-module.tsx`
-- Add runtime guards or type narrowing where needed
-- Consider a branded type or discriminated union (`VirtualInstance | PersistedEvent`) to make the null case explicit at the type level
-
----
-
 ## Low Priority (Nice to Have)
 
 ### 1. Web Vitals Tracking
@@ -113,36 +98,7 @@ Lighthouse detected unused JavaScript in the bundle.
 
 ---
 
-### 5. MemberProfileModal Component Tests
-**Source:** PR #67 Review
-**Files:** `src/components/settings/member-profile-modal.tsx`
-**Status:** Testing gap
-
-**Problem:**
-No component-level tests verify that each mutation call site (form submit, avatar upload, avatar remove) sends the correct fields. Hook-level tests cover optimistic updates, but a modal refactor could regress the payload completeness fix from PR #67.
-
-**Suggested Fix:**
-- Add tests asserting each mutation call includes all required fields (`name`, `color`, `email`, `avatarUrl`)
-- Verify avatar removal sends `avatarUrl: null` (not `undefined`)
-- Verify form submit preserves `avatarUrl` from current member data
-
----
-
-### 6. Silent Avatar Upload Validation Failures
-**Source:** PR #67 Review (pre-existing)
-**Files:** `src/components/settings/member-profile-modal.tsx` (lines 92-99)
-**Status:** UX gap
-
-**Problem:**
-`handleAvatarUpload` silently returns on invalid file type or file size (>500KB) with no user feedback. Users get no indication why their upload didn't work.
-
-**Suggested Fix:**
-- Show a toast or inline error for invalid file type ("Please select an image file")
-- Show a toast or inline error for oversized files ("Image must be under 500KB")
-
----
-
-### 7. PWA Optimizations
+### 5. PWA Optimizations
 **Source:** Lighthouse CI (PR #60)
 **Files:** `vite.config.ts` (vite-plugin-pwa)
 **Status:** Deferred - PWA basics in place
@@ -240,6 +196,9 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| CalendarEvent.id Null Safety (guard optimistic update comparison) | - | #118 | Mar 13, 2026 |
+| Silent Avatar Upload Validation Failures (inline error messages) | - | #118 | Mar 13, 2026 |
+| MemberProfileModal Component Tests (mutation payload assertions) | - | #118 | Mar 13, 2026 |
 | Google Fonts Render-Blocking (self-host Nunito font) | - | #109 | Mar 13, 2026 |
 | Orphaned Events Warning (BE handles via ON DELETE CASCADE) | - | - | Mar 13, 2026 |
 | Lighthouse CI Integration (performance/a11y tracking in CI) | - | #60 | Feb 3, 2026 |

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -14,21 +14,7 @@ _No high priority items at this time._
 
 ## Medium Priority (Future Sprint)
 
-### 1. Orphaned Events Warning
-**Source:** PR #10 Review (Sprint 5)
-**Files:** `src/stores/family-store.ts`, `src/components/settings/family-settings-modal.tsx`
-**Status:** Deferred to Backend Integration
-
-**Problem:**
-When a member is deleted:
-1. Their events become orphaned (hidden by filter but still exist)
-2. No warning shown to user
-3. Backend sync could fail if it validates member IDs
-
-**Suggested Fix:**
-- Count assigned events before delete
-- Show confirmation dialog: "This member has X events. Delete anyway?"
-- Consider cascade delete or reassignment to "Unassigned" member
+_No medium priority items at this time._
 
 ---
 
@@ -112,22 +98,7 @@ The 100ms wait allows React to settle after UI indicators are visible. This is a
 
 ---
 
-### 4. Google Fonts Render-Blocking
-**Source:** Lighthouse CI (PR #60)
-**Status:** Optimization opportunity
-
-**Problem:**
-Google Fonts CSS is render-blocking, adding to the critical request chain (3 levels, ~131ms).
-
-**Suggested Fixes:**
-- Add `font-display: swap` to font declarations
-- Preload critical fonts: `<link rel="preload" as="font" ...>`
-- Self-host fonts to eliminate external dependency
-- Use `font-display: optional` for non-critical fonts
-
----
-
-### 5. Unused JavaScript
+### 4. Unused JavaScript
 **Source:** Lighthouse CI (PR #60)
 **Status:** Optimization opportunity
 
@@ -142,7 +113,7 @@ Lighthouse detected unused JavaScript in the bundle.
 
 ---
 
-### 6. MemberProfileModal Component Tests
+### 5. MemberProfileModal Component Tests
 **Source:** PR #67 Review
 **Files:** `src/components/settings/member-profile-modal.tsx`
 **Status:** Testing gap
@@ -157,7 +128,7 @@ No component-level tests verify that each mutation call site (form submit, avata
 
 ---
 
-### 7. Silent Avatar Upload Validation Failures
+### 6. Silent Avatar Upload Validation Failures
 **Source:** PR #67 Review (pre-existing)
 **Files:** `src/components/settings/member-profile-modal.tsx` (lines 92-99)
 **Status:** UX gap
@@ -171,7 +142,7 @@ No component-level tests verify that each mutation call site (form submit, avata
 
 ---
 
-### 8. PWA Optimizations
+### 7. PWA Optimizations
 **Source:** Lighthouse CI (PR #60)
 **Files:** `vite.config.ts` (vite-plugin-pwa)
 **Status:** Deferred - PWA basics in place
@@ -203,10 +174,12 @@ See `.env.example` for environment variable documentation.
 - [x] All family hooks use TanStack Query
 - [x] Both calendar and family ready for backend
 
-**Phase 2: Backend Implementation**
-- [ ] Set `VITE_API_BASE_URL` to backend URL
-- [ ] Implement calendar endpoints
-- [ ] Implement family endpoints
+**Phase 2: Backend Implementation** ✅ COMPLETED (PRs #83, #87, #89, #96, #105, #106)
+- [x] Set `VITE_API_BASE_URL` to backend URL
+- [x] Implement calendar endpoints
+- [x] Implement family endpoints
+- [x] Remove mock API layer (#106)
+- [x] E2E tests run against real backend (#105)
 
 **Phase 3: Authentication** ✅ COMPLETED (PR #35)
 - [x] Add auth system (JWT-based with mock API)
@@ -231,10 +204,10 @@ Types: `src/lib/types/calendar.ts`
 ```
 GET    /family                   → ApiResponse<FamilyData | null>
 POST   /family                   body: CreateFamilyRequest
-PATCH  /family                   body: UpdateFamilyRequest
+PUT    /family                   body: UpdateFamilyRequest
 DELETE /family
 POST   /family/members           body: AddMemberRequest
-PATCH  /family/members/:id       body: UpdateMemberRequest (no id in body)
+PUT    /family/members/:id       body: UpdateMemberRequest (no id in body)
 DELETE /family/members/:id
 ```
 Types: `src/lib/types/family.ts`
@@ -243,7 +216,7 @@ Types: `src/lib/types/family.ts`
 
 1. **Member ID Format**: Frontend uses `crypto.randomUUID()`. Backend must accept UUID v4 format without reassigning IDs.
 
-2. **Event-Member Relationship**: Need to decide on cascade delete vs. orphan handling when members are removed. See Medium Priority #1.
+2. **Event-Member Relationship**: ✅ Resolved — Backend uses `ON DELETE CASCADE`, so member deletion automatically removes their events.
 
 3. **PWA API Response Caching**: Add service worker caching for API responses to enable offline functionality.
    - **Files:** `vite.config.ts` (workbox runtimeCaching)
@@ -267,6 +240,8 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| Google Fonts Render-Blocking (self-host Nunito font) | - | #109 | Mar 13, 2026 |
+| Orphaned Events Warning (BE handles via ON DELETE CASCADE) | - | - | Mar 13, 2026 |
 | Lighthouse CI Integration (performance/a11y tracking in CI) | - | #60 | Feb 3, 2026 |
 | Family Mutation Tests (optimistic updates, rollback, useUpdateMember, useDeleteFamily) | - | #56 | Feb 1, 2026 |
 | Outdated TODO Comments in use-family.ts | - | #46 | Jan 29, 2026 |

--- a/src/api/hooks/use-calendar.ts
+++ b/src/api/hooks/use-calendar.ts
@@ -101,7 +101,7 @@ export function useUpdateEvent(callbacks?: UpdateEventCallbacks) {
           return {
             ...old,
             data: old.data.map((event) =>
-              event.id === updatedEvent.id
+              event.id != null && event.id === updatedEvent.id
                 ? {
                     ...event,
                     ...updatedEvent,

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -16,6 +16,7 @@ import type {
   UpdateMemberRequest,
 } from "@/lib/types";
 import { familyColors } from "@/lib/types";
+import { validateFamilyData } from "@/lib/validations/family";
 import { useIsAuthenticated } from "@/stores";
 
 // ============================================================================
@@ -67,7 +68,7 @@ export function readFamilyFromStorage(): FamilyData | null {
     if (!stored) return null;
 
     const parsed = JSON.parse(stored);
-    return parsed?.state?.family ?? null;
+    return validateFamilyData(parsed?.state?.family);
   } catch (error) {
     if (import.meta.env.DEV) {
       console.error("Failed to read family from localStorage:", error);

--- a/src/components/settings/member-profile-modal.test.tsx
+++ b/src/components/settings/member-profile-modal.test.tsx
@@ -1,0 +1,218 @@
+import { HttpResponse, http } from "msw";
+import { describe, expect, it, vi } from "vitest";
+import type { FamilyMember, UpdateMemberRequest } from "@/lib/types";
+import { API_BASE, setupMswServer } from "@/test/mocks/server";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedFamilyStore,
+  TEST_TIMEOUTS,
+  waitFor,
+} from "@/test/test-utils";
+import { MemberProfileModal } from "./member-profile-modal";
+
+setupMswServer();
+
+const testMember: FamilyMember = {
+  id: "member-1",
+  name: "Alice",
+  color: "coral",
+  avatarUrl: "https://example.com/avatar.jpg",
+  email: "alice@example.com",
+};
+
+const testMembers: FamilyMember[] = [
+  testMember,
+  { id: "member-2", name: "Bob", color: "teal" },
+];
+
+function seedFamily() {
+  seedFamilyStore({ name: "Test Family", members: testMembers });
+}
+
+describe("MemberProfileModal", () => {
+  it("form submit preserves avatarUrl from existing member data", async () => {
+    seedFamily();
+    let capturedBody: UpdateMemberRequest | null = null;
+
+    const { server } = await import("@/test/mocks/server");
+    server.use(
+      http.put(`${API_BASE}/family/members/:id`, async ({ request }) => {
+        capturedBody = (await request.json()) as UpdateMemberRequest;
+        return HttpResponse.json({
+          data: { ...testMember, ...capturedBody },
+          message: "Member updated",
+        });
+      }),
+    );
+
+    const { user } = renderWithUser(
+      <MemberProfileModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId="member-1"
+      />,
+    );
+
+    // Change name to make form dirty
+    const nameInput = screen.getByLabelText("Name");
+    await user.clear(nameInput);
+    await user.type(nameInput, "Alice Updated");
+
+    await waitFor(
+      () => {
+        expect(nameInput).toHaveValue("Alice Updated");
+      },
+      { timeout: TEST_TIMEOUTS.FORM_STATE },
+    );
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(
+      () => {
+        expect(capturedBody).not.toBeNull();
+      },
+      { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+    );
+
+    expect(capturedBody).toMatchObject({
+      name: "Alice Updated",
+      color: "coral",
+      avatarUrl: "https://example.com/avatar.jpg",
+    });
+  });
+
+  it("avatar upload sends all fields including base64 avatarUrl", async () => {
+    seedFamily();
+    let capturedBody: UpdateMemberRequest | null = null;
+
+    const { server } = await import("@/test/mocks/server");
+    server.use(
+      http.put(`${API_BASE}/family/members/:id`, async ({ request }) => {
+        capturedBody = (await request.json()) as UpdateMemberRequest;
+        return HttpResponse.json({
+          data: { ...testMember, ...capturedBody },
+          message: "Member updated",
+        });
+      }),
+    );
+
+    render(
+      <MemberProfileModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId="member-1"
+      />,
+    );
+
+    const fileInput = screen.getByLabelText("Upload avatar image");
+    const file = new File(["fake-image-content"], "photo.png", {
+      type: "image/png",
+    });
+
+    // Simulate upload via fireEvent (userEvent.upload can be flaky with hidden inputs)
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await waitFor(
+      () => {
+        expect(capturedBody).not.toBeNull();
+      },
+      { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+    );
+
+    expect(capturedBody!.name).toBe("Alice");
+    expect(capturedBody!.color).toBe("coral");
+    expect(capturedBody!.avatarUrl).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("avatar removal sends avatarUrl: null", async () => {
+    seedFamily();
+    let capturedBody: UpdateMemberRequest | null = null;
+
+    const { server } = await import("@/test/mocks/server");
+    server.use(
+      http.put(`${API_BASE}/family/members/:id`, async ({ request }) => {
+        capturedBody = (await request.json()) as UpdateMemberRequest;
+        return HttpResponse.json({
+          data: { ...testMember, avatarUrl: undefined },
+          message: "Member updated",
+        });
+      }),
+    );
+
+    const { user } = renderWithUser(
+      <MemberProfileModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId="member-1"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /remove photo/i }));
+
+    await waitFor(
+      () => {
+        expect(capturedBody).not.toBeNull();
+      },
+      { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+    );
+
+    expect(capturedBody).toMatchObject({
+      name: "Alice",
+      color: "coral",
+      avatarUrl: null,
+    });
+  });
+
+  it("shows error for invalid file type", async () => {
+    seedFamily();
+
+    render(
+      <MemberProfileModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId="member-1"
+      />,
+    );
+
+    const fileInput = screen.getByLabelText("Upload avatar image");
+    const file = new File(["not-an-image"], "readme.txt", {
+      type: "text/plain",
+    });
+
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(
+      await screen.findByText("Please select an image file"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows error for oversized file", async () => {
+    seedFamily();
+
+    render(
+      <MemberProfileModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId="member-1"
+      />,
+    );
+
+    const fileInput = screen.getByLabelText("Upload avatar image");
+    // Create a file larger than 500KB
+    const bigContent = new Uint8Array(501 * 1024);
+    const file = new File([bigContent], "big-photo.png", {
+      type: "image/png",
+    });
+
+    Object.defineProperty(fileInput, "files", { value: [file] });
+    fileInput.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(
+      await screen.findByText("Image must be smaller than 500KB"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Camera, Trash2, X } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useFamilyMemberById, useFamilyMembers, useUpdateMember } from "@/api";
 import { Button } from "@/components/ui/button";
@@ -35,6 +35,7 @@ export function MemberProfileModal({
   const familyMembers = useFamilyMembers();
   const updateMemberMutation = useUpdateMember();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
 
   const existingNames = familyMembers.map((m) => m.name);
   const usedColors = familyMembers
@@ -72,6 +73,11 @@ export function MemberProfileModal({
     }
   }, [member, reset]);
 
+  // Clear avatar error when dialog reopens
+  useEffect(() => {
+    if (open) setAvatarError(null);
+  }, [open]);
+
   if (!member) return null;
 
   const onSubmit = (data: MemberProfileFormData) => {
@@ -91,13 +97,17 @@ export function MemberProfileModal({
 
     // Validate file type
     if (!file.type.startsWith("image/")) {
+      setAvatarError("Please select an image file");
       return;
     }
 
     // Validate file size (max 500KB for localStorage)
     if (file.size > 500 * 1024) {
+      setAvatarError("Image must be smaller than 500KB");
       return;
     }
+
+    setAvatarError(null);
 
     const reader = new FileReader();
     reader.onload = (e) => {
@@ -179,6 +189,11 @@ export function MemberProfileModal({
               className="hidden"
               aria-label="Upload avatar image"
             />
+            {avatarError && (
+              <p className="text-sm text-destructive" role="alert">
+                {avatarError}
+              </p>
+            )}
             {member.avatarUrl && (
               <Button
                 type="button"


### PR DESCRIPTION
## Summary

- **Validate family data on rehydration**: Wire `validateFamilyData()` into `readFamilyFromStorage()` so corrupted localStorage data is rejected at startup
- **CalendarEvent.id null safety**: Guard `event.id === updatedEvent.id` in optimistic update to prevent `null === null` matching virtual recurring instances
- **Avatar upload validation feedback**: Show inline error messages for invalid file type and oversized files (previously silent failures)
- **MemberProfileModal tests**: 5 component tests verifying mutation payloads — form submit preserves avatarUrl, upload sends base64, removal sends null, validation errors render

## Test plan

- [x] `npx tsc --noEmit` — type-check passes
- [x] `npx vitest run src/api/hooks/use-calendar` — null safety doesn't break existing tests
- [x] `npx vitest run src/api/hooks/use-family` — validation wiring doesn't break existing tests (47 tests pass)
- [x] `npx vitest run src/components/settings/member-profile-modal` — all 5 new tests pass
- [x] CI passes (lint, tests, build)