### PR TITLE
fix(e2e): fix recurring event E2E assertions and mobile-chrome FAB overlap

### DIFF
--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -20,37 +20,7 @@ _No medium priority items at this time._
 
 ## Medium-Low Priority (Follow-up PRs)
 
-### 1. "Edit All" on Recurring Instance Clears Recurrence Rule
-**Source:** E2E test failure — edit-all changes title but removes recurrence
-**Files:** `src/components/calendar/components/event-form-modal.tsx` (line 40), `src/components/calendar/calendar-module.tsx` (line 270-277)
-**Status:** Bug — data loss
-
-**Problem:**
-When editing "all events" from an expanded instance, the recurrence rule is silently dropped. Root cause: expanded instances have `recurrenceRule: null` (by design — §4 of `docs/recurring-events-design.md`). `eventToFormData()` skips recurrence fields when `event.recurrenceRule` is falsy. The form opens with RecurrencePicker defaulting to "Does not repeat". On submit, `buildRRule({ frequency: "none" })` returns `null`, which is sent as `recurrenceRule: null` — clearing the series.
-
-**Impact:** User edits a recurring event title via "all events" → the entire series is silently converted to a one-time event. Future instances disappear.
-
-**Suggested Fix:**
-When `editScope === "all"`, fetch or derive the parent's `recurrenceRule` before opening the edit form. Options:
-- **(A)** Include `recurrenceRule` on expanded instance responses (the same BE change suggested in item #2 below — solves both issues)
-- **(B)** FE fetches the parent event by `recurringEventId` before opening the form
-- **(C)** Store the parent's recurrence rule in the scope dialog flow (cheapest FE-only fix)
-
----
-
-### 2. Recurring Event Detail Shows Generic "Recurring event" Label
-**Source:** E2E test observation (recurring events spec)
-**Files:** FE: `src/components/calendar/components/event-detail-modal.tsx` (line 127-129), BE: `CalendarEventMapper.toInstanceResponse()`
-**Status:** UX improvement
-
-**Problem:**
-`formatRecurrenceLabel()` is wired up in EventDetailModal and produces specific labels ("Daily", "Weekly on Mon, Wed", "Every 2 days"). However, expanded instances from the backend have `recurrenceRule: null` — by design (see `docs/recurring-events-design.md` §4: "only on parent events, null for instances/regular"). So the modal falls back to the generic "Recurring event" text for every instance.
-
-**Risk assessment:**
-FE expansion is NOT a concern — all RRULE expansion happens on the BE in `RecurrenceExpander`. The FE only uses `recurrenceRule` for: (1) display label in detail modal, (2) pre-populating RecurrencePicker in "edit all" mode, (3) optimistic cache updates. Adding the field to instances would not cause duplicate rendering.
-
-**Suggested Fix:**
-In BE `CalendarEventMapper.toInstanceResponse()`, copy the parent's `recurrenceRule` onto expanded instance responses. The parent is already loaded during expansion so this is a simple field copy, no extra query. No FE changes needed — `formatRecurrenceLabel()` will just start receiving non-null values.
+_No medium-low priority items at this time._
 
 ---
 
@@ -215,7 +185,9 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
-| E2E Tests for Recurring Events (8 tests: create, edit this/all, delete this/all, monthly, all-day, end date) | - | #TBD | Mar 13, 2026 |
+| "Edit All" Clears Recurrence Rule (BE includes recurrenceRule on instances) | - | BE #21 | Mar 13, 2026 |
+| Recurring Event Detail Generic Label (formatRecurrenceLabel now receives RRULE) | - | BE #21 | Mar 13, 2026 |
+| E2E Tests for Recurring Events (8 tests: create, edit this/all, delete this/all, monthly, all-day, end date) | - | #119 | Mar 13, 2026 |
 | CalendarEvent.id Null Safety (guard optimistic update comparison) | - | #118 | Mar 13, 2026 |
 | Silent Avatar Upload Validation Failures (inline error messages) | - | #118 | Mar 13, 2026 |
 | MemberProfileModal Component Tests (mutation payload assertions) | - | #118 | Mar 13, 2026 |

--- a/e2e/calendar-recurring.spec.ts
+++ b/e2e/calendar-recurring.spec.ts
@@ -53,7 +53,7 @@ test.describe("Recurring Events", () => {
 
     // Open detail modal and verify recurrence label
     const dialog = await openEventDetail(page, "Daily Standup");
-    await expect(dialog.getByText("Daily")).toBeVisible();
+    await expect(dialog.getByText("Daily", { exact: true })).toBeVisible();
   });
 
   test("creates weekly recurring event with custom days and verifies placement", async ({

--- a/e2e/calendar-recurring.spec.ts
+++ b/e2e/calendar-recurring.spec.ts
@@ -72,7 +72,13 @@ test.describe("Recurring Events", () => {
     // The event was created today, so current week should show it
     await expect(page.getByText("Gym").first()).toBeVisible({ timeout: 10000 });
 
-    // Open detail modal and verify it's marked as recurring
+    // Switch back to daily view before opening detail modal.
+    // On mobile, the FAB overlaps event cards in the narrow weekly columns,
+    // causing clicks to hit the FAB instead of the event card.
+    await viewSwitcher.locator("button").nth(0).click();
+    await page.waitForTimeout(200);
+
+    // Open detail modal and verify recurrence label
     const dialog = await openEventDetail(page, "Gym");
     await expect(dialog.getByText(/Mon, Wed/)).toBeVisible();
   });

--- a/e2e/calendar-recurring.spec.ts
+++ b/e2e/calendar-recurring.spec.ts
@@ -74,7 +74,7 @@ test.describe("Recurring Events", () => {
 
     // Open detail modal and verify it's marked as recurring
     const dialog = await openEventDetail(page, "Gym");
-    await expect(dialog.getByText("Recurring event")).toBeVisible();
+    await expect(dialog.getByText(/Mon, Wed/)).toBeVisible();
   });
 
   test("edits single instance without affecting the series", async ({
@@ -152,12 +152,8 @@ test.describe("Recurring Events", () => {
     // Verify today shows updated name
     await expect(page.getByText("Daily Sync")).toBeVisible();
 
-    // BUG (TECHNICAL-DEBT.md #1): "Edit all" from an expanded instance clears the
-    // recurrence rule because instances don't carry recurrenceRule. The form defaults
-    // RecurrencePicker to "Does not repeat", so submitting sends recurrenceRule: null.
-    // Once fixed, uncomment this assertion:
-    // await navigateDay(page, "next");
-    // await expect(page.getByText("Daily Sync")).toBeVisible();
+    await navigateDay(page, "next");
+    await expect(page.getByText("Daily Sync")).toBeVisible();
   });
 
   test("deletes single instance, then deletes entire series", async ({
@@ -256,8 +252,7 @@ test.describe("Recurring Events", () => {
     // Open detail modal and check labels
     const dialog = await openEventDetail(page, "Sprint Review");
     await expect(dialog.getByText("All day")).toBeVisible();
-    // Instances don't carry recurrenceRule (by design), so label is generic
-    await expect(dialog.getByText("Recurring event")).toBeVisible();
+    await expect(dialog.getByText(/Every 2 days/)).toBeVisible();
 
     // Close detail modal
     await page.keyboard.press("Escape");

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -162,7 +162,9 @@ export async function createEvent(
   page: Page,
   options: CreateEventOptions,
 ): Promise<void> {
-  await page.getByRole("button", { name: "Add event" }).click();
+  // Use safeClick for the FAB to handle TanStack Query DevTools overlap
+  // when running locally without VITE_E2E=true
+  await safeClick(page.getByRole("button", { name: "Add event" }));
   await expect(page.getByRole("dialog")).toBeVisible();
 
   await page.getByLabel("Event Name").fill(options.title);


### PR DESCRIPTION
## Summary

- **Fix mobile-chrome CI failure (Issue 3):** The FAB "Add event" button (`fixed bottom-8 right-8 z-40`) overlaps event cards in the weekly view on mobile viewport (390×664). `safeClick()` dispatches at the event card's center, but the FAB intercepts the click, opening the Add Event dialog instead of the Event Detail modal. Fix: switch to daily view before opening the detail modal.
- **Strengthen recurrence label assertions (Issue 1):** After BE PR #21, instances carry `recurrenceRule`, so `formatRecurrenceLabel()` returns specific labels ("Daily", "Weekly on Mon, Wed") instead of generic "Recurring event". Updated assertions and added `{ exact: true }` to avoid strict mode violation with "Daily Standup" title.
- **Fix `createEvent()` DevTools overlap (Issue 2):** Use `safeClick()` for the FAB click in `createEvent()` to handle TanStack Query DevTools overlap when running locally without `VITE_E2E=true`.

## Test plan

- [x] All 32 recurring E2E tests pass across chromium, firefox, webkit, mobile-chrome
- [x] Full E2E suite (48 tests) passes across all browsers
- [ ] CI passes on this branch