### PR TITLE
Pull versioned BE image in E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,17 @@ jobs:
       - run: npx playwright install --with-deps
       - run: npm run lint
       - run: npm run test:coverage
+      - name: Resolve stable BE version
+        run: |
+          BE_VERSION=$(curl -sf \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/joe-bor/family-hub-api/releases/latest \
+            | jq -r '.tag_name // empty' | sed 's/^v//')
+          if [ -z "$BE_VERSION" ]; then
+            echo "::warning::No BE release found — falling back to 'latest' tag"
+          fi
+          echo "BE_IMAGE_TAG=${BE_VERSION:-latest}" >> "$GITHUB_ENV"
+          echo "Using BE image tag: ${BE_VERSION:-latest}"
       - name: Start backend container
         run: docker compose -f docker-compose.e2e.yml up -d --wait
       - name: Run E2E tests (real backend)

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,6 +1,6 @@
 services:
   family-hub-api:
-    image: ghcr.io/joe-bor/family-hub-api:latest
+    image: ghcr.io/joe-bor/family-hub-api:${BE_IMAGE_TAG:-latest}
     platform: linux/amd64
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- Update `docker-compose.e2e.yml` to use `${BE_IMAGE_TAG:-latest}` instead of hardcoded `latest`
- Add "Resolve stable BE version" step in CI that queries the GitHub API for the latest BE release tag
- Falls back to `latest` if no release exists (preserves current behavior)

## Why
Depends on joe-bor/family-hub-api adding release-please (see that repo's PR). Once BE publishes semver releases, FE CI should pull the latest stable release instead of whatever was last pushed to `main`. This decouples BE incremental work from FE CI stability.

## Test plan
- [ ] Local: run `docker compose -f docker-compose.e2e.yml up -d --wait` without `BE_IMAGE_TAG` set → should pull `latest` (fallback)
- [ ] CI: verify "Resolve stable BE version" step runs and logs the resolved tag
- [ ] Before first BE release: CI falls back to `latest` with a `::warning::` annotation
- [ ] After first BE release: CI pulls the semver-tagged image (e.g., `0.1.0`)