### PR TITLE
feat: add Google Calendar frontend integration

### DIFF
--- a/.agents/skills/tech-debt/SKILL.md
+++ b/.agents/skills/tech-debt/SKILL.md
@@ -1,0 +1,98 @@
+<tech-debt-skill>
+# Technical Debt Management Skill
+
+Manages the `docs/TECHNICAL-DEBT.md` document to ensure proper tracking of technical debt items.
+
+## Usage
+
+- `/tech-debt close <item-name>` — Close a completed debt item
+- `/tech-debt audit` — Check document for issues
+- `/tech-debt add` — Add a new debt item
+
+---
+
+## Subcommands
+
+### `/tech-debt close <item-name>`
+
+Guides through properly closing a technical debt item.
+
+**Steps:**
+1. Read `docs/TECHNICAL-DEBT.md`
+2. Search for the item by name (fuzzy match on item titles)
+3. If not found, list available items and ask user to clarify
+4. Verify the fix exists (ask user for PR number if not obvious from context)
+5. **MOVE** the item to the Completed Items table (do NOT copy — remove from original section)
+6. Add proper entry with: Item description | Sprint (or `-`) | PR number | Date
+
+**Example entry:**
+```markdown
+| Item Name (brief description) | Sprint 7 | #65 | Feb 4, 2026 |
+```
+
+### `/tech-debt audit`
+
+Scans the document for common issues.
+
+**Checks to perform:**
+1. **Duplicates** — Item appears in both active sections AND Completed Items
+2. **Missing PR numbers** — Completed Items with `-` or blank PR column
+3. **Stale items** — Items marked as "Fixed" or "Completed" still in active sections
+4. **Numbering issues** — Items not numbered sequentially within sections
+
+**Output format:**
+```
+## Technical Debt Audit Results
+
+### Issues Found
+- ❌ Duplicate: "Item Name" exists in Low Priority AND Completed Items
+- ❌ Missing PR: "Item Name" in Completed Items has no PR number
+- ⚠️ Stale: "Item Name" marked as Fixed but still in Medium Priority
+
+### Summary
+Found X issues. Use `/tech-debt close` to fix duplicates.
+```
+
+If no issues: `✅ Technical debt document is clean. No issues found.`
+
+### `/tech-debt add`
+
+Guides through adding a new debt item with proper format.
+
+**Required information:**
+1. **Priority** — High, Medium, or Low
+2. **Title** — Brief descriptive title
+3. **Source** — Where was this identified? (PR number, sprint, investigation)
+4. **Files** — Which files are affected?
+5. **Problem** — What's the issue?
+6. **Suggested Fix** — How should it be resolved?
+
+**Template to use:**
+```markdown
+### N. Item Title
+**Source:** PR #XX / Sprint N / Investigation
+**Files:** `path/to/file.ts`, `path/to/other.ts`
+**Status:** Description of current state
+
+**Problem:**
+Description of the issue.
+
+**Suggested Fix:**
+- Step 1
+- Step 2
+```
+
+After adding, remind user to:
+- Number the item correctly within its priority section
+- Update "Last Updated" date at top of document
+
+---
+
+## Important Rules
+
+1. **MOVE, don't copy** — When closing items, DELETE from active section
+2. **Always include PR numbers** — Every completed item needs a PR reference
+3. **Use today's date** — Format: `Mon D, YYYY` (e.g., Feb 4, 2026)
+4. **Keep numbering sequential** — Renumber remaining items after moves/deletes
+
+</tech-debt-skill>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Commands
 

--- a/docs/superpowers/plans/2026-03-20-google-calendar-fe-integration.md
+++ b/docs/superpowers/plans/2026-03-20-google-calendar-fe-integration.md
@@ -1,0 +1,2487 @@
+# Google Calendar FE Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add frontend support for read-only Google Calendar integration — types, API layer, OAuth flow, member profile connection UI, event display changes, and description field.
+
+**Architecture:** New `google-calendar.service.ts` + `use-google-calendar.ts` handle Google-specific API calls (OAuth, sync, disconnect). Existing calendar hooks stay untouched — the BE already mixes Google events into the regular events endpoint. UI changes are localized to existing components (member profile, event cards, event detail modal, event form).
+
+**Tech Stack:** React 19, TypeScript, TanStack Query, Zustand, react-hook-form, Zod, Radix UI, Tailwind CSS v4, Vitest, Playwright
+
+**Spec:** `docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src/lib/types/google-calendar.ts` | Google Calendar types (`GoogleCalendarInfo`, `GoogleConnectionStatus`, `GoogleAuthUrl`) |
+| `src/api/services/google-calendar.service.ts` | HTTP calls to `/api/google/*` endpoints |
+| `src/api/hooks/use-google-calendar.ts` | TanStack Query hooks for Google connection management |
+| `src/components/settings/google-calendar-section.tsx` | Google Calendar section in member profile (3 states: disconnected/connected/syncing) |
+| `src/components/settings/google-calendar-picker-modal.tsx` | Modal with checkboxes for selecting which Google calendars to sync |
+| `src/hooks/use-google-auth-return.ts` | OAuth return detection + state restoration on app mount |
+| `src/components/ui/toast.tsx` | Toast notification component (Radix `@radix-ui/react-toast` already installed) |
+| `src/components/ui/toaster.tsx` | Toaster provider + `useToast` hook |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `src/lib/types/calendar.ts` | Add `source`, `description`, `htmlLink` to `CalendarEvent` + `description` to request types |
+| `src/lib/types/index.ts` | Add barrel export for `google-calendar` |
+| `src/lib/validations/calendar.ts` | Add `description` to Zod schema |
+| `src/api/services/index.ts` | Add barrel export for `googleCalendarService` |
+| `src/api/hooks/index.ts` | Add barrel exports for Google Calendar hooks |
+| `src/api/index.ts` | Add barrel exports for Google Calendar hooks + service |
+| `src/components/calendar/components/calendar-event.tsx` | Add Google "G" icon overlay |
+| `src/components/calendar/components/event-detail-modal.tsx` | Add description, "Open in Google Calendar" link, edit/delete guard toast |
+| `src/components/calendar/components/mobile-event-detail.tsx` | Same as above for mobile |
+| `src/components/calendar/components/event-form.tsx` | Add collapsible description textarea |
+| `src/components/calendar/calendar-module.tsx` | Add Google event guard before edit/delete |
+| `src/components/settings/member-profile-modal.tsx` | Add `GoogleCalendarSection`, remove "coming soon" text |
+| `src/App.tsx` | Add `useGoogleAuthReturn()` hook + `<Toaster />` |
+
+---
+
+## Task 1: Toast Component (dependency for later tasks)
+
+The app needs toast notifications for the Google event guard and OAuth return feedback. `@radix-ui/react-toast` is already installed but no component exists.
+
+**Files:**
+- Create: `src/components/ui/toast.tsx`
+- Create: `src/components/ui/toaster.tsx`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Create the toast component using shadcn/ui pattern**
+
+```typescript
+// src/components/ui/toast.tsx
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const Toast = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & {
+    variant?: "default" | "destructive";
+  }
+>(({ className, variant = "default", ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(
+      "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-4 shadow-lg transition-all",
+      "data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+      variant === "destructive"
+        ? "border-destructive bg-destructive text-destructive-foreground"
+        : "border-border bg-background text-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium",
+      "hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none disabled:opacity-50",
+      "group-[.destructive]:border-destructive/30 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100",
+      "group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+};
+
+export type ToastActionElement = React.ReactElement<typeof ToastAction>;
+```
+
+- [ ] **Step 2: Create the toaster hook and provider**
+
+```typescript
+// src/components/ui/toaster.tsx
+import { useEffect, useState } from "react";
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+  type ToastActionElement,
+} from "@/components/ui/toast";
+
+const TOAST_LIMIT = 3;
+const TOAST_REMOVE_DELAY = 5000;
+
+type ToastData = {
+  id: string;
+  title?: string;
+  description?: string;
+  action?: ToastActionElement;
+  variant?: "default" | "destructive";
+  open: boolean;
+};
+
+let toastCount = 0;
+const listeners: Array<(toasts: ToastData[]) => void> = [];
+let memoryToasts: ToastData[] = [];
+
+function genId() {
+  toastCount = (toastCount + 1) % Number.MAX_SAFE_INTEGER;
+  return toastCount.toString();
+}
+
+function dispatch(toasts: ToastData[]) {
+  memoryToasts = toasts;
+  listeners.forEach((listener) => listener(toasts));
+}
+
+export function toast({
+  title,
+  description,
+  action,
+  variant,
+}: Omit<ToastData, "id" | "open">) {
+  const id = genId();
+  const newToast: ToastData = { id, title, description, action, variant, open: true };
+
+  dispatch([newToast, ...memoryToasts].slice(0, TOAST_LIMIT));
+
+  setTimeout(() => {
+    dispatch(memoryToasts.map((t) => (t.id === id ? { ...t, open: false } : t)));
+  }, TOAST_REMOVE_DELAY);
+
+  return id;
+}
+
+function useToastState() {
+  const [toasts, setToasts] = useState<ToastData[]>(memoryToasts);
+
+  useEffect(() => {
+    listeners.push(setToasts);
+    return () => {
+      const index = listeners.indexOf(setToasts);
+      if (index > -1) listeners.splice(index, 1);
+    };
+  }, []);
+
+  return toasts;
+}
+
+export function Toaster() {
+  const toasts = useToastState();
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, variant, open }) => (
+        <Toast key={id} open={open} variant={variant}>
+          <div className="grid gap-1">
+            {title && <ToastTitle>{title}</ToastTitle>}
+            {description && <ToastDescription>{description}</ToastDescription>}
+          </div>
+          {action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}
+```
+
+- [ ] **Step 3: Add Toaster to App.tsx**
+
+In `src/App.tsx`, import `{ Toaster }` from `@/components/ui/toaster` and add `<Toaster />` as the last child inside the root fragment or after the main layout div — it renders a portal so placement doesn't matter structurally, but it must be inside the component tree.
+
+```typescript
+// Add import
+import { Toaster } from "@/components/ui/toaster";
+
+// In the return of FamilyHub component, add after closing </div>:
+// Before the final return's closing fragment or as sibling to the layout div:
+<Toaster />
+```
+
+The `<Toaster />` should be rendered in ALL states (authenticated and unauthenticated) since OAuth return toasts fire before full auth check. Place it outside the auth conditionals, right before the function's closing.
+
+- [ ] **Step 4: Verify toast works manually**
+
+Run: `npm run dev`
+
+In browser console, test: Import toast and fire a test notification to verify the setup works. Then remove the test code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ui/toast.tsx src/components/ui/toaster.tsx src/App.tsx
+git commit -m "feat(ui): add toast notification component using Radix Toast"
+```
+
+---
+
+## Task 2: Type Changes
+
+**Files:**
+- Modify: `src/lib/types/calendar.ts`
+- Create: `src/lib/types/google-calendar.ts`
+- Modify: `src/lib/types/index.ts`
+- Modify: `src/lib/validations/calendar.ts`
+
+- [ ] **Step 1: Extend CalendarEvent type**
+
+In `src/lib/types/calendar.ts`, add three optional fields to the `CalendarEvent` interface:
+
+```typescript
+export interface CalendarEvent {
+  id: string | null;
+  title: string;
+  startTime: string;
+  endTime: string;
+  date: Date;
+  endDate?: Date;
+  memberId: string;
+  isAllDay: boolean;
+  location?: string;
+  recurrenceRule?: string;
+  recurringEventId?: string;
+  isRecurring?: boolean;
+  // Google Calendar integration
+  source?: "NATIVE" | "GOOGLE";
+  description?: string;
+  htmlLink?: string;
+}
+```
+
+Add `description` to both request types:
+
+```typescript
+export interface CreateEventRequest {
+  title: string;
+  startTime: string;
+  endTime: string;
+  date: string;
+  endDate?: string | null;
+  memberId: string;
+  isAllDay?: boolean;
+  location?: string;
+  recurrenceRule?: string | null;
+  description?: string;
+}
+
+export interface UpdateEventRequest {
+  title: string;
+  startTime: string;
+  endTime: string;
+  date: string;
+  endDate?: string | null;
+  memberId: string;
+  isAllDay?: boolean;
+  location?: string;
+  recurrenceRule?: string | null;
+  description?: string;
+}
+```
+
+- [ ] **Step 2: Create google-calendar.ts types**
+
+```typescript
+// src/lib/types/google-calendar.ts
+
+export interface GoogleAuthUrl {
+  url: string;
+}
+
+export interface GoogleCalendarInfo {
+  id: string;
+  name: string;
+  primary: boolean;
+  enabled: boolean;
+}
+
+export interface GoogleConnectionStatus {
+  connected: boolean;
+  calendars: Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    lastSyncedAt: string | null;
+  }>;
+}
+```
+
+- [ ] **Step 3: Update barrel exports**
+
+In `src/lib/types/index.ts`, add:
+
+```typescript
+export * from "./google-calendar";
+```
+
+- [ ] **Step 4: Add description to Zod schema**
+
+In `src/lib/validations/calendar.ts`, add `description` to the `.object({})` block, after the `location` field:
+
+```typescript
+    description: z
+      .string()
+      .max(2000, "Description must be 2000 characters or less")
+      .optional(),
+```
+
+- [ ] **Step 5: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors — all new fields are optional so existing code compiles.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/types/calendar.ts src/lib/types/google-calendar.ts src/lib/types/index.ts src/lib/validations/calendar.ts
+git commit -m "feat(types): add Google Calendar types and description field"
+```
+
+---
+
+## Task 3: Google Calendar API Service
+
+**Files:**
+- Create: `src/api/services/google-calendar.service.ts`
+- Modify: `src/api/services/index.ts`
+
+- [ ] **Step 1: Write the service tests**
+
+Create `src/api/services/google-calendar.service.test.ts` to verify each service method makes the correct HTTP call. Use MSW to mock API responses.
+
+```typescript
+// src/api/services/google-calendar.service.test.ts
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
+import { googleCalendarService } from "./google-calendar.service";
+
+const MEMBER_ID = "member-123";
+
+describe("googleCalendarService", () => {
+  describe("getAuthUrl", () => {
+    it("returns the OAuth redirect URL", async () => {
+      server.use(
+        http.get("*/google/auth", () =>
+          HttpResponse.json({
+            data: { url: "https://accounts.google.com/o/oauth2/v2/auth?..." },
+            message: null,
+          }),
+        ),
+      );
+
+      const result = await googleCalendarService.getAuthUrl(MEMBER_ID);
+      expect(result.data.url).toContain("accounts.google.com");
+    });
+  });
+
+  describe("getConnectionStatus", () => {
+    it("returns connection status for a member", async () => {
+      server.use(
+        http.get(`*/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: { connected: true, calendars: [] },
+            message: null,
+          }),
+        ),
+      );
+
+      const result = await googleCalendarService.getConnectionStatus(MEMBER_ID);
+      expect(result.data.connected).toBe(true);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("calls DELETE endpoint", async () => {
+      server.use(
+        http.delete(`*/google/disconnect/${MEMBER_ID}`, () =>
+          new HttpResponse(null, { status: 204 }),
+        ),
+      );
+
+      await expect(
+        googleCalendarService.disconnect(MEMBER_ID),
+      ).resolves.not.toThrow();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/api/services/google-calendar.service.test.ts`
+Expected: FAIL — `googleCalendarService` not found.
+
+- [ ] **Step 3: Create the service**
+
+```typescript
+// src/api/services/google-calendar.service.ts
+import { httpClient } from "@/api/client";
+import type {
+  ApiResponse,
+  GoogleAuthUrl,
+  GoogleCalendarInfo,
+  GoogleConnectionStatus,
+} from "@/lib/types";
+
+export const googleCalendarService = {
+  async getAuthUrl(memberId: string): Promise<ApiResponse<GoogleAuthUrl>> {
+    return httpClient.get<ApiResponse<GoogleAuthUrl>>("/google/auth", {
+      params: { memberId },
+    });
+  },
+
+  async getConnectionStatus(
+    memberId: string,
+  ): Promise<ApiResponse<GoogleConnectionStatus>> {
+    return httpClient.get<ApiResponse<GoogleConnectionStatus>>(
+      `/google/status/${memberId}`,
+    );
+  },
+
+  async getCalendars(
+    memberId: string,
+  ): Promise<ApiResponse<GoogleCalendarInfo[]>> {
+    return httpClient.get<ApiResponse<GoogleCalendarInfo[]>>(
+      `/google/calendars/${memberId}`,
+    );
+  },
+
+  async updateCalendars(
+    memberId: string,
+    calendarIds: string[],
+  ): Promise<ApiResponse<GoogleCalendarInfo[]>> {
+    return httpClient.put<ApiResponse<GoogleCalendarInfo[]>>(
+      `/google/calendars/${memberId}`,
+      { calendarIds },
+    );
+  },
+
+  async syncCalendar(memberId: string): Promise<void> {
+    return httpClient.post(`/google/sync/${memberId}`);
+  },
+
+  async disconnect(memberId: string): Promise<void> {
+    return httpClient.delete(`/google/disconnect/${memberId}`);
+  },
+};
+```
+
+- [ ] **Step 4: Update barrel export**
+
+In `src/api/services/index.ts`, add:
+
+```typescript
+export { googleCalendarService } from "./google-calendar.service";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/api/services/google-calendar.service.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/api/services/google-calendar.service.ts src/api/services/google-calendar.service.test.ts src/api/services/index.ts
+git commit -m "feat(api): add Google Calendar service layer"
+```
+
+---
+
+## Task 4: Google Calendar TanStack Query Hooks
+
+**Files:**
+- Create: `src/api/hooks/use-google-calendar.ts`
+- Modify: `src/api/hooks/index.ts`
+- Modify: `src/api/index.ts`
+
+- [ ] **Step 1: Write hook tests**
+
+Create `src/api/hooks/use-google-calendar.test.tsx`. Test the query hooks return data and mutation hooks invalidate correct keys.
+
+```typescript
+// src/api/hooks/use-google-calendar.test.tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { server } from "@/test/mocks/server";
+import { calendarKeys } from "./use-calendar";
+import {
+  googleCalendarKeys,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+} from "./use-google-calendar";
+
+const MEMBER_ID = "member-123";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useGoogleConnectionStatus", () => {
+  it("fetches connection status for a member", async () => {
+    server.use(
+      http.get(`*/google/status/${MEMBER_ID}`, () =>
+        HttpResponse.json({
+          data: { connected: false, calendars: [] },
+          message: null,
+        }),
+      ),
+    );
+
+    const { result } = renderHook(
+      () => useGoogleConnectionStatus(MEMBER_ID),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data.connected).toBe(false);
+  });
+
+  it("does not fetch when memberId is empty", () => {
+    const { result } = renderHook(
+      () => useGoogleConnectionStatus(""),
+      { wrapper: createWrapper() },
+    );
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe("useSyncGoogleCalendar", () => {
+  it("invalidates status and events on success", async () => {
+    server.use(
+      http.post(`*/google/sync/${MEMBER_ID}`, () =>
+        new HttpResponse(null, { status: 200 }),
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    // Seed cache
+    queryClient.setQueryData(googleCalendarKeys.status(MEMBER_ID), {
+      data: { connected: true, calendars: [] },
+    });
+    queryClient.setQueryData(calendarKeys.events(), { data: [] });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSyncGoogleCalendar(), {
+      wrapper,
+    });
+
+    result.current.mutate(MEMBER_ID);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Verify cache was invalidated
+    expect(
+      queryClient.getQueryState(googleCalendarKeys.status(MEMBER_ID))?.isInvalidated,
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/api/hooks/use-google-calendar.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the hooks**
+
+```typescript
+// src/api/hooks/use-google-calendar.ts
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ApiException } from "@/api/client";
+import { googleCalendarService } from "@/api/services";
+import type {
+  ApiResponse,
+  GoogleCalendarInfo,
+  GoogleConnectionStatus,
+} from "@/lib/types";
+import { calendarKeys } from "./use-calendar";
+
+export const googleCalendarKeys = {
+  all: ["google-calendar"] as const,
+  status: (memberId: string) =>
+    [...googleCalendarKeys.all, "status", memberId] as const,
+  calendars: (memberId: string) =>
+    [...googleCalendarKeys.all, "calendars", memberId] as const,
+};
+
+// Queries
+
+export function useGoogleConnectionStatus(memberId: string) {
+  return useQuery({
+    queryKey: googleCalendarKeys.status(memberId),
+    queryFn: () => googleCalendarService.getConnectionStatus(memberId),
+    enabled: !!memberId,
+    staleTime: 30 * 1000, // 30 seconds — status changes infrequently
+  });
+}
+
+export function useGoogleCalendars(memberId: string, enabled = true) {
+  return useQuery({
+    queryKey: googleCalendarKeys.calendars(memberId),
+    queryFn: () => googleCalendarService.getCalendars(memberId),
+    enabled: !!memberId && enabled,
+  });
+}
+
+// Mutations
+
+interface GoogleMutationCallbacks<T = void> {
+  onSuccess?: (data: T) => void;
+  onError?: (error: ApiException) => void;
+}
+
+export function useUpdateGoogleCalendars(
+  callbacks?: GoogleMutationCallbacks<ApiResponse<GoogleCalendarInfo[]>>,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      memberId,
+      calendarIds,
+    }: {
+      memberId: string;
+      calendarIds: string[];
+    }) => googleCalendarService.updateCalendars(memberId, calendarIds),
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.calendars(variables.memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(variables.memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.(data);
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+export function useSyncGoogleCalendar(
+  callbacks?: GoogleMutationCallbacks,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (memberId: string) =>
+      googleCalendarService.syncCalendar(memberId),
+    onSuccess: (_data, memberId) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.();
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+export function useDisconnectGoogle(
+  callbacks?: GoogleMutationCallbacks,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (memberId: string) =>
+      googleCalendarService.disconnect(memberId),
+    onSuccess: (_data, memberId) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.();
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Update barrel exports**
+
+In `src/api/hooks/index.ts`, add:
+
+```typescript
+export {
+  googleCalendarKeys,
+  useDisconnectGoogle,
+  useGoogleCalendars,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+  useUpdateGoogleCalendars,
+} from "./use-google-calendar";
+```
+
+In `src/api/index.ts`, add to the hooks export block:
+
+```typescript
+  googleCalendarKeys,
+  useDisconnectGoogle,
+  useGoogleCalendars,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+  useUpdateGoogleCalendars,
+```
+
+And to the services export:
+
+```typescript
+export { authService, calendarService, familyService, googleCalendarService } from "./services";
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/api/hooks/use-google-calendar.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Run full type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api/hooks/use-google-calendar.ts src/api/hooks/use-google-calendar.test.tsx src/api/hooks/index.ts src/api/index.ts
+git commit -m "feat(api): add Google Calendar TanStack Query hooks"
+```
+
+---
+
+## Task 5: Google "G" Icon on Event Cards
+
+**Files:**
+- Modify: `src/components/calendar/components/calendar-event.tsx`
+
+- [ ] **Step 1: Write tests for the Google icon**
+
+Create `src/components/calendar/components/calendar-event.test.tsx`:
+
+```typescript
+import { render, screen } from "@/test/test-utils";
+import type { CalendarEvent } from "@/lib/types";
+import { CalendarEventCard } from "./calendar-event";
+
+// Mock useFamilyMembers to return test data
+vi.mock("@/api", () => ({
+  useFamilyMembers: () => [
+    { id: "m1", name: "Alice", color: "coral" as const },
+  ],
+}));
+
+const baseEvent: CalendarEvent = {
+  id: "e1",
+  title: "Test Event",
+  startTime: "09:00",
+  endTime: "10:00",
+  date: new Date("2026-01-15"),
+  memberId: "m1",
+  isAllDay: false,
+};
+
+describe("CalendarEventCard", () => {
+  it("does not show Google icon for native events", () => {
+    render(<CalendarEventCard event={baseEvent} />);
+    expect(screen.queryByLabelText("Google Calendar event")).not.toBeInTheDocument();
+  });
+
+  it("does not show Google icon when source is NATIVE", () => {
+    render(<CalendarEventCard event={{ ...baseEvent, source: "NATIVE" }} />);
+    expect(screen.queryByLabelText("Google Calendar event")).not.toBeInTheDocument();
+  });
+
+  it("shows Google icon when source is GOOGLE", () => {
+    render(<CalendarEventCard event={{ ...baseEvent, source: "GOOGLE" }} />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+  });
+
+  it("shows Google icon in all variants", () => {
+    const googleEvent = { ...baseEvent, source: "GOOGLE" as const };
+
+    const { rerender } = render(<CalendarEventCard event={googleEvent} variant="default" />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+
+    rerender(<CalendarEventCard event={googleEvent} variant="large" />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+
+    rerender(<CalendarEventCard event={googleEvent} variant="compact" />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/calendar/components/calendar-event.test.tsx`
+Expected: FAIL — no element with label "Google Calendar event"
+
+- [ ] **Step 3: Add Google icon to CalendarEventCard**
+
+Create a `GoogleIcon` component inline in `calendar-event.tsx` (a small Google "G" SVG). Add it to each variant when `event.source === "GOOGLE"`.
+
+```typescript
+// Add at top of file, after imports:
+function GoogleBadge({ size = 14 }: { size?: number }) {
+  return (
+    <span
+      aria-label="Google Calendar event"
+      className="inline-flex items-center justify-center rounded-full bg-white/70 shadow-sm"
+      style={{ width: size + 6, height: size + 6 }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+        <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+        <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+        <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+      </svg>
+    </span>
+  );
+}
+
+const isGoogleEvent = (event: CalendarEvent) => event.source === "GOOGLE";
+```
+
+For each variant, add the badge:
+
+**Default variant** — add after the existing member dot in the top-right area (line ~123-130 area):
+
+```typescript
+// In the default variant's right-side icons area, add:
+{isGoogleEvent(event) && <GoogleBadge size={12} />}
+```
+
+**Large variant** — add in the top-right of the card content:
+
+```typescript
+// After the <div className="flex-1 min-w-0"> in the large variant, add a positioned badge:
+{isGoogleEvent(event) && (
+  <div className="shrink-0 mt-0.5">
+    <GoogleBadge size={14} />
+  </div>
+)}
+```
+
+**Compact variant** — smaller badge:
+
+```typescript
+// Add at end of the inner flex div:
+{isGoogleEvent(event) && (
+  <div className="shrink-0">
+    <GoogleBadge size={10} />
+  </div>
+)}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/calendar/components/calendar-event.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/calendar/components/calendar-event.tsx src/components/calendar/components/calendar-event.test.tsx
+git commit -m "feat(calendar): add Google icon badge to event cards"
+```
+
+---
+
+## Task 6: Event Detail Modal — Description, Google Link, Guard
+
+**Files:**
+- Modify: `src/components/calendar/components/event-detail-modal.tsx`
+- Modify: `src/components/calendar/components/mobile-event-detail.tsx`
+
+- [ ] **Step 1: Write tests for desktop EventDetailModal Google event behavior**
+
+Create `src/components/calendar/components/event-detail-modal.test.tsx`:
+
+```typescript
+import { render, screen } from "@/test/test-utils";
+import { userEvent } from "@testing-library/user-event";
+import type { CalendarEvent } from "@/lib/types";
+import { EventDetailModal } from "./event-detail-modal";
+
+// Mock useIsMobile to test desktop variant
+vi.mock("@/hooks", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/api", () => ({
+  useFamilyMembers: () => [
+    { id: "m1", name: "Alice", color: "coral" as const },
+  ],
+}));
+
+// Mock toast
+const mockToast = vi.fn();
+vi.mock("@/components/ui/toaster", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const baseEvent: CalendarEvent = {
+  id: "e1",
+  title: "Test Event",
+  startTime: "09:00",
+  endTime: "10:00",
+  date: new Date("2026-01-15"),
+  memberId: "m1",
+  isAllDay: false,
+};
+
+const mockClose = vi.fn();
+const mockEdit = vi.fn();
+const mockDelete = vi.fn();
+
+const defaultProps = {
+  event: baseEvent,
+  isOpen: true,
+  onClose: mockClose,
+  onEdit: mockEdit,
+  onDelete: mockDelete,
+};
+
+describe("EventDetailModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows description when present", () => {
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, description: "Meeting notes here" }}
+      />,
+    );
+    expect(screen.getByText("Meeting notes here")).toBeInTheDocument();
+  });
+
+  it("does not show description section when absent", () => {
+    render(<EventDetailModal {...defaultProps} />);
+    expect(screen.queryByText("Meeting notes here")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Open in Google Calendar' link for Google events", () => {
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{
+          ...baseEvent,
+          source: "GOOGLE",
+          htmlLink: "https://calendar.google.com/event/123",
+        }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /open in google calendar/i });
+    expect(link).toHaveAttribute("href", "https://calendar.google.com/event/123");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("shows toast when clicking Edit on a Google event", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, source: "GOOGLE" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(mockToast).toHaveBeenCalled();
+    expect(mockEdit).not.toHaveBeenCalled();
+  });
+
+  it("shows toast when clicking Delete on a Google event", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, source: "GOOGLE" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+    expect(mockToast).toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("calls onEdit normally for native events", async () => {
+    const user = userEvent.setup();
+    render(<EventDetailModal {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(mockEdit).toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/calendar/components/event-detail-modal.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Update EventDetailModal**
+
+In `src/components/calendar/components/event-detail-modal.tsx`:
+
+1. Import `toast` from `@/components/ui/toaster` and `ExternalLink`, `FileText` from `lucide-react`
+2. Add a Google event guard helper:
+
+```typescript
+const isGoogleEvent = event.source === "GOOGLE";
+
+const handleEditClick = () => {
+  if (isGoogleEvent) {
+    toast({
+      title: "Synced from Google Calendar",
+      description: "Edit this event in Google Calendar.",
+      action: event.htmlLink ? (
+        <ToastAction altText="Open in Google Calendar" asChild>
+          <a href={event.htmlLink} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        </ToastAction>
+      ) : undefined,
+    });
+    return;
+  }
+  onEdit();
+};
+
+const handleDeleteAttempt = () => {
+  if (isGoogleEvent) {
+    toast({
+      title: "Synced from Google Calendar",
+      description: "Delete this event in Google Calendar.",
+      action: event.htmlLink ? (
+        <ToastAction altText="Open in Google Calendar" asChild>
+          <a href={event.htmlLink} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        </ToastAction>
+      ) : undefined,
+    });
+    return;
+  }
+  handleDeleteClick();
+};
+```
+
+3. Wire these handlers to the Edit and Delete buttons (replace `onEdit` with `handleEditClick`, `handleDeleteClick` with `handleDeleteAttempt`)
+
+4. Add description display after location, before error message:
+
+```tsx
+{/* Description (conditional) */}
+{event.description && (
+  <div className="flex items-start gap-3 text-muted-foreground">
+    <FileText className="w-4 h-4 shrink-0 mt-0.5" />
+    <p className="text-sm whitespace-pre-wrap">{event.description}</p>
+  </div>
+)}
+
+{/* Open in Google Calendar (conditional) */}
+{isGoogleEvent && event.htmlLink && (
+  <div className="flex items-center gap-3">
+    <ExternalLink className="w-4 h-4 shrink-0 text-muted-foreground" />
+    <a
+      href={event.htmlLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-sm text-primary hover:underline"
+    >
+      Open in Google Calendar
+    </a>
+  </div>
+)}
+```
+
+5. Also import `ToastAction` from `@/components/ui/toast`.
+
+- [ ] **Step 4: Update MobileEventDetail with same changes**
+
+In `src/components/calendar/components/mobile-event-detail.tsx`:
+
+1. Import `toast` from `@/components/ui/toaster`, `ExternalLink`, `FileText` from `lucide-react`, `ToastAction` from `@/components/ui/toast`
+2. Add the same Google event guard logic for Edit and Delete buttons
+3. Add description display and "Open in Google Calendar" link in the detail rows section
+4. Wire the guarded handlers to the Edit and Delete buttons in the header
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/calendar/components/event-detail-modal.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/calendar/components/event-detail-modal.tsx src/components/calendar/components/event-detail-modal.test.tsx src/components/calendar/components/mobile-event-detail.tsx
+git commit -m "feat(calendar): add description, Google link, and edit/delete guard to event detail"
+```
+
+---
+
+## Task 7: CalendarModule — Orchestrator-Level Google Event Guard
+
+**Files:**
+- Modify: `src/components/calendar/calendar-module.tsx`
+
+- [ ] **Step 1: Add Google event guard to handleEditClick and handleDeleteEvent**
+
+In `calendar-module.tsx`, import `toast` from `@/components/ui/toaster` and `ToastAction` from `@/components/ui/toast`.
+
+Update `handleEditClick`:
+
+```typescript
+const handleEditClick = () => {
+  if (!selectedEvent) return;
+
+  // Guard: Google events are read-only
+  if (selectedEvent.source === "GOOGLE") {
+    toast({
+      title: "Synced from Google Calendar",
+      description: "Edit this event in Google Calendar.",
+      action: selectedEvent.htmlLink ? (
+        <ToastAction altText="Open in Google Calendar" asChild>
+          <a href={selectedEvent.htmlLink} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        </ToastAction>
+      ) : undefined,
+    });
+    return;
+  }
+
+  if (selectedEvent.isRecurring) {
+    setScopeAction("edit");
+    setScopeDialogOpen(true);
+  } else {
+    openEditModal(selectedEvent);
+  }
+};
+```
+
+Update `handleDeleteEvent`:
+
+```typescript
+const handleDeleteEvent = () => {
+  if (!selectedEvent) return;
+
+  // Guard: Google events are read-only
+  if (selectedEvent.source === "GOOGLE") {
+    toast({
+      title: "Synced from Google Calendar",
+      description: "Delete this event in Google Calendar.",
+      action: selectedEvent.htmlLink ? (
+        <ToastAction altText="Open in Google Calendar" asChild>
+          <a href={selectedEvent.htmlLink} target="_blank" rel="noopener noreferrer">
+            Open
+          </a>
+        </ToastAction>
+      ) : undefined,
+    });
+    return;
+  }
+
+  if (selectedEvent.isRecurring) {
+    setScopeAction("delete");
+    setScopeDialogOpen(true);
+  } else {
+    if (!selectedEvent.id) return;
+    deleteEvent.mutate(selectedEvent.id);
+  }
+};
+```
+
+Also add `description` to `handleAddEvent` and `handleUpdateEvent` request objects:
+
+```typescript
+// In handleAddEvent, add to the request:
+description: formData.description,
+
+// In handleUpdateEvent, add to the request:
+description: formData.description,
+```
+
+- [ ] **Step 2: Run type check and existing tests**
+
+Run: `npx tsc --noEmit && npx vitest run --reporter=verbose`
+Expected: All pass — no behavioral change for native events.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/calendar/calendar-module.tsx
+git commit -m "feat(calendar): add Google event guard at orchestrator level and description in mutations"
+```
+
+---
+
+## Task 8: Event Form — Collapsible Description Field
+
+**Files:**
+- Modify: `src/components/calendar/components/event-form.tsx`
+
+- [ ] **Step 1: Write tests for description field behavior**
+
+Add tests to `src/components/calendar/components/event-form.test.tsx` (create if doesn't exist):
+
+```typescript
+import { render, screen } from "@/test/test-utils";
+import { userEvent } from "@testing-library/user-event";
+import { EventForm } from "./event-form";
+
+vi.mock("@/api", () => ({
+  useFamilyMembers: () => [
+    { id: "m1", name: "Alice", color: "coral" as const },
+  ],
+}));
+
+describe("EventForm description field", () => {
+  const defaultProps = {
+    mode: "add" as const,
+    onSubmit: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("hides description textarea by default in add mode", () => {
+    render(<EventForm {...defaultProps} />);
+    expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/add description/i)).toBeInTheDocument();
+  });
+
+  it("shows description textarea when 'Add description' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<EventForm {...defaultProps} />);
+
+    await user.click(screen.getByText(/add description/i));
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+  });
+
+  it("auto-expands in edit mode when description has value", () => {
+    render(
+      <EventForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{
+          title: "Test",
+          date: "2026-01-15",
+          startTime: "09:00",
+          endTime: "10:00",
+          memberId: "m1",
+          description: "Some notes",
+        }}
+      />,
+    );
+    expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description/i)).toHaveValue("Some notes");
+  });
+
+  it("does not auto-expand in edit mode when description is empty", () => {
+    render(
+      <EventForm
+        {...defaultProps}
+        mode="edit"
+        defaultValues={{
+          title: "Test",
+          date: "2026-01-15",
+          startTime: "09:00",
+          endTime: "10:00",
+          memberId: "m1",
+        }}
+      />,
+    );
+    expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/calendar/components/event-form.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Add collapsible description to EventForm**
+
+In `src/components/calendar/components/event-form.tsx`:
+
+1. Import `ChevronDown` from `lucide-react`
+2. Add `useState` for description visibility:
+
+```typescript
+const [showDescription, setShowDescription] = useState(false);
+```
+
+3. Watch the description value:
+
+```typescript
+const descriptionValue = watch("description");
+```
+
+4. Auto-expand if description has a value (in the existing useEffect or a new one):
+
+```typescript
+useEffect(() => {
+  if (initialValues.description) {
+    setShowDescription(true);
+  }
+}, [initialValues.description]);
+```
+
+5. Add the description section after the "Assign To" (member selector) section, before the action buttons. Note: the form has no location input field — location is only shown on event cards and detail modals.
+
+```tsx
+{/* Description (collapsible) */}
+<div className="space-y-2">
+  {!showDescription ? (
+    <button
+      type="button"
+      onClick={() => setShowDescription(true)}
+      className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <ChevronDown className="w-3.5 h-3.5" />
+      Add description
+    </button>
+  ) : (
+    <>
+      <Label htmlFor="description">Description</Label>
+      <textarea
+        id="description"
+        {...register("description")}
+        placeholder="Add notes or details..."
+        className={cn(
+          "flex min-h-[80px] w-full rounded-md border border-input bg-input px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y",
+          errors.description && "border-destructive",
+        )}
+        maxLength={2000}
+        aria-invalid={!!errors.description}
+      />
+      {descriptionValue && descriptionValue.length > 1900 && (
+        <p className="text-xs text-muted-foreground text-right">
+          {descriptionValue.length}/2000
+        </p>
+      )}
+      <FormError message={errors.description?.message} />
+    </>
+  )}
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/calendar/components/event-form.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/calendar/components/event-form.tsx src/components/calendar/components/event-form.test.tsx
+git commit -m "feat(calendar): add collapsible description field to event form"
+```
+
+---
+
+## Task 9: Google Calendar Picker Modal
+
+> **Note:** This task is ordered before the Google Calendar Section (Task 10) because `GoogleCalendarSection` imports `GoogleCalendarPickerModal`.
+
+**Files:**
+- Create: `src/components/settings/google-calendar-picker-modal.tsx`
+
+- [ ] **Step 1: Write tests for GoogleCalendarPickerModal**
+
+Create `src/components/settings/google-calendar-picker-modal.test.tsx`:
+
+```typescript
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@/test/test-utils";
+import { userEvent } from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { server } from "@/test/mocks/server";
+import { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+
+const MEMBER_ID = "member-123";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("GoogleCalendarPickerModal", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`*/google/calendars/${MEMBER_ID}`, () =>
+        HttpResponse.json({
+          data: [
+            { id: "primary", name: "Main Calendar", primary: true, enabled: true },
+            { id: "work@group.calendar.google.com", name: "Work", primary: false, enabled: false },
+          ],
+          message: null,
+        }),
+      ),
+    );
+  });
+
+  it("shows calendars with checkboxes", async () => {
+    render(
+      <GoogleCalendarPickerModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId={MEMBER_ID}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    expect(await screen.findByText(/Main Calendar/i)).toBeInTheDocument();
+    expect(screen.getByText(/\(Primary\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Work/i)).toBeInTheDocument();
+  });
+
+  it("primary calendar is checked, non-enabled is unchecked", async () => {
+    render(
+      <GoogleCalendarPickerModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId={MEMBER_ID}
+      />,
+      { wrapper: createWrapper() },
+    );
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked(); // Main Calendar — enabled: true
+    expect(checkboxes[1]).not.toBeChecked(); // Work — enabled: false
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/settings/google-calendar-picker-modal.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Create the component**
+
+```typescript
+// src/components/settings/google-calendar-picker-modal.tsx
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useGoogleCalendars, useUpdateGoogleCalendars } from "@/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "@/components/ui/toaster";
+
+interface GoogleCalendarPickerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memberId: string;
+}
+
+export function GoogleCalendarPickerModal({
+  open,
+  onOpenChange,
+  memberId,
+}: GoogleCalendarPickerModalProps) {
+  const { data: calendarsResponse, isLoading } = useGoogleCalendars(memberId, open);
+  const updateCalendars = useUpdateGoogleCalendars();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const calendars = calendarsResponse?.data ?? [];
+
+  // Sort: primary first, then alphabetical
+  const sortedCalendars = [...calendars].sort((a, b) => {
+    if (a.primary && !b.primary) return -1;
+    if (!a.primary && b.primary) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  // Sync local state when data loads — use stringified key to avoid
+  // infinite re-renders from unstable array references
+  const calendarKey = calendars.map((c) => `${c.id}:${c.enabled}`).join(",");
+  useEffect(() => {
+    if (calendars.length > 0) {
+      setSelectedIds(new Set(calendars.filter((c) => c.enabled).map((c) => c.id)));
+    }
+  }, [calendarKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleToggle = (calendarId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(calendarId)) {
+        next.delete(calendarId);
+      } else {
+        next.add(calendarId);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    updateCalendars.mutate(
+      { memberId, calendarIds: Array.from(selectedIds) },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          toast({ title: "Calendars updated", description: "Your calendar selection has been saved." });
+        },
+        onError: () => {
+          toast({ title: "Update failed", description: "Could not save calendar selection.", variant: "destructive" });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Choose Calendars</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="space-y-2 py-2">
+            {sortedCalendars.map((cal) => (
+              <label
+                key={cal.id}
+                className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted cursor-pointer transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(cal.id)}
+                  onChange={() => handleToggle(cal.id)}
+                  className="rounded border-border"
+                />
+                <span className="text-sm">
+                  {cal.name}
+                  {cal.primary && (
+                    <span className="text-muted-foreground ml-1">(Primary)</span>
+                  )}
+                </span>
+              </label>
+            ))}
+            {sortedCalendars.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No calendars found
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={updateCalendars.isPending || isLoading}
+          >
+            {updateCalendars.isPending ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 4: Update settings barrel export**
+
+Check if `src/components/settings/index.ts` exists and add exports for the new components:
+
+```typescript
+export { GoogleCalendarSection } from "./google-calendar-section";
+export { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run src/components/settings/google-calendar-picker-modal.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/settings/google-calendar-picker-modal.tsx src/components/settings/google-calendar-picker-modal.test.tsx src/components/settings/index.ts
+git commit -m "feat(settings): add Google Calendar picker modal"
+```
+
+---
+
+## Task 10: Google Calendar Section in Member Profile
+
+**Files:**
+- Create: `src/components/settings/google-calendar-section.tsx`
+- Modify: `src/components/settings/member-profile-modal.tsx`
+
+- [ ] **Step 1: Write tests for GoogleCalendarSection**
+
+Create `src/components/settings/google-calendar-section.test.tsx`:
+
+```typescript
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@/test/test-utils";
+import { http, HttpResponse } from "msw";
+import type { ReactNode } from "react";
+import { server } from "@/test/mocks/server";
+import { GoogleCalendarSection } from "./google-calendar-section";
+
+const MEMBER_ID = "member-123";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("GoogleCalendarSection", () => {
+  describe("disconnected state", () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`*/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: { connected: false, calendars: [] },
+            message: null,
+          }),
+        ),
+      );
+    });
+
+    it("shows connect button when member has email", async () => {
+      render(
+        <GoogleCalendarSection memberId={MEMBER_ID} memberEmail="test@example.com" memberName="Alice" />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(await screen.findByRole("button", { name: /connect google calendar/i })).toBeInTheDocument();
+    });
+
+    it("disables connect button when member has no email", async () => {
+      render(
+        <GoogleCalendarSection memberId={MEMBER_ID} memberEmail="" memberName="Alice" />,
+        { wrapper: createWrapper() },
+      );
+
+      const button = await screen.findByRole("button", { name: /connect google calendar/i });
+      expect(button).toBeDisabled();
+      expect(screen.getByText(/add an email/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("connected state", () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`*/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: {
+              connected: true,
+              calendars: [
+                { id: "primary", name: "Main Calendar", enabled: true, lastSyncedAt: "2026-03-20T10:00:00Z" },
+              ],
+            },
+            message: null,
+          }),
+        ),
+      );
+    });
+
+    it("shows connected status and action buttons", async () => {
+      render(
+        <GoogleCalendarSection memberId={MEMBER_ID} memberEmail="test@example.com" memberName="Alice" />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(await screen.findByText(/connected/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /choose calendars/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /sync now/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/settings/google-calendar-section.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create GoogleCalendarSection component**
+
+```typescript
+// src/components/settings/google-calendar-section.tsx
+import { formatDistanceToNow } from "date-fns";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import {
+  googleCalendarService,
+  useDisconnectGoogle,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+} from "@/api";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toaster";
+import { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+
+interface GoogleCalendarSectionProps {
+  memberId: string;
+  memberEmail: string;
+  memberName: string;
+}
+
+export function GoogleCalendarSection({
+  memberId,
+  memberEmail,
+  memberName,
+}: GoogleCalendarSectionProps) {
+  const { data: statusResponse, isLoading } = useGoogleConnectionStatus(memberId);
+  const syncMutation = useSyncGoogleCalendar();
+  const disconnectMutation = useDisconnectGoogle();
+  const [showCalendarPicker, setShowCalendarPicker] = useState(false);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+
+  const status = statusResponse?.data;
+  const isConnected = status?.connected ?? false;
+  const isSyncing = syncMutation.isPending;
+
+  const handleConnect = async () => {
+    try {
+      const response = await googleCalendarService.getAuthUrl(memberId);
+      // Save return state before redirect
+      sessionStorage.setItem(
+        "google-auth-return",
+        JSON.stringify({
+          memberId,
+          returnTo: "member-profile",
+          timestamp: Date.now(),
+        }),
+      );
+      window.location.href = response.data.url;
+    } catch {
+      toast({
+        title: "Connection failed",
+        description: "Could not connect to Google Calendar. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSync = () => {
+    syncMutation.mutate(memberId, {
+      onSuccess: () => {
+        toast({ title: "Sync started", description: "Your Google Calendar events are being synced." });
+      },
+      onError: () => {
+        toast({ title: "Sync failed", description: "Could not sync. Please try again.", variant: "destructive" });
+      },
+    });
+  };
+
+  const handleDisconnect = () => {
+    disconnectMutation.mutate(memberId, {
+      onSuccess: () => {
+        setShowDisconnectConfirm(false);
+        toast({ title: "Disconnected", description: "Google Calendar has been disconnected." });
+      },
+      onError: () => {
+        toast({ title: "Disconnect failed", description: "Could not disconnect. Please try again.", variant: "destructive" });
+      },
+    });
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Google Calendar</p>
+        <div className="h-10 bg-muted animate-pulse rounded-md" />
+      </div>
+    );
+  }
+
+  // Get last synced time from first calendar
+  const lastSyncedAt = status?.calendars?.[0]?.lastSyncedAt;
+  const lastSyncedLabel = lastSyncedAt
+    ? `Last synced ${formatDistanceToNow(new Date(lastSyncedAt), { addSuffix: true })}`
+    : "Never synced";
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">Google Calendar</p>
+
+      {!isConnected ? (
+        // Disconnected state
+        <div className="space-y-2">
+          <Button
+            type="button"
+            onClick={handleConnect}
+            disabled={!memberEmail}
+            className="w-full"
+          >
+            Connect Google Calendar
+          </Button>
+          {!memberEmail && (
+            <p className="text-xs text-muted-foreground">
+              Add an email address to connect Google Calendar
+            </p>
+          )}
+        </div>
+      ) : (
+        // Connected state
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <span className="text-sm text-foreground">Connected</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{lastSyncedLabel}</p>
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCalendarPicker(true)}
+            >
+              Choose Calendars
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleSync}
+              disabled={isSyncing}
+            >
+              {isSyncing ? (
+                <>
+                  <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                  Syncing...
+                </>
+              ) : (
+                "Sync Now"
+              )}
+            </Button>
+          </div>
+
+          {/* Disconnect */}
+          {showDisconnectConfirm ? (
+            <div className="space-y-2 p-3 border border-border rounded-md">
+              <p className="text-xs text-muted-foreground">
+                This will remove all synced Google events for {memberName}.
+                Events created in FamilyHub are not affected.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowDisconnectConfirm(false)}
+                  disabled={disconnectMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleDisconnect}
+                  disabled={disconnectMutation.isPending}
+                >
+                  {disconnectMutation.isPending ? "Disconnecting..." : "Confirm Disconnect"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDisconnectConfirm(true)}
+              className="text-xs text-destructive hover:underline"
+            >
+              Disconnect
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Calendar Picker Modal */}
+      <GoogleCalendarPickerModal
+        open={showCalendarPicker}
+        onOpenChange={setShowCalendarPicker}
+        memberId={memberId}
+      />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Update MemberProfileModal**
+
+In `src/components/settings/member-profile-modal.tsx`:
+
+1. Import `GoogleCalendarSection` from `./google-calendar-section`
+2. Replace the email helper text (lines 258-263) — remove "Used for Google Calendar sync (coming soon)"
+3. Add the Google Calendar section after the email field div, before the action buttons:
+
+```tsx
+{/* Google Calendar */}
+<GoogleCalendarSection
+  memberId={memberId}
+  memberEmail={watch("email") || member?.email || ""}
+  memberName={member?.name || ""}
+/>
+```
+
+The `watch("email")` ensures the connect button enables/disables reactively as the user types an email.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run src/components/settings/google-calendar-section.test.tsx`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/settings/google-calendar-section.tsx src/components/settings/google-calendar-section.test.tsx src/components/settings/member-profile-modal.tsx
+git commit -m "feat(settings): add Google Calendar connection section to member profile"
+```
+
+---
+
+## Task 11: OAuth Return Hook
+
+**Files:**
+- Create: `src/hooks/use-google-auth-return.ts`
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Write tests**
+
+Create `src/hooks/use-google-auth-return.test.ts`:
+
+```typescript
+import { renderHook } from "@testing-library/react";
+import { useGoogleAuthReturn } from "./use-google-auth-return";
+
+// Mock toast
+const mockToast = vi.fn();
+vi.mock("@/components/ui/toaster", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+// Mock stores
+const mockOpenSidebar = vi.fn();
+vi.mock("@/stores", () => ({
+  useAppStore: {
+    getState: () => ({ openSidebar: mockOpenSidebar }),
+  },
+}));
+
+describe("useGoogleAuthReturn", () => {
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    replaceStateSpy = vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+    // Reset URL
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "" },
+      writable: true,
+    });
+  });
+
+  it("does nothing when no google-auth query param", () => {
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("shows success toast on googleConnected=true", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?googleConnected=true" },
+      writable: true,
+    });
+
+    sessionStorage.setItem(
+      "google-auth-return",
+      JSON.stringify({ memberId: "m1", returnTo: "member-profile", timestamp: Date.now() }),
+    );
+
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringContaining("Connected") }),
+    );
+  });
+
+  it("shows error toast on error param", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?error=consent_denied" },
+      writable: true,
+    });
+
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    );
+  });
+
+  it("cleans up query params and sessionStorage", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?googleConnected=true" },
+      writable: true,
+    });
+
+    sessionStorage.setItem("google-auth-return", JSON.stringify({ memberId: "m1", timestamp: Date.now() }));
+
+    renderHook(() => useGoogleAuthReturn());
+
+    expect(replaceStateSpy).toHaveBeenCalled();
+    expect(sessionStorage.getItem("google-auth-return")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/hooks/use-google-auth-return.test.ts`
+Expected: FAIL
+
+- [ ] **Step 3: Create the hook**
+
+```typescript
+// src/hooks/use-google-auth-return.ts
+import { useEffect } from "react";
+import { toast } from "@/components/ui/toaster";
+import { useAppStore } from "@/stores";
+
+const STORAGE_KEY = "google-auth-return";
+const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+interface GoogleAuthReturnState {
+  memberId: string;
+  returnTo: string;
+  timestamp: number;
+}
+
+/**
+ * Handles the OAuth return flow after Google redirects back to the app.
+ *
+ * BE redirects to:
+ * - /?googleConnected=true (on success)
+ * - /?error=consent_denied (user denied consent)
+ * - /?error=token_exchange_failed (server error)
+ *
+ * Note: The BE redirect URL is configured with a base path (e.g., /settings)
+ * but we check query params regardless of path since the app is a SPA.
+ */
+export function useGoogleAuthReturn() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const success = params.get("googleConnected");
+    const error = params.get("error");
+
+    if (!success && !error) return;
+
+    // Clean up query params
+    const url = new URL(window.location.href);
+    url.searchParams.delete("googleConnected");
+    url.searchParams.delete("error");
+    window.history.replaceState({}, "", url.pathname + url.search);
+
+    // Read and clean up return state
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
+
+    let returnState: GoogleAuthReturnState | null = null;
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as GoogleAuthReturnState;
+        // Ignore stale entries
+        if (Date.now() - parsed.timestamp < STALE_THRESHOLD_MS) {
+          returnState = parsed;
+        }
+      } catch {
+        // Ignore corrupt data
+      }
+    }
+
+    if (success === "true") {
+      toast({
+        title: "Google Calendar Connected",
+        description: "Your Google Calendar events will appear shortly.",
+      });
+
+      // Restore UI state: open sidebar so user can see member profile
+      if (returnState) {
+        useAppStore.getState().openSidebar();
+        // The member profile modal needs to be opened by the sidebar.
+        // We store the memberId so the sidebar can auto-open the profile.
+        // This is handled via a sessionStorage flag that SidebarMenu reads.
+        sessionStorage.setItem(
+          "open-member-profile",
+          returnState.memberId,
+        );
+      }
+    } else if (error) {
+      const messages: Record<string, string> = {
+        consent_denied: "Google Calendar access was denied. You can try again anytime.",
+        token_exchange_failed: "Failed to connect Google Calendar. Please try again.",
+      };
+      toast({
+        title: "Connection failed",
+        description: messages[error] ?? "Failed to connect Google Calendar. Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, []);
+}
+```
+
+- [ ] **Step 4: Update SidebarMenu to read the auto-open flag**
+
+In `src/components/shared/sidebar-menu.tsx`, add a `useEffect` that checks for the `open-member-profile` flag in sessionStorage when the sidebar opens:
+
+```typescript
+// After the existing state declarations, add:
+useEffect(() => {
+  if (isOpen) {
+    const autoOpenMemberId = sessionStorage.getItem("open-member-profile");
+    if (autoOpenMemberId) {
+      sessionStorage.removeItem("open-member-profile");
+      setSelectedMemberId(autoOpenMemberId);
+    }
+  }
+}, [isOpen]);
+```
+
+- [ ] **Step 5: Wire the hook in App.tsx**
+
+In `src/App.tsx`, import and call the hook inside `FamilyHub`:
+
+```typescript
+import { useGoogleAuthReturn } from "@/hooks/use-google-auth-return";
+
+// Inside FamilyHub, before the hydration gate:
+useGoogleAuthReturn();
+```
+
+Also update `src/hooks/index.ts` barrel export:
+
+```typescript
+export { useGoogleAuthReturn } from "./use-google-auth-return";
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run src/hooks/use-google-auth-return.test.ts`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/hooks/use-google-auth-return.ts src/hooks/use-google-auth-return.test.ts src/hooks/index.ts src/App.tsx src/components/shared/sidebar-menu.tsx
+git commit -m "feat(auth): add Google OAuth return handler with state restoration"
+```
+
+---
+
+## Task 12: Final Integration — Type Check, Lint, Full Test Suite
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 2: Run linter**
+
+Run: `npm run lint`
+Expected: No errors. If formatting issues, run `npm run format` first.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `npm test -- --run`
+Expected: All tests pass, including new tests from this implementation.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 5: Manual smoke test**
+
+Run: `npm run dev`
+
+Verify:
+1. Calendar renders normally (no regressions)
+2. Member profile modal shows Google Calendar section (disconnected state)
+3. Event form shows "Add description" collapsible
+4. Create an event with a description — verify it persists
+5. No console errors
+
+- [ ] **Step 6: Commit any final fixes**
+
+If any fixes were needed:
+
+```bash
+git add -A
+git commit -m "fix: resolve integration issues from Google Calendar FE integration"
+```
+
+---
+
+## Task 13: E2E Tests
+
+**Files:**
+- Create: `e2e/google-calendar.spec.ts`
+
+- [ ] **Step 1: Write E2E tests for the settings UI and event display**
+
+```typescript
+// e2e/google-calendar.spec.ts
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  waitForCalendarReady,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+test.describe("Google Calendar Integration", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.goto("/");
+    await clearStorage(page);
+
+    const reg = await registerFamily(request, {
+      familyName: "Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+
+    await page.reload();
+    await waitForHydration(page);
+    await waitForCalendarReady(page);
+  });
+
+  test("member profile shows Google Calendar section", async ({ page }) => {
+    // Open sidebar
+    await page.getByRole("button", { name: /settings/i }).click();
+
+    // Click on member name to open profile
+    await page.getByText("Alice").click();
+
+    // Verify Google Calendar section is visible
+    await expect(page.getByText("Google Calendar")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /connect google calendar/i }),
+    ).toBeVisible();
+  });
+
+  test("connect button is disabled without email", async ({ page }) => {
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByText("Alice").click();
+
+    const connectButton = page.getByRole("button", {
+      name: /connect google calendar/i,
+    });
+    await expect(connectButton).toBeDisabled();
+    await expect(page.getByText(/add an email/i)).toBeVisible();
+  });
+
+  test("event form has collapsible description field", async ({ page }) => {
+    // Open add event modal
+    await page.getByRole("button", { name: /add event/i }).click();
+
+    // Description should be collapsed
+    await expect(page.getByText(/add description/i)).toBeVisible();
+    await expect(page.getByLabelText(/description/i)).not.toBeVisible();
+
+    // Expand it
+    await page.getByText(/add description/i).click();
+    await expect(page.getByLabelText(/description/i)).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run E2E tests**
+
+Run: `npm run test:e2e -- --grep "Google Calendar"`
+Expected: PASS (tests that don't require real Google OAuth)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e/google-calendar.spec.ts
+git commit -m "test(e2e): add Google Calendar integration E2E tests"
+```
+
+---
+
+## Task 14: Update Spec — Confirm BE Redirect Params
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md`
+
+- [ ] **Step 1: Update the spec with confirmed redirect params**
+
+Replace the "assumed" language in Section 3 with the confirmed values from the BE:
+
+- Success: `?googleConnected=true`
+- Error (consent denied): `?error=consent_denied`
+- Error (token exchange): `?error=token_exchange_failed`
+
+The BE redirects to the configured `frontendRedirectUrl` which includes `/settings` in the path — but since our SPA handles routing client-side, the `useGoogleAuthReturn` hook checks query params regardless of path.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
+git commit -m "docs: confirm BE OAuth redirect params in spec"
+```

--- a/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
+++ b/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
@@ -39,13 +39,25 @@ Add `description?: string` to both `CreateEventRequest` and `UpdateEventRequest`
 
 ```typescript
 // src/lib/types/google-calendar.ts
+
+// Return type for GET /api/google/auth?memberId={uuid}
+// Wrapped in ApiResponse<GoogleAuthUrl> by the service layer
+interface GoogleAuthUrl {
+  url: string;
+}
+
+// Return type for GET /api/google/calendars/{memberId}
+// and PUT /api/google/calendars/{memberId}
+// Wrapped in ApiResponse<GoogleCalendarInfo[]>
 interface GoogleCalendarInfo {
   id: string;            // "primary" or specific calendar ID
   name: string;
-  primary: boolean;
-  enabled: boolean;
+  primary: boolean;      // Google's default calendar — shown first, labeled "(Primary)" in picker
+  enabled: boolean;      // whether the user selected it for sync
 }
 
+// Return type for GET /api/google/status/{memberId}
+// Wrapped in ApiResponse<GoogleConnectionStatus>
 interface GoogleConnectionStatus {
   connected: boolean;
   calendars: Array<{
@@ -56,6 +68,8 @@ interface GoogleConnectionStatus {
   }>;
 }
 ```
+
+All service methods return `ApiResponse<T>` (same `{ data, message }` wrapper used throughout the codebase). The service layer unwraps `data` for consumers.
 
 ### Zod schema update
 
@@ -78,7 +92,7 @@ Handles all `/api/google/*` endpoints:
 | `getConnectionStatus(memberId)` | `GET /api/google/status/{memberId}` | Returns connection status |
 | `getCalendars(memberId)` | `GET /api/google/calendars/{memberId}` | Lists available Google calendars |
 | `updateCalendars(memberId, calendarIds)` | `PUT /api/google/calendars/{memberId}` | Sets which calendars to sync |
-| `syncNow(memberId)` | `POST /api/google/sync/{memberId}` | Triggers manual sync |
+| `syncCalendar(memberId)` | `POST /api/google/sync/{memberId}` | Triggers manual sync |
 | `disconnect(memberId)` | `DELETE /api/google/disconnect/{memberId}` | Revokes tokens, removes Google events |
 
 ### New hooks: use-google-calendar.ts
@@ -99,7 +113,7 @@ googleCalendarKeys = {
 |------|------|-------------|
 | `useGoogleConnectionStatus(memberId)` | Query | — |
 | `useGoogleCalendars(memberId)` | Query | — |
-| `useUpdateGoogleCalendars(callbacks)` | Mutation | `calendars`, `status` |
+| `useUpdateGoogleCalendars(callbacks)` | Mutation | `calendars`, `status`, `calendarKeys.events()` |
 | `useSyncGoogleCalendar(callbacks)` | Mutation | `status`, `calendarKeys.events()` |
 | `useDisconnectGoogle(callbacks)` | Mutation | `status`, `calendarKeys.events()` |
 
@@ -120,12 +134,12 @@ The BE returns Google events in the regular events endpoint. `useCalendarEvents`
 
 ### Handling the return
 
-The BE callback redirects to the FE with a query param (e.g., `/?google-auth=success` or `/?google-auth=error`).
+The BE callback redirects to the FE with a query param. The exact param name and values must be confirmed from the merged BE code before implementation — assumed to be `/?google-auth=success` or `/?google-auth=error&message=...`.
 
 1. On app mount, check for `google-auth` query param
 2. If present, read return state from `sessionStorage`, clean up both (query param via `replaceState`, storage entry)
 3. On success: open sidebar → open member profile modal for the saved `memberId` → show success toast
-4. On error: show error toast with message
+4. On error: show error toast with message from `message` query param, or a hardcoded fallback ("Failed to connect Google Calendar. Please try again.")
 5. Stale entries ignored via timestamp check
 
 ### Implementation
@@ -142,7 +156,9 @@ A `useGoogleAuthReturn()` hook that runs once on mount in `App.tsx`. Handles det
 
 Below the email field in `MemberProfileModal`. The email field already has helper text saying "Used for Google Calendar sync (coming soon)" — replace that with the actual integration.
 
-### Three states
+### States
+
+**Loading:** While `useGoogleConnectionStatus` is fetching, show a subtle skeleton/shimmer placeholder for the section. No buttons rendered until status is known.
 
 **Disconnected:**
 - "Connect Google Calendar" button (primary style)
@@ -162,7 +178,7 @@ Below the email field in `MemberProfileModal`. The email field already has helpe
 
 Separate modal (opened from "Choose Calendars" button) with:
 - Checkboxes for each calendar from `useGoogleCalendars(memberId)`
-- Calendar names as labels, primary calendar indicated
+- Calendar names as labels; primary calendar sorted first with "(Primary)" suffix
 - Save button calls `useUpdateGoogleCalendars` and triggers a sync
 - Cancel to dismiss
 

--- a/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
+++ b/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
@@ -134,12 +134,20 @@ The BE returns Google events in the regular events endpoint. `useCalendarEvents`
 
 ### Handling the return
 
-The BE callback redirects to the FE with a query param. The exact param name and values must be confirmed from the merged BE code before implementation — assumed to be `/?google-auth=success` or `/?google-auth=error&message=...`.
+The BE redirects to the configured `frontendRedirectUrl` (which includes `/settings` in the path) with one of these query params:
+- Success: `?googleConnected=true`
+- Error (consent denied): `?error=consent_denied`
+- Error (token exchange): `?error=token_exchange_failed`
 
-1. On app mount, check for `google-auth` query param
+Since our SPA handles routing client-side, the `useGoogleAuthReturn()` hook checks query params regardless of path.
+
+1. On app mount, check for `googleConnected` or `error` query param
 2. If present, read return state from `sessionStorage`, clean up both (query param via `replaceState`, storage entry)
-3. On success: open sidebar → open member profile modal for the saved `memberId` → show success toast
-4. On error: show error toast with message from `message` query param, or a hardcoded fallback ("Failed to connect Google Calendar. Please try again.")
+3. On success (`?googleConnected=true`): open sidebar → open member profile modal for the saved `memberId` → show success toast
+4. On error (`?error=...`): show error toast with a mapping to user-friendly message:
+   - `consent_denied` → "You denied access to your Google Calendar. Please try again if you'd like to connect."
+   - `token_exchange_failed` → "Failed to exchange the auth code. Please try again."
+   - Fallback for unknown errors → "Failed to connect Google Calendar. Please try again."
 5. Stale entries ignored via timestamp check
 
 ### Implementation

--- a/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
+++ b/docs/superpowers/specs/2026-03-20-google-calendar-fe-integration.md
@@ -1,0 +1,275 @@
+# Google Calendar FE Integration — Design Spec
+
+**Date:** 2026-03-20
+**Status:** Approved
+**Scope:** Phase 1b — FE integration for read-only Google Calendar sync
+**Depends on:** BE Google Calendar integration (complete, merged), [google-calendar-integration-design.md](../../google-calendar-integration-design.md)
+
+---
+
+## Overview
+
+Add frontend support for Google Calendar integration. Family members can connect their Google accounts from their member profile, select which calendars to sync, and see Google events rendered alongside native events on the calendar. Google events are read-only in Phase 1 — edit/delete actions show a toast directing users to Google Calendar.
+
+The BE already returns Google events mixed into the regular `GET /api/calendar/events` response, so the existing event fetching path is unchanged. This spec covers: new API hooks for Google connection management, type extensions, UI changes to the member profile, event cards, event detail modal, and event form.
+
+---
+
+## 1. Type Changes
+
+### CalendarEvent — extend with three optional fields
+
+```typescript
+// src/lib/types/calendar.ts
+interface CalendarEvent {
+  // ... existing fields ...
+  source?: "NATIVE" | "GOOGLE";   // defaults to NATIVE from BE
+  description?: string;            // both native and Google events
+  htmlLink?: string;               // Google events only — opens in Google Calendar
+}
+```
+
+All optional — existing code continues working unchanged.
+
+### Request types — add description
+
+Add `description?: string` to both `CreateEventRequest` and `UpdateEventRequest`.
+
+### New types — google-calendar.ts
+
+```typescript
+// src/lib/types/google-calendar.ts
+interface GoogleCalendarInfo {
+  id: string;            // "primary" or specific calendar ID
+  name: string;
+  primary: boolean;
+  enabled: boolean;
+}
+
+interface GoogleConnectionStatus {
+  connected: boolean;
+  calendars: Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    lastSyncedAt: string | null;
+  }>;
+}
+```
+
+### Zod schema update
+
+```typescript
+// src/lib/validations/calendar.ts
+description: z.string().max(2000, "Description must be 2000 characters or less").optional(),
+```
+
+---
+
+## 2. API Layer
+
+### New service: google-calendar.service.ts
+
+Handles all `/api/google/*` endpoints:
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `getAuthUrl(memberId)` | `GET /api/google/auth?memberId={uuid}` | Returns OAuth redirect URL |
+| `getConnectionStatus(memberId)` | `GET /api/google/status/{memberId}` | Returns connection status |
+| `getCalendars(memberId)` | `GET /api/google/calendars/{memberId}` | Lists available Google calendars |
+| `updateCalendars(memberId, calendarIds)` | `PUT /api/google/calendars/{memberId}` | Sets which calendars to sync |
+| `syncNow(memberId)` | `POST /api/google/sync/{memberId}` | Triggers manual sync |
+| `disconnect(memberId)` | `DELETE /api/google/disconnect/{memberId}` | Revokes tokens, removes Google events |
+
+### New hooks: use-google-calendar.ts
+
+**Query key factory:**
+
+```typescript
+googleCalendarKeys = {
+  all:                         ["google-calendar"],
+  status: (memberId) =>       ["google-calendar", "status", memberId],
+  calendars: (memberId) =>    ["google-calendar", "calendars", memberId],
+}
+```
+
+**Hooks:**
+
+| Hook | Type | Invalidates |
+|------|------|-------------|
+| `useGoogleConnectionStatus(memberId)` | Query | — |
+| `useGoogleCalendars(memberId)` | Query | — |
+| `useUpdateGoogleCalendars(callbacks)` | Mutation | `calendars`, `status` |
+| `useSyncGoogleCalendar(callbacks)` | Mutation | `status`, `calendarKeys.events()` |
+| `useDisconnectGoogle(callbacks)` | Mutation | `status`, `calendarKeys.events()` |
+
+### Existing calendar hooks — no changes
+
+The BE returns Google events in the regular events endpoint. `useCalendarEvents` works as-is — the three new optional fields flow through automatically via the extended `CalendarEvent` type.
+
+---
+
+## 3. OAuth Flow & Return State
+
+### Initiating the flow
+
+1. User clicks "Connect Google Calendar" in the member profile modal
+2. FE calls `getAuthUrl(memberId)` to get the OAuth URL
+3. Save return state to `sessionStorage`: `{ memberId, returnTo: "member-profile", timestamp }`
+4. `window.location.href = oauthUrl` — user leaves the app
+
+### Handling the return
+
+The BE callback redirects to the FE with a query param (e.g., `/?google-auth=success` or `/?google-auth=error`).
+
+1. On app mount, check for `google-auth` query param
+2. If present, read return state from `sessionStorage`, clean up both (query param via `replaceState`, storage entry)
+3. On success: open sidebar → open member profile modal for the saved `memberId` → show success toast
+4. On error: show error toast with message
+5. Stale entries ignored via timestamp check
+
+### Implementation
+
+A `useGoogleAuthReturn()` hook that runs once on mount in `App.tsx`. Handles detection, restoration, and cleanup.
+
+**Why sessionStorage:** Survives the redirect but scoped to the current tab and cleared when the tab closes. No stale state lingers.
+
+---
+
+## 4. Member Profile Modal — Google Calendar Section
+
+### Placement
+
+Below the email field in `MemberProfileModal`. The email field already has helper text saying "Used for Google Calendar sync (coming soon)" — replace that with the actual integration.
+
+### Three states
+
+**Disconnected:**
+- "Connect Google Calendar" button (primary style)
+- Disabled if member has no email saved, with hint: "Add an email address to connect Google Calendar"
+
+**Connected:**
+- Green dot + "Connected" status text
+- "Last synced: 5 minutes ago" (relative time, or "Never" if null)
+- "Choose Calendars" button → opens `GoogleCalendarPickerModal`
+- "Sync Now" button (secondary)
+- "Disconnect" button (destructive/red text)
+
+**Syncing:**
+- Same as connected, but "Sync Now" shows a spinner and is disabled
+
+### GoogleCalendarPickerModal
+
+Separate modal (opened from "Choose Calendars" button) with:
+- Checkboxes for each calendar from `useGoogleCalendars(memberId)`
+- Calendar names as labels, primary calendar indicated
+- Save button calls `useUpdateGoogleCalendars` and triggers a sync
+- Cancel to dismiss
+
+### Disconnect confirmation
+
+Confirmation dialog: "This will remove all synced Google events for {memberName}. Events created in FamilyHub are not affected." Then calls `useDisconnectGoogle`.
+
+---
+
+## 5. Event Display Changes
+
+### CalendarEventCard — Google icon overlay
+
+- When `source === "GOOGLE"`, render a small Google "G" SVG in the top-right corner
+- Size scales with card variant: ~14px for default/large, ~10px for compact
+- Semi-transparent background pill (`bg-white/70 rounded-full`) for visibility against any member color
+- Inline SVG — no icon library addition needed
+
+### EventDetailModal — Google event handling
+
+- **Description field:** Display for all events when present (below location, muted body text style)
+- **Google events:** Show "Open in Google Calendar" link using `htmlLink` (opens in new tab)
+- **Edit/Delete guard:** Buttons remain visible. Clicking either shows a toast: "This event is synced from Google Calendar. Edit it in Google Calendar." with an optional "Open in Google Calendar" action on the toast
+- **Recurrence label:** Works automatically — Google recurring instances carry `recurrenceRule` from BE expansion
+
+### MobileEventDetail
+
+Same treatment as desktop: description display, Google guard toast, "Open in Google Calendar" link.
+
+### CalendarModule — orchestrator-level guard
+
+Before opening edit modal or running delete, check `event.source === "GOOGLE"`. If true, show toast and bail. Catches all entry points and prevents the edit modal or scope dialog from opening.
+
+---
+
+## 6. Event Form — Description Field
+
+### Collapsible description
+
+- "Add description" link below the location field, collapsed by default in "add" mode
+- In "edit" mode, auto-expand if the event already has a description
+- Reveals a `textarea` with placeholder "Add notes or details..."
+- Max 2000 chars; character counter appears only near limit (1900+)
+
+### Submission
+
+- `description` included in request when present
+- Empty/untouched → omitted (`undefined`, not `""`)
+
+### Google events
+
+Never reach the form — the guard in §5 prevents it. No special handling needed.
+
+---
+
+## 7. Testing Strategy
+
+### Unit tests
+
+| Component/Hook | What to test |
+|---------------|-------------|
+| `useGoogleConnectionStatus` | Mock MSW responses, verify query behavior |
+| `useGoogleCalendars` | Mock MSW responses, verify query behavior |
+| `useSyncGoogleCalendar` | Verify mutation + cache invalidation (`status` + `calendarKeys.events()`) |
+| `useDisconnectGoogle` | Verify mutation + cache invalidation |
+| `CalendarEventCard` | Google icon renders for `source === "GOOGLE"`, absent for `"NATIVE"` |
+| `EventDetailModal` | Description displays, "Open in Google Calendar" link for Google events, toast on Edit/Delete |
+| `EventForm` | Description collapse/expand, value in submission |
+| Member profile Google section | Three states render correctly based on connection status |
+| `useGoogleAuthReturn` | Mock `window.location.search`, verify sessionStorage read + cleanup |
+
+### E2E tests
+
+- Cannot test real Google OAuth in CI — mock API responses
+- Member profile: "Connect Google Calendar" button visible, connected state renders, disconnect flow
+- Calendar picker modal: opens, saves selections
+- Event display: seed Google-sourced events, verify icon visible, verify edit/delete toast
+
+### Existing tests
+
+No changes needed — Google events flow through the same `useCalendarEvents` hook.
+
+---
+
+## 8. New Files
+
+| File | Purpose |
+|------|---------|
+| `src/lib/types/google-calendar.ts` | `GoogleCalendarInfo`, `GoogleConnectionStatus` types |
+| `src/api/services/google-calendar.service.ts` | Google Calendar API service |
+| `src/api/hooks/use-google-calendar.ts` | TanStack Query hooks for Google connection |
+| `src/components/settings/google-calendar-section.tsx` | Google Calendar section in member profile |
+| `src/components/settings/google-calendar-picker-modal.tsx` | Calendar selection modal |
+| `src/hooks/use-google-auth-return.ts` | OAuth return detection + state restoration |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/lib/types/calendar.ts` | Add `source`, `description`, `htmlLink` to `CalendarEvent`; add `description` to request types |
+| `src/lib/validations/calendar.ts` | Add `description` to Zod schema |
+| `src/components/calendar/components/calendar-event.tsx` | Google "G" icon overlay |
+| `src/components/calendar/components/event-detail-modal.tsx` | Description display, Google link, edit/delete guard toast |
+| `src/components/calendar/components/mobile-event-detail.tsx` | Same as above |
+| `src/components/calendar/components/event-form.tsx` | Collapsible description textarea |
+| `src/components/calendar/calendar-module.tsx` | Google event guard before edit/delete actions |
+| `src/components/settings/member-profile-modal.tsx` | Add Google Calendar section, remove "coming soon" text |
+| `src/App.tsx` | Call `useGoogleAuthReturn()` hook |
+| `src/api/index.ts` | Barrel export new Google Calendar hooks/service |
+| `src/lib/types/index.ts` | Barrel export new Google Calendar types |

--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -43,7 +43,7 @@ test.describe("Calendar Event CRUD", () => {
 
     // Submit the form (date, time, and member are pre-filled with smart defaults)
     const addDialog = page.getByRole("dialog");
-    await addDialog.getByRole("button", { name: /add/i }).click();
+    await addDialog.getByRole("button", { name: /add event/i }).click();
 
     // Wait for modal to close
     await expect(page.getByRole("dialog")).toBeHidden();

--- a/e2e/google-calendar.spec.ts
+++ b/e2e/google-calendar.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  waitForCalendarReady,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+test.describe("Google Calendar Integration", () => {
+  test.beforeEach(async ({ page, request }) => {
+    await page.goto("/");
+    await clearStorage(page);
+
+    const reg = await registerFamily(request, {
+      familyName: "Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+
+    await page.reload();
+    await waitForHydration(page);
+    await waitForCalendarReady(page);
+  });
+
+  test("member profile shows Google Calendar section", async ({ page }) => {
+    // Open sidebar
+    await page.getByRole("button", { name: /settings/i }).click();
+
+    // Click on member name to open profile
+    await page.getByText("Alice").click();
+
+    // Verify Google Calendar section is visible
+    await expect(page.getByText("Google Calendar")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /connect google calendar/i }),
+    ).toBeVisible();
+  });
+
+  test("connect button is disabled without email", async ({ page }) => {
+    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByText("Alice").click();
+
+    const connectButton = page.getByRole("button", {
+      name: /connect google calendar/i,
+    });
+    await expect(connectButton).toBeDisabled();
+    await expect(page.getByText(/add an email/i)).toBeVisible();
+  });
+
+  test("event form has collapsible description field", async ({ page }) => {
+    // Open add event modal
+    await page.getByRole("button", { name: /add event/i }).click();
+
+    // Description should be collapsed
+    await expect(page.getByText(/add description/i)).toBeVisible();
+    await expect(page.getByLabelText(/description/i)).not.toBeVisible();
+
+    // Expand it
+    await page.getByText(/add description/i).click();
+    await expect(page.getByLabelText(/description/i)).toBeVisible();
+  });
+});

--- a/e2e/google-calendar.spec.ts
+++ b/e2e/google-calendar.spec.ts
@@ -24,21 +24,27 @@ test.describe("Google Calendar Integration", () => {
 
   test("member profile shows Google Calendar section", async ({ page }) => {
     // Open sidebar
-    await page.getByRole("button", { name: /settings/i }).click();
+    await page.getByRole("button", { name: "Menu" }).click();
+    const sidebar = page.locator("aside");
+    await expect(sidebar).toBeVisible();
 
     // Click on member name to open profile
-    await page.getByText("Alice").click();
+    await sidebar.getByText("Alice").click();
 
     // Verify Google Calendar section is visible
-    await expect(page.getByText("Google Calendar")).toBeVisible();
+    await expect(
+      page.getByText("Google Calendar", { exact: true }),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: /connect google calendar/i }),
     ).toBeVisible();
   });
 
   test("connect button is disabled without email", async ({ page }) => {
-    await page.getByRole("button", { name: /settings/i }).click();
-    await page.getByText("Alice").click();
+    await page.getByRole("button", { name: "Menu" }).click();
+    const sidebar = page.locator("aside");
+    await expect(sidebar).toBeVisible();
+    await sidebar.getByText("Alice").click();
 
     const connectButton = page.getByRole("button", {
       name: /connect google calendar/i,
@@ -53,10 +59,10 @@ test.describe("Google Calendar Integration", () => {
 
     // Description should be collapsed
     await expect(page.getByText(/add description/i)).toBeVisible();
-    await expect(page.getByLabelText(/description/i)).not.toBeVisible();
+    await expect(page.getByLabel(/description/i)).not.toBeVisible();
 
     // Expand it
     await page.getByText(/add description/i).click();
-    await expect(page.getByLabelText(/description/i)).toBeVisible();
+    await expect(page.getByLabel(/description/i)).toBeVisible();
   });
 });

--- a/e2e/mobile-calendar.spec.ts
+++ b/e2e/mobile-calendar.spec.ts
@@ -82,7 +82,7 @@ test.describe("Mobile Calendar Views", () => {
     await page.getByLabel("Event Name").fill("Test Event");
 
     // Submit via the header "Add" button
-    await dialog.getByRole("button", { name: /add/i }).click();
+    await dialog.getByRole("button", { name: /add event/i }).click();
 
     // Sheet should close after submission
     await expect(dialog).toBeHidden();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useSetupComplete } from "@/api";
 import { CalendarModule } from "@/components/calendar";
 import { HomeDashboard } from "@/components/home";
 import { AppHeader, NavigationTabs, SidebarMenu } from "@/components/shared";
+import { Toaster } from "@/components/ui/toaster";
 import { useIsMobile } from "@/hooks";
 import {
   type ModuleType,
@@ -115,39 +116,51 @@ export default function FamilyHub() {
   if (!isAuthenticated) {
     if (showOnboarding) {
       return (
-        <Suspense fallback={<LoadingScreen />}>
-          <OnboardingFlow />
-        </Suspense>
+        <>
+          <Suspense fallback={<LoadingScreen />}>
+            <OnboardingFlow />
+          </Suspense>
+          <Toaster />
+        </>
       );
     }
     return (
-      <Suspense fallback={<LoadingScreen />}>
-        <LoginFlow onStartOnboarding={() => setShowOnboarding(true)} />
-      </Suspense>
+      <>
+        <Suspense fallback={<LoadingScreen />}>
+          <LoginFlow onStartOnboarding={() => setShowOnboarding(true)} />
+        </Suspense>
+        <Toaster />
+      </>
     );
   }
 
   // Authenticated but setup not complete (edge case)
   if (!setupComplete) {
     return (
-      <Suspense fallback={<LoadingScreen />}>
-        <OnboardingFlow />
-      </Suspense>
+      <>
+        <Suspense fallback={<LoadingScreen />}>
+          <OnboardingFlow />
+        </Suspense>
+        <Toaster />
+      </>
     );
   }
 
   return (
-    <div className="h-screen flex flex-col bg-background">
-      {!(isMobile && activeModule === "calendar") && <AppHeader />}
+    <>
+      <div className="h-screen flex flex-col bg-background">
+        {!(isMobile && activeModule === "calendar") && <AppHeader />}
 
-      <div className="flex-1 flex overflow-hidden">
-        <NavigationTabs />
-        <main className="flex-1 flex flex-col overflow-hidden">
-          {renderModule(activeModule)}
-        </main>
+        <div className="flex-1 flex overflow-hidden">
+          <NavigationTabs />
+          <main className="flex-1 flex flex-col overflow-hidden">
+            {renderModule(activeModule)}
+          </main>
+        </div>
+
+        <SidebarMenu />
       </div>
-
-      <SidebarMenu />
-    </div>
+      <Toaster />
+    </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { CalendarModule } from "@/components/calendar";
 import { HomeDashboard } from "@/components/home";
 import { AppHeader, NavigationTabs, SidebarMenu } from "@/components/shared";
 import { Toaster } from "@/components/ui/toaster";
-import { useIsMobile } from "@/hooks";
+import { useGoogleAuthReturn, useIsMobile } from "@/hooks";
 import {
   type ModuleType,
   useAppStore,
@@ -96,6 +96,8 @@ export default function FamilyHub() {
   const isAuthenticated = useIsAuthenticated();
   const setupComplete = useSetupComplete();
   const isMobile = useIsMobile();
+
+  useGoogleAuthReturn();
 
   // State to toggle between login and onboarding for new users
   const [showOnboarding, setShowOnboarding] = useState(false);

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -39,3 +39,12 @@ export {
   useUpdateFamily,
   useUpdateMember,
 } from "./use-family";
+
+export {
+  googleCalendarKeys,
+  useDisconnectGoogle,
+  useGoogleCalendars,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+  useUpdateGoogleCalendars,
+} from "./use-google-calendar";

--- a/src/api/hooks/use-google-calendar.test.tsx
+++ b/src/api/hooks/use-google-calendar.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { server } from "@/test/mocks/server";
+import { calendarKeys } from "./use-calendar";
+import {
+  googleCalendarKeys,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+} from "./use-google-calendar";
+
+const API_BASE = "http://localhost:3000/api";
+const MEMBER_ID = "member-123";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useGoogleConnectionStatus", () => {
+  it("fetches connection status for a member", async () => {
+    server.use(
+      http.get(`${API_BASE}/google/status/${MEMBER_ID}`, () =>
+        HttpResponse.json({
+          data: { connected: false, calendars: [] },
+          message: null,
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useGoogleConnectionStatus(MEMBER_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.data.connected).toBe(false);
+  });
+
+  it("does not fetch when memberId is empty", () => {
+    const { result } = renderHook(() => useGoogleConnectionStatus(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});
+
+describe("useSyncGoogleCalendar", () => {
+  it("invalidates status and events on success", async () => {
+    server.use(
+      http.post(
+        `${API_BASE}/google/sync/${MEMBER_ID}`,
+        () => new HttpResponse(null, { status: 204 }),
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    // Seed cache
+    queryClient.setQueryData(googleCalendarKeys.status(MEMBER_ID), {
+      data: { connected: true, calendars: [] },
+    });
+    queryClient.setQueryData(calendarKeys.events(), { data: [] });
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useSyncGoogleCalendar(), {
+      wrapper,
+    });
+
+    result.current.mutate(MEMBER_ID);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Verify cache was invalidated
+    expect(
+      queryClient.getQueryState(googleCalendarKeys.status(MEMBER_ID))
+        ?.isInvalidated,
+    ).toBe(true);
+  });
+});

--- a/src/api/hooks/use-google-calendar.ts
+++ b/src/api/hooks/use-google-calendar.ts
@@ -1,11 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { googleCalendarService } from "@/api/services";
-import type {
-  ApiResponse,
-  GoogleCalendarInfo,
-  GoogleConnectionStatus,
-} from "@/lib/types";
+import type { ApiResponse, GoogleCalendarInfo } from "@/lib/types";
 import { calendarKeys } from "./use-calendar";
 
 export const googleCalendarKeys = {

--- a/src/api/hooks/use-google-calendar.ts
+++ b/src/api/hooks/use-google-calendar.ts
@@ -1,0 +1,116 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { ApiException } from "@/api/client";
+import { googleCalendarService } from "@/api/services";
+import type {
+  ApiResponse,
+  GoogleCalendarInfo,
+  GoogleConnectionStatus,
+} from "@/lib/types";
+import { calendarKeys } from "./use-calendar";
+
+export const googleCalendarKeys = {
+  all: ["google-calendar"] as const,
+  status: (memberId: string) =>
+    [...googleCalendarKeys.all, "status", memberId] as const,
+  calendars: (memberId: string) =>
+    [...googleCalendarKeys.all, "calendars", memberId] as const,
+};
+
+// Queries
+
+export function useGoogleConnectionStatus(memberId: string) {
+  return useQuery({
+    queryKey: googleCalendarKeys.status(memberId),
+    queryFn: () => googleCalendarService.getConnectionStatus(memberId),
+    enabled: !!memberId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useGoogleCalendars(memberId: string, enabled = true) {
+  return useQuery({
+    queryKey: googleCalendarKeys.calendars(memberId),
+    queryFn: () => googleCalendarService.getCalendars(memberId),
+    enabled: !!memberId && enabled,
+  });
+}
+
+// Mutations
+
+interface GoogleMutationCallbacks<T = void> {
+  onSuccess?: (data: T) => void;
+  onError?: (error: ApiException) => void;
+}
+
+export function useUpdateGoogleCalendars(
+  callbacks?: GoogleMutationCallbacks<ApiResponse<GoogleCalendarInfo[]>>,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      memberId,
+      calendarIds,
+    }: {
+      memberId: string;
+      calendarIds: string[];
+    }) => googleCalendarService.updateCalendars(memberId, calendarIds),
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.calendars(variables.memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(variables.memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.(data);
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+export function useSyncGoogleCalendar(callbacks?: GoogleMutationCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (memberId: string) =>
+      googleCalendarService.syncCalendar(memberId),
+    onSuccess: (_data, memberId) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.();
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}
+
+export function useDisconnectGoogle(callbacks?: GoogleMutationCallbacks) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (memberId: string) =>
+      googleCalendarService.disconnect(memberId),
+    onSuccess: (_data, memberId) => {
+      queryClient.invalidateQueries({
+        queryKey: googleCalendarKeys.status(memberId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: calendarKeys.events(),
+      });
+      callbacks?.onSuccess?.();
+    },
+    onError: (error: ApiException) => {
+      callbacks?.onError?.(error);
+    },
+  });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,7 @@ export {
   clearStoredToken,
   familyKeys,
   getStoredToken,
+  googleCalendarKeys,
   readFamilyFromStorage,
   setStoredToken,
   syncFamilyFromStorage,
@@ -25,6 +26,7 @@ export {
   useDeleteEvent,
   useDeleteFamily,
   useDeleteInstance,
+  useDisconnectGoogle,
   useFamily,
   useFamilyData,
   useFamilyLoading,
@@ -32,16 +34,25 @@ export {
   useFamilyMemberMap,
   useFamilyMembers,
   useFamilyName,
+  useGoogleCalendars,
+  useGoogleConnectionStatus,
   useLogin,
   useLogout,
   useRegister,
   useRemoveMember,
   useSetupComplete,
+  useSyncGoogleCalendar,
   useUnusedColors,
   useUpdateEvent,
   useUpdateFamily,
+  useUpdateGoogleCalendars,
   useUpdateInstance,
   useUpdateMember,
 } from "./hooks";
 // Services
-export { authService, calendarService, familyService } from "./services";
+export {
+  authService,
+  calendarService,
+  familyService,
+  googleCalendarService,
+} from "./services";

--- a/src/api/services/google-calendar.service.test.ts
+++ b/src/api/services/google-calendar.service.test.ts
@@ -1,5 +1,6 @@
 import { HttpResponse, http } from "msw";
 import { afterAll, afterEach, beforeAll } from "vitest";
+import type { GoogleCalendarInfo } from "@/lib/types";
 import { server } from "@/test/mocks/server";
 import { googleCalendarService } from "./google-calendar.service";
 
@@ -54,6 +55,28 @@ describe("googleCalendarService", () => {
       await expect(
         googleCalendarService.disconnect(MEMBER_ID),
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe("getCalendars", () => {
+    it("returns calendars for a member", async () => {
+      const mockCalendars: GoogleCalendarInfo[] = [
+        { id: "cal-1", name: "Personal", primary: true, enabled: true },
+        { id: "cal-2", name: "Work", primary: false, enabled: false },
+      ];
+
+      server.use(
+        http.get(`*/google/calendars/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: mockCalendars,
+            message: null,
+          }),
+        ),
+      );
+
+      const result = await googleCalendarService.getCalendars(MEMBER_ID);
+      expect(result.data).toEqual(mockCalendars);
+      expect(result.data).toHaveLength(2);
     });
   });
 });

--- a/src/api/services/google-calendar.service.test.ts
+++ b/src/api/services/google-calendar.service.test.ts
@@ -79,4 +79,34 @@ describe("googleCalendarService", () => {
       expect(result.data).toHaveLength(2);
     });
   });
+
+  describe("updateCalendars", () => {
+    it("sends selected calendar IDs and returns updated calendars", async () => {
+      const selectedIds = ["cal-1", "cal-3"];
+      const updatedCalendars: GoogleCalendarInfo[] = [
+        { id: "cal-1", name: "Personal", primary: true, enabled: true },
+        { id: "cal-2", name: "Work", primary: false, enabled: false },
+        { id: "cal-3", name: "Holidays", primary: false, enabled: true },
+      ];
+
+      let capturedBody: unknown;
+
+      server.use(
+        http.put(`*/google/calendars/${MEMBER_ID}`, async ({ request }) => {
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            data: updatedCalendars,
+            message: null,
+          });
+        }),
+      );
+
+      const result = await googleCalendarService.updateCalendars(
+        MEMBER_ID,
+        selectedIds,
+      );
+      expect(capturedBody).toEqual({ calendarIds: selectedIds });
+      expect(result.data).toEqual(updatedCalendars);
+    });
+  });
 });

--- a/src/api/services/google-calendar.service.test.ts
+++ b/src/api/services/google-calendar.service.test.ts
@@ -111,17 +111,21 @@ describe("googleCalendarService", () => {
   });
 
   describe("syncCalendar", () => {
-    it("calls POST endpoint and resolves", async () => {
+    it("calls POST endpoint and returns 202 Accepted", async () => {
       server.use(
-        http.post(
-          `*/google/sync/${MEMBER_ID}`,
-          () => new HttpResponse(null, { status: 204 }),
+        http.post(`*/google/sync/${MEMBER_ID}`, () =>
+          HttpResponse.json(
+            {
+              data: null,
+              message: "Sync started",
+            },
+            { status: 202 },
+          ),
         ),
       );
 
-      await expect(
-        googleCalendarService.syncCalendar(MEMBER_ID),
-      ).resolves.not.toThrow();
+      const result = await googleCalendarService.syncCalendar(MEMBER_ID);
+      expect(result).toEqual({ data: null, message: "Sync started" });
     });
   });
 });

--- a/src/api/services/google-calendar.service.test.ts
+++ b/src/api/services/google-calendar.service.test.ts
@@ -109,4 +109,19 @@ describe("googleCalendarService", () => {
       expect(result.data).toEqual(updatedCalendars);
     });
   });
+
+  describe("syncCalendar", () => {
+    it("calls POST endpoint and resolves", async () => {
+      server.use(
+        http.post(
+          `*/google/sync/${MEMBER_ID}`,
+          () => new HttpResponse(null, { status: 204 }),
+        ),
+      );
+
+      await expect(
+        googleCalendarService.syncCalendar(MEMBER_ID),
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/src/api/services/google-calendar.service.test.ts
+++ b/src/api/services/google-calendar.service.test.ts
@@ -1,0 +1,59 @@
+import { HttpResponse, http } from "msw";
+import { afterAll, afterEach, beforeAll } from "vitest";
+import { server } from "@/test/mocks/server";
+import { googleCalendarService } from "./google-calendar.service";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const MEMBER_ID = "member-123";
+
+describe("googleCalendarService", () => {
+  describe("getAuthUrl", () => {
+    it("returns the OAuth redirect URL", async () => {
+      server.use(
+        http.get("*/google/auth", () =>
+          HttpResponse.json({
+            data: { url: "https://accounts.google.com/o/oauth2/v2/auth?..." },
+            message: null,
+          }),
+        ),
+      );
+
+      const result = await googleCalendarService.getAuthUrl(MEMBER_ID);
+      expect(result.data.url).toContain("accounts.google.com");
+    });
+  });
+
+  describe("getConnectionStatus", () => {
+    it("returns connection status for a member", async () => {
+      server.use(
+        http.get(`*/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: { connected: true, calendars: [] },
+            message: null,
+          }),
+        ),
+      );
+
+      const result = await googleCalendarService.getConnectionStatus(MEMBER_ID);
+      expect(result.data.connected).toBe(true);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("calls DELETE endpoint", async () => {
+      server.use(
+        http.delete(
+          `*/google/disconnect/${MEMBER_ID}`,
+          () => new HttpResponse(null, { status: 204 }),
+        ),
+      );
+
+      await expect(
+        googleCalendarService.disconnect(MEMBER_ID),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/api/services/google-calendar.service.ts
+++ b/src/api/services/google-calendar.service.ts
@@ -1,0 +1,49 @@
+import { httpClient } from "@/api/client";
+import type {
+  ApiResponse,
+  GoogleAuthUrl,
+  GoogleCalendarInfo,
+  GoogleConnectionStatus,
+} from "@/lib/types";
+
+export const googleCalendarService = {
+  async getAuthUrl(memberId: string): Promise<ApiResponse<GoogleAuthUrl>> {
+    return httpClient.get<ApiResponse<GoogleAuthUrl>>("/google/auth", {
+      params: { memberId },
+    });
+  },
+
+  async getConnectionStatus(
+    memberId: string,
+  ): Promise<ApiResponse<GoogleConnectionStatus>> {
+    return httpClient.get<ApiResponse<GoogleConnectionStatus>>(
+      `/google/status/${memberId}`,
+    );
+  },
+
+  async getCalendars(
+    memberId: string,
+  ): Promise<ApiResponse<GoogleCalendarInfo[]>> {
+    return httpClient.get<ApiResponse<GoogleCalendarInfo[]>>(
+      `/google/calendars/${memberId}`,
+    );
+  },
+
+  async updateCalendars(
+    memberId: string,
+    calendarIds: string[],
+  ): Promise<ApiResponse<GoogleCalendarInfo[]>> {
+    return httpClient.put<ApiResponse<GoogleCalendarInfo[]>>(
+      `/google/calendars/${memberId}`,
+      { calendarIds },
+    );
+  },
+
+  async syncCalendar(memberId: string): Promise<void> {
+    return httpClient.post(`/google/sync/${memberId}`);
+  },
+
+  async disconnect(memberId: string): Promise<void> {
+    return httpClient.delete(`/google/disconnect/${memberId}`);
+  },
+};

--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -1,3 +1,4 @@
 export { authService } from "./auth.service";
 export { calendarService } from "./calendar.service";
 export { familyService } from "./family.service";
+export { googleCalendarService } from "./google-calendar.service";

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -34,6 +34,7 @@ import {
   ScheduleCalendar,
   WeeklyCalendar,
 } from "@/components/calendar";
+import { toast } from "@/components/ui/toaster";
 import { useIsMobile } from "@/hooks";
 import { buildRRule } from "@/lib/recurrence-utils";
 import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
@@ -217,6 +218,15 @@ export function CalendarModule() {
   const handleDeleteEvent = () => {
     if (!selectedEvent) return;
 
+    // Guard: Google events are read-only
+    if (selectedEvent.source === "GOOGLE") {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Delete this event in Google Calendar.",
+      });
+      return;
+    }
+
     if (selectedEvent.isRecurring) {
       setScopeAction("delete");
       setScopeDialogOpen(true);
@@ -228,6 +238,15 @@ export function CalendarModule() {
 
   const handleEditClick = () => {
     if (!selectedEvent) return;
+
+    // Guard: Google events are read-only
+    if (selectedEvent.source === "GOOGLE") {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Edit this event in Google Calendar.",
+      });
+      return;
+    }
 
     if (selectedEvent.isRecurring) {
       setScopeAction("edit");
@@ -271,6 +290,7 @@ export function CalendarModule() {
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
+      description: formData.description,
     };
 
     if (currentEditingEvent.isRecurring && editScope === "this") {
@@ -329,6 +349,7 @@ export function CalendarModule() {
       memberId: formData.memberId,
       isAllDay: formData.isAllDay,
       location: formData.location,
+      description: formData.description,
       recurrenceRule,
     };
     createEvent.mutate(request);

--- a/src/components/calendar/components/calendar-event.test.tsx
+++ b/src/components/calendar/components/calendar-event.test.tsx
@@ -1,0 +1,55 @@
+import type { CalendarEvent } from "@/lib/types";
+import { render, screen } from "@/test/test-utils";
+import { CalendarEventCard } from "./calendar-event";
+
+vi.mock("@/api", () => ({
+  useFamilyMembers: () => [
+    { id: "m1", name: "Alice", color: "coral" as const },
+  ],
+}));
+
+const baseEvent: CalendarEvent = {
+  id: "e1",
+  title: "Test Event",
+  startTime: "09:00",
+  endTime: "10:00",
+  date: new Date("2026-01-15"),
+  memberId: "m1",
+  isAllDay: false,
+};
+
+describe("CalendarEventCard", () => {
+  it("does not show Google icon for native events", () => {
+    render(<CalendarEventCard event={baseEvent} />);
+    expect(
+      screen.queryByLabelText("Google Calendar event"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show Google icon when source is NATIVE", () => {
+    render(<CalendarEventCard event={{ ...baseEvent, source: "NATIVE" }} />);
+    expect(
+      screen.queryByLabelText("Google Calendar event"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows Google icon when source is GOOGLE", () => {
+    render(<CalendarEventCard event={{ ...baseEvent, source: "GOOGLE" }} />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+  });
+
+  it("shows Google icon in all variants", () => {
+    const googleEvent = { ...baseEvent, source: "GOOGLE" as const };
+
+    const { rerender } = render(
+      <CalendarEventCard event={googleEvent} variant="default" />,
+    );
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+
+    rerender(<CalendarEventCard event={googleEvent} variant="large" />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+
+    rerender(<CalendarEventCard event={googleEvent} variant="compact" />);
+    expect(screen.getByLabelText("Google Calendar event")).toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/components/calendar-event.tsx
+++ b/src/components/calendar/components/calendar-event.tsx
@@ -4,7 +4,7 @@ import type { CalendarEvent } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-function GoogleBadge({ size = 14 }: { size?: number }) {
+export function GoogleBadge({ size = 14 }: { size?: number }) {
   return (
     <span
       role="img"
@@ -41,7 +41,8 @@ function GoogleBadge({ size = 14 }: { size?: number }) {
   );
 }
 
-const isGoogleEvent = (event: CalendarEvent) => event.source === "GOOGLE";
+export const isGoogleEvent = (event: CalendarEvent) =>
+  event.source === "GOOGLE";
 
 interface CalendarEventCardProps {
   event: CalendarEvent;

--- a/src/components/calendar/components/calendar-event.tsx
+++ b/src/components/calendar/components/calendar-event.tsx
@@ -4,6 +4,45 @@ import type { CalendarEvent } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
+function GoogleBadge({ size = 14 }: { size?: number }) {
+  return (
+    <span
+      role="img"
+      aria-label="Google Calendar event"
+      className="inline-flex items-center justify-center rounded-full bg-white/70 shadow-sm"
+      style={{ width: size + 6, height: size + 6 }}
+    >
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+    </span>
+  );
+}
+
+const isGoogleEvent = (event: CalendarEvent) => event.source === "GOOGLE";
+
 interface CalendarEventCardProps {
   event: CalendarEvent;
   onClick?: () => void;
@@ -55,6 +94,11 @@ export function CalendarEventCard({
               </p>
             )}
           </div>
+          {isGoogleEvent(event) && (
+            <div className="shrink-0 mt-0.5">
+              <GoogleBadge size={14} />
+            </div>
+          )}
         </div>
       </button>
     );
@@ -86,6 +130,11 @@ export function CalendarEventCard({
               {event.title}
             </h4>
           </div>
+          {isGoogleEvent(event) && (
+            <div className="shrink-0">
+              <GoogleBadge size={10} />
+            </div>
+          )}
         </div>
       </button>
     );
@@ -121,6 +170,7 @@ export function CalendarEventCard({
           )}
         </div>
         <div className="flex items-center gap-1 shrink-0 mt-1">
+          {isGoogleEvent(event) && <GoogleBadge size={12} />}
           {event.isRecurring && (
             <Repeat
               className={cn("w-3 h-3", colors?.text || "text-muted-foreground")}

--- a/src/components/calendar/components/event-detail-modal.test.tsx
+++ b/src/components/calendar/components/event-detail-modal.test.tsx
@@ -1,0 +1,118 @@
+import { userEvent } from "@testing-library/user-event";
+import type { CalendarEvent } from "@/lib/types";
+import { render, screen } from "@/test/test-utils";
+import { EventDetailModal } from "./event-detail-modal";
+
+vi.mock("@/hooks", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/api", () => ({
+  useFamilyMembers: () => [
+    { id: "m1", name: "Alice", color: "coral" as const },
+  ],
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/components/ui/toaster", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const baseEvent: CalendarEvent = {
+  id: "e1",
+  title: "Test Event",
+  startTime: "09:00",
+  endTime: "10:00",
+  date: new Date("2026-01-15"),
+  memberId: "m1",
+  isAllDay: false,
+};
+
+const mockClose = vi.fn();
+const mockEdit = vi.fn();
+const mockDelete = vi.fn();
+
+const defaultProps = {
+  event: baseEvent,
+  isOpen: true,
+  onClose: mockClose,
+  onEdit: mockEdit,
+  onDelete: mockDelete,
+};
+
+describe("EventDetailModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows description when present", () => {
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, description: "Meeting notes here" }}
+      />,
+    );
+    expect(screen.getByText("Meeting notes here")).toBeInTheDocument();
+  });
+
+  it("does not show description section when absent", () => {
+    render(<EventDetailModal {...defaultProps} />);
+    expect(screen.queryByText("Meeting notes here")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Open in Google Calendar' link for Google events", () => {
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{
+          ...baseEvent,
+          source: "GOOGLE",
+          htmlLink: "https://calendar.google.com/event/123",
+        }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /open in google calendar/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://calendar.google.com/event/123",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("shows toast when clicking Edit on a Google event", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, source: "GOOGLE" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(mockToast).toHaveBeenCalled();
+    expect(mockEdit).not.toHaveBeenCalled();
+  });
+
+  it("shows toast when clicking Delete on a Google event", async () => {
+    const user = userEvent.setup();
+    render(
+      <EventDetailModal
+        {...defaultProps}
+        event={{ ...baseEvent, source: "GOOGLE" }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+    expect(mockToast).toHaveBeenCalled();
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("calls onEdit normally for native events", async () => {
+    const user = userEvent.setup();
+    render(<EventDetailModal {...defaultProps} />);
+
+    await user.click(screen.getByRole("button", { name: /edit/i }));
+    expect(mockEdit).toHaveBeenCalled();
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -2,6 +2,8 @@ import { format } from "date-fns";
 import {
   Calendar,
   Clock,
+  ExternalLink,
+  FileText,
   Loader2,
   MapPin,
   Pencil,
@@ -18,6 +20,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toast } from "@/components/ui/toaster";
 import { useIsMobile } from "@/hooks";
 import { formatRecurrenceLabel } from "@/lib/recurrence-utils";
 import type { CalendarEvent } from "@/lib/types";
@@ -57,6 +60,19 @@ function EventDetailModal({
 
   if (!event) return null;
 
+  const isGoogleEvent = event.source === "GOOGLE";
+
+  const handleEditClick = () => {
+    if (isGoogleEvent) {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Edit this event in Google Calendar.",
+      });
+      return;
+    }
+    onEdit();
+  };
+
   const member = getFamilyMember(familyMembers, event.memberId);
   const colors = member ? colorMap[member.color] : null;
 
@@ -77,6 +93,17 @@ function EventDetailModal({
 
   const handleDeleteClick = () => {
     setShowDeleteConfirm(true);
+  };
+
+  const handleDeleteAttempt = () => {
+    if (isGoogleEvent) {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Delete this event in Google Calendar.",
+      });
+      return;
+    }
+    handleDeleteClick();
   };
 
   const handleCancelDelete = () => {
@@ -156,6 +183,31 @@ function EventDetailModal({
                 <span className="truncate">{event.location}</span>
               </div>
             )}
+
+            {/* Description (conditional) */}
+            {event.description && (
+              <div className="flex items-start gap-3 text-muted-foreground">
+                <FileText className="w-4 h-4 shrink-0 mt-0.5" />
+                <p className="text-sm whitespace-pre-wrap">
+                  {event.description}
+                </p>
+              </div>
+            )}
+
+            {/* Open in Google Calendar (conditional) */}
+            {isGoogleEvent && event.htmlLink && (
+              <div className="flex items-center gap-3">
+                <ExternalLink className="w-4 h-4 shrink-0 text-muted-foreground" />
+                <a
+                  href={event.htmlLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-primary hover:underline"
+                >
+                  Open in Google Calendar
+                </a>
+              </div>
+            )}
           </div>
 
           {/* Error message */}
@@ -202,7 +254,7 @@ function EventDetailModal({
             <div className="flex gap-3 w-full">
               <Button
                 variant="outline"
-                onClick={onEdit}
+                onClick={handleEditClick}
                 disabled={isDeleting}
                 className="flex-1 min-h-[48px]"
               >
@@ -211,7 +263,7 @@ function EventDetailModal({
               </Button>
               <Button
                 variant="destructive"
-                onClick={handleDeleteClick}
+                onClick={handleDeleteAttempt}
                 disabled={isDeleting}
                 className="flex-1 min-h-[48px]"
               >
@@ -226,5 +278,5 @@ function EventDetailModal({
   );
 }
 
-export { EventDetailModal };
 export type { EventDetailModalProps };
+export { EventDetailModal };

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -36,6 +36,7 @@ function eventToFormData(event: CalendarEvent): Partial<EventFormData> {
     endTime: format12hTo24h(event.endTime),
     memberId: event.memberId,
     location: event.location ?? undefined,
+    description: event.description ?? undefined,
     isAllDay: event.isAllDay,
   };
 

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -662,6 +662,71 @@ describe("EventForm", () => {
     });
   });
 
+  describe("Description Field", () => {
+    it("hides description textarea by default in add mode", () => {
+      render(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+      expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/add description/i)).toBeInTheDocument();
+    });
+
+    it("shows description textarea when 'Add description' is clicked", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(screen.getByText(/add description/i));
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    it("auto-expands in edit mode when description has value", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{
+            title: "Test",
+            date: "2026-01-15",
+            startTime: "09:00",
+            endTime: "10:00",
+            memberId: testMembers[0].id,
+            description: "Some notes",
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/description/i)).toHaveValue("Some notes");
+    });
+
+    it("does not auto-expand in edit mode when description is empty", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{
+            title: "Test",
+            date: "2026-01-15",
+            startTime: "09:00",
+            endTime: "10:00",
+            memberId: testMembers[0].id,
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+      expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
+    });
+  });
+
   describe("Member Selection", () => {
     it("allows changing selected family member", async () => {
       // Pass explicit defaultValues to avoid async initialization race condition

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { useEffect, useMemo } from "react";
+import { ChevronDown } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useFamilyMembers } from "@/api";
 import { Button } from "@/components/ui/button";
@@ -76,6 +77,8 @@ function EventForm({
     defaultValues: initialValues,
   });
 
+  const [showDescription, setShowDescription] = useState(false);
+
   // Watch values for controlled components
   const dateValue = watch("date");
   const endDateValue = watch("endDate");
@@ -88,11 +91,19 @@ function EventForm({
   const recurrenceWeeklyDays = watch("recurrenceWeeklyDays");
   const recurrenceMonthDay = watch("recurrenceMonthDay");
   const recurrenceEndDate = watch("recurrenceEndDate");
+  const descriptionValue = watch("description");
 
   // Reset form when defaultValues change (e.g., switching between events in edit mode)
   useEffect(() => {
     reset(initialValues);
   }, [initialValues, reset]);
+
+  // Auto-expand description if initial value has content
+  useEffect(() => {
+    if (initialValues.description) {
+      setShowDescription(true);
+    }
+  }, [initialValues.description]);
 
   const handleFormSubmit = (data: EventFormData) => {
     if (isPending) return;
@@ -258,6 +269,41 @@ function EventForm({
           error={!!errors.memberId}
         />
         <FormError message={errors.memberId?.message} />
+      </div>
+
+      {/* Description (collapsible) */}
+      <div className="space-y-2">
+        {!showDescription ? (
+          <button
+            type="button"
+            onClick={() => setShowDescription(true)}
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronDown className="w-3.5 h-3.5" />
+            Add description
+          </button>
+        ) : (
+          <>
+            <Label htmlFor="description">Description</Label>
+            <textarea
+              id="description"
+              {...register("description")}
+              placeholder="Add notes or details..."
+              className={cn(
+                "flex min-h-[80px] w-full rounded-md border border-input bg-input px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 resize-y",
+                errors.description && "border-destructive",
+              )}
+              maxLength={2000}
+              aria-invalid={!!errors.description}
+            />
+            {descriptionValue && descriptionValue.length > 1900 && (
+              <p className="text-xs text-muted-foreground text-right">
+                {descriptionValue.length}/2000
+              </p>
+            )}
+            <FormError message={errors.description?.message} />
+          </>
+        )}
       </div>
 
       {/* Actions */}

--- a/src/components/calendar/components/mobile-event-detail.tsx
+++ b/src/components/calendar/components/mobile-event-detail.tsx
@@ -3,6 +3,8 @@ import {
   ArrowLeft,
   Calendar,
   Clock,
+  ExternalLink,
+  FileText,
   Loader2,
   MapPin,
   Pencil,
@@ -11,6 +13,7 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toaster";
 import { formatRecurrenceLabel } from "@/lib/recurrence-utils";
 import type { CalendarEvent } from "@/lib/types";
 import { colorMap, type FamilyColor } from "@/lib/types";
@@ -47,6 +50,30 @@ function MobileEventDetail({
   }, [isOpen]);
 
   if (!isOpen) return null;
+
+  const isGoogleEvent = event.source === "GOOGLE";
+
+  const handleEditClick = () => {
+    if (isGoogleEvent) {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Edit this event in Google Calendar.",
+      });
+      return;
+    }
+    onEdit();
+  };
+
+  const handleDeleteAttempt = () => {
+    if (isGoogleEvent) {
+      toast({
+        title: "Synced from Google Calendar",
+        description: "Delete this event in Google Calendar.",
+      });
+      return;
+    }
+    handleDeleteClick();
+  };
 
   const colors = colorMap[member.color];
   const hexColor = colors.hex;
@@ -99,7 +126,7 @@ function MobileEventDetail({
             <Button
               variant="ghost"
               size="sm"
-              onClick={onEdit}
+              onClick={handleEditClick}
               disabled={isDeleting}
               className="text-white hover:text-white hover:bg-white/20 h-9 px-3"
             >
@@ -109,7 +136,7 @@ function MobileEventDetail({
             <Button
               variant="ghost"
               size="sm"
-              onClick={handleDeleteClick}
+              onClick={handleDeleteAttempt}
               disabled={isDeleting}
               className="text-white hover:text-white hover:bg-white/20 h-9 px-3"
             >
@@ -178,6 +205,31 @@ function MobileEventDetail({
             <div className="flex items-center gap-3">
               <MapPin className={cn("w-5 h-5 shrink-0", colors.text)} />
               <span className="text-foreground truncate">{event.location}</span>
+            </div>
+          )}
+
+          {/* Description (conditional) */}
+          {event.description && (
+            <div className="flex items-start gap-3">
+              <FileText className={cn("w-5 h-5 shrink-0", colors.text)} />
+              <p className="text-foreground text-sm whitespace-pre-wrap">
+                {event.description}
+              </p>
+            </div>
+          )}
+
+          {/* Open in Google Calendar (conditional) */}
+          {isGoogleEvent && event.htmlLink && (
+            <div className="flex items-center gap-3">
+              <ExternalLink className={cn("w-5 h-5 shrink-0", colors.text)} />
+              <a
+                href={event.htmlLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline text-sm"
+              >
+                Open in Google Calendar
+              </a>
             </div>
           )}
         </div>

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -13,6 +13,7 @@ import {
   getFamilyMember,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { GoogleBadge, isGoogleEvent } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
 import { CalendarNavigation } from "../components/calendar-navigation";
 
@@ -231,12 +232,19 @@ export function MonthlyCalendar({
                         onEventClick?.(event);
                       }}
                       className={cn(
-                        "text-xs px-1.5 py-1 sm:py-0.5 rounded truncate text-left w-full min-h-[28px] sm:min-h-0",
+                        "text-xs px-1.5 py-1 sm:py-0.5 rounded text-left w-full min-h-[28px] sm:min-h-0 flex items-center gap-1",
                         member ? colorMap[member.color]?.bg : "bg-muted",
                         "text-white font-medium",
                       )}
                     >
-                      {event.isAllDay ? `● ${event.title}` : event.title}
+                      {isGoogleEvent(event) && (
+                        <span className="shrink-0">
+                          <GoogleBadge size={8} />
+                        </span>
+                      )}
+                      <span className="truncate">
+                        {event.isAllDay ? `● ${event.title}` : event.title}
+                      </span>
                     </button>
                   );
                 })}

--- a/src/components/settings/google-calendar-picker-modal.test.tsx
+++ b/src/components/settings/google-calendar-picker-modal.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { API_BASE, server, setupMswServer } from "@/test/mocks/server";
+import { render } from "@/test/test-utils";
+import { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+
+const MEMBER_ID = "member-123";
+
+setupMswServer();
+
+describe("GoogleCalendarPickerModal", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${API_BASE}/google/calendars/${MEMBER_ID}`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "primary",
+              name: "Main Calendar",
+              primary: true,
+              enabled: true,
+            },
+            {
+              id: "work@group.calendar.google.com",
+              name: "Work",
+              primary: false,
+              enabled: false,
+            },
+          ],
+          message: null,
+        }),
+      ),
+    );
+  });
+
+  it("shows calendars with checkboxes", async () => {
+    render(
+      <GoogleCalendarPickerModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId={MEMBER_ID}
+      />,
+    );
+
+    expect(await screen.findByText(/Main Calendar/i)).toBeInTheDocument();
+    expect(screen.getByText(/\(Primary\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/Work/i)).toBeInTheDocument();
+  });
+
+  it("primary calendar is checked, non-enabled is unchecked", async () => {
+    render(
+      <GoogleCalendarPickerModal
+        open={true}
+        onOpenChange={vi.fn()}
+        memberId={MEMBER_ID}
+      />,
+    );
+
+    const checkboxes = await screen.findAllByRole("checkbox");
+    expect(checkboxes[0]).toBeChecked(); // Main Calendar — enabled: true
+    expect(checkboxes[1]).not.toBeChecked(); // Work — enabled: false
+  });
+});

--- a/src/components/settings/google-calendar-picker-modal.tsx
+++ b/src/components/settings/google-calendar-picker-modal.tsx
@@ -1,0 +1,145 @@
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useGoogleCalendars, useUpdateGoogleCalendars } from "@/api";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { toast } from "@/components/ui/toaster";
+
+interface GoogleCalendarPickerModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  memberId: string;
+}
+
+export function GoogleCalendarPickerModal({
+  open,
+  onOpenChange,
+  memberId,
+}: GoogleCalendarPickerModalProps) {
+  const { data: calendarsResponse, isLoading } = useGoogleCalendars(
+    memberId,
+    open,
+  );
+  const updateCalendars = useUpdateGoogleCalendars();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const calendars = calendarsResponse?.data ?? [];
+
+  // Sort: primary first, then alphabetical
+  const sortedCalendars = [...calendars].sort((a, b) => {
+    if (a.primary && !b.primary) return -1;
+    if (!a.primary && b.primary) return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  // Sync local state when data loads
+  useEffect(() => {
+    if (calendars.length > 0) {
+      setSelectedIds(
+        new Set(calendars.filter((c) => c.enabled).map((c) => c.id)),
+      );
+    }
+  }, [calendars]);
+
+  const handleToggle = (calendarId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(calendarId)) {
+        next.delete(calendarId);
+      } else {
+        next.add(calendarId);
+      }
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    updateCalendars.mutate(
+      { memberId, calendarIds: Array.from(selectedIds) },
+      {
+        onSuccess: () => {
+          onOpenChange(false);
+          toast({
+            title: "Calendars updated",
+            description: "Your calendar selection has been saved.",
+          });
+        },
+        onError: () => {
+          toast({
+            title: "Update failed",
+            description: "Could not save calendar selection.",
+            variant: "destructive",
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Choose Calendars</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <div className="space-y-2 py-2">
+            {sortedCalendars.map((cal) => (
+              <label
+                key={cal.id}
+                className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted cursor-pointer transition-colors"
+              >
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(cal.id)}
+                  onChange={() => handleToggle(cal.id)}
+                  className="rounded border-border"
+                />
+                <span className="text-sm">
+                  {cal.name}
+                  {cal.primary && (
+                    <span className="text-muted-foreground ml-1">
+                      (Primary)
+                    </span>
+                  )}
+                </span>
+              </label>
+            ))}
+            {sortedCalendars.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-4">
+                No calendars found
+              </p>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSave}
+            disabled={updateCalendars.isPending || isLoading}
+          >
+            {updateCalendars.isPending ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/settings/google-calendar-picker-modal.tsx
+++ b/src/components/settings/google-calendar-picker-modal.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useGoogleCalendars, useUpdateGoogleCalendars } from "@/api";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,6 +28,7 @@ export function GoogleCalendarPickerModal({
   );
   const updateCalendars = useUpdateGoogleCalendars();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const hasSynced = useRef(false);
 
   const calendars = calendarsResponse?.data ?? [];
 
@@ -38,14 +39,22 @@ export function GoogleCalendarPickerModal({
     return a.name.localeCompare(b.name);
   });
 
-  // Sync local state when data loads
+  // Sync local state only on initial data load
   useEffect(() => {
-    if (calendars.length > 0) {
+    if (calendars.length > 0 && !hasSynced.current) {
+      hasSynced.current = true;
       setSelectedIds(
         new Set(calendars.filter((c) => c.enabled).map((c) => c.id)),
       );
     }
   }, [calendars]);
+
+  // Reset sync flag when modal closes so next open re-syncs
+  useEffect(() => {
+    if (!open) {
+      hasSynced.current = false;
+    }
+  }, [open]);
 
   const handleToggle = (calendarId: string) => {
     setSelectedIds((prev) => {

--- a/src/components/settings/google-calendar-section.test.tsx
+++ b/src/components/settings/google-calendar-section.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { HttpResponse, http } from "msw";
+import type { ReactNode } from "react";
+import { API_BASE, server, setupMswServer } from "@/test/mocks/server";
+import { render, screen } from "@/test/test-utils";
+import { GoogleCalendarSection } from "./google-calendar-section";
+
+const MEMBER_ID = "member-123";
+
+setupMswServer();
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("GoogleCalendarSection", () => {
+  describe("disconnected state", () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${API_BASE}/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: { connected: false, calendars: [] },
+            message: null,
+          }),
+        ),
+      );
+    });
+
+    it("shows connect button when member has email", async () => {
+      render(
+        <GoogleCalendarSection
+          memberId={MEMBER_ID}
+          memberEmail="test@example.com"
+          memberName="Alice"
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(
+        await screen.findByRole("button", { name: /connect google calendar/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("disables connect button when member has no email", async () => {
+      render(
+        <GoogleCalendarSection
+          memberId={MEMBER_ID}
+          memberEmail=""
+          memberName="Alice"
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      const button = await screen.findByRole("button", {
+        name: /connect google calendar/i,
+      });
+      expect(button).toBeDisabled();
+      expect(screen.getByText(/add an email/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("connected state", () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${API_BASE}/google/status/${MEMBER_ID}`, () =>
+          HttpResponse.json({
+            data: {
+              connected: true,
+              calendars: [
+                {
+                  id: "primary",
+                  name: "Main Calendar",
+                  enabled: true,
+                  lastSyncedAt: "2026-03-20T10:00:00Z",
+                },
+              ],
+            },
+            message: null,
+          }),
+        ),
+      );
+    });
+
+    it("shows connected status and action buttons", async () => {
+      render(
+        <GoogleCalendarSection
+          memberId={MEMBER_ID}
+          memberEmail="test@example.com"
+          memberName="Alice"
+        />,
+        { wrapper: createWrapper() },
+      );
+
+      expect(await screen.findByText(/connected/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /choose calendars/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /sync now/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /disconnect/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/settings/google-calendar-section.tsx
+++ b/src/components/settings/google-calendar-section.tsx
@@ -1,0 +1,211 @@
+import { formatDistanceToNow } from "date-fns";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+import {
+  googleCalendarService,
+  useDisconnectGoogle,
+  useGoogleConnectionStatus,
+  useSyncGoogleCalendar,
+} from "@/api";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/toaster";
+import { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+
+interface GoogleCalendarSectionProps {
+  memberId: string;
+  memberEmail: string;
+  memberName: string;
+}
+
+export function GoogleCalendarSection({
+  memberId,
+  memberEmail,
+  memberName,
+}: GoogleCalendarSectionProps) {
+  const { data: statusResponse, isLoading } =
+    useGoogleConnectionStatus(memberId);
+  const syncMutation = useSyncGoogleCalendar();
+  const disconnectMutation = useDisconnectGoogle();
+  const [showCalendarPicker, setShowCalendarPicker] = useState(false);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+
+  const status = statusResponse?.data;
+  const isConnected = status?.connected ?? false;
+  const isSyncing = syncMutation.isPending;
+
+  const handleConnect = async () => {
+    try {
+      const response = await googleCalendarService.getAuthUrl(memberId);
+      sessionStorage.setItem(
+        "google-auth-return",
+        JSON.stringify({
+          memberId,
+          returnTo: "member-profile",
+          timestamp: Date.now(),
+        }),
+      );
+      window.location.href = response.data.url;
+    } catch {
+      toast({
+        title: "Connection failed",
+        description: "Could not connect to Google Calendar. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSync = () => {
+    syncMutation.mutate(memberId, {
+      onSuccess: () => {
+        toast({
+          title: "Sync started",
+          description: "Your Google Calendar events are being synced.",
+        });
+      },
+      onError: () => {
+        toast({
+          title: "Sync failed",
+          description: "Could not sync. Please try again.",
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  const handleDisconnect = () => {
+    disconnectMutation.mutate(memberId, {
+      onSuccess: () => {
+        setShowDisconnectConfirm(false);
+        toast({
+          title: "Disconnected",
+          description: "Google Calendar has been disconnected.",
+        });
+      },
+      onError: () => {
+        toast({
+          title: "Disconnect failed",
+          description: "Could not disconnect. Please try again.",
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Google Calendar</p>
+        <div className="h-10 bg-muted animate-pulse rounded-md" />
+      </div>
+    );
+  }
+
+  const lastSyncedAt = status?.calendars?.[0]?.lastSyncedAt;
+  const lastSyncedLabel = lastSyncedAt
+    ? `Last synced ${formatDistanceToNow(new Date(lastSyncedAt), { addSuffix: true })}`
+    : "Never synced";
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm font-medium">Google Calendar</p>
+
+      {!isConnected ? (
+        <div className="space-y-2">
+          <Button
+            type="button"
+            onClick={handleConnect}
+            disabled={!memberEmail}
+            className="w-full"
+          >
+            Connect Google Calendar
+          </Button>
+          {!memberEmail && (
+            <p className="text-xs text-muted-foreground">
+              Add an email address to connect Google Calendar
+            </p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <span className="text-sm text-foreground">Connected</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{lastSyncedLabel}</p>
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCalendarPicker(true)}
+            >
+              Choose Calendars
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleSync}
+              disabled={isSyncing}
+            >
+              {isSyncing ? (
+                <>
+                  <Loader2 className="w-3 h-3 mr-1.5 animate-spin" />
+                  Syncing...
+                </>
+              ) : (
+                "Sync Now"
+              )}
+            </Button>
+          </div>
+
+          {showDisconnectConfirm ? (
+            <div className="space-y-2 p-3 border border-border rounded-md">
+              <p className="text-xs text-muted-foreground">
+                This will remove all synced Google events for {memberName}.
+                Events created in FamilyHub are not affected.
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowDisconnectConfirm(false)}
+                  disabled={disconnectMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleDisconnect}
+                  disabled={disconnectMutation.isPending}
+                >
+                  {disconnectMutation.isPending
+                    ? "Disconnecting..."
+                    : "Confirm Disconnect"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setShowDisconnectConfirm(true)}
+              className="text-xs text-destructive hover:underline"
+            >
+              Disconnect
+            </button>
+          )}
+        </div>
+      )}
+
+      <GoogleCalendarPickerModal
+        open={showCalendarPicker}
+        onOpenChange={setShowCalendarPicker}
+        memberId={memberId}
+      />
+    </div>
+  );
+}

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,2 +1,3 @@
 export { FamilySettingsModal } from "./family-settings-modal";
+export { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
 export { MemberProfileModal } from "./member-profile-modal";

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,3 +1,4 @@
 export { FamilySettingsModal } from "./family-settings-modal";
 export { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
+export { GoogleCalendarSection } from "./google-calendar-section";
 export { MemberProfileModal } from "./member-profile-modal";

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -19,6 +19,7 @@ import {
   createMemberProfileSchema,
   type MemberProfileFormData,
 } from "@/lib/validations/family";
+import { GoogleCalendarSection } from "./google-calendar-section";
 
 interface MemberProfileModalProps {
   open: boolean;
@@ -259,10 +260,17 @@ export function MemberProfileModal({
                 id="email-description"
                 className="text-xs text-muted-foreground"
               >
-                Used for Google Calendar sync (coming soon)
+                Used for notifications and Google Calendar sync
               </p>
             )}
           </div>
+
+          {/* Google Calendar */}
+          <GoogleCalendarSection
+            memberId={memberId}
+            memberEmail={watch("email") || member?.email || ""}
+            memberName={member?.name || ""}
+          />
 
           {/* Actions */}
           <div className="flex justify-end gap-3 pt-2">

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,5 +1,5 @@
 import { LogOut, Users, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFamilyMembers, useFamilyName, useLogout } from "@/api";
 import { FamilySettingsModal, MemberProfileModal } from "@/components/settings";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,16 @@ export function SidebarMenu() {
   // Modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      const autoOpenMemberId = sessionStorage.getItem("open-member-profile");
+      if (autoOpenMemberId) {
+        sessionStorage.removeItem("open-member-profile");
+        setSelectedMemberId(autoOpenMemberId);
+      }
+    }
+  }, [isOpen]);
 
   if (!isOpen) return null;
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,115 @@
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { X } from "lucide-react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const Toast = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & {
+    variant?: "default" | "destructive";
+  }
+>(({ className, variant = "default", ...props }, ref) => (
+  <ToastPrimitives.Root
+    ref={ref}
+    className={cn(
+      "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-4 shadow-lg transition-all",
+      "data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+      variant === "destructive"
+        ? "border-destructive bg-destructive text-destructive-foreground"
+        : "border-border bg-background text-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium",
+      "hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring disabled:pointer-events-none disabled:opacity-50",
+      "group-[.destructive]:border-destructive/30 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100",
+      "group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ComponentRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+export {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+};
+
+export type ToastActionElement = React.ReactElement<typeof ToastAction>;

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import {
+  Toast,
+  type ToastActionElement,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast";
+
+const TOAST_LIMIT = 3;
+const TOAST_REMOVE_DELAY = 5000;
+
+type ToastData = {
+  id: string;
+  title?: string;
+  description?: string;
+  action?: ToastActionElement;
+  variant?: "default" | "destructive";
+  open: boolean;
+};
+
+let toastCount = 0;
+const listeners: Array<(toasts: ToastData[]) => void> = [];
+let memoryToasts: ToastData[] = [];
+
+function genId() {
+  toastCount = (toastCount + 1) % Number.MAX_SAFE_INTEGER;
+  return toastCount.toString();
+}
+
+function dispatch(toasts: ToastData[]) {
+  memoryToasts = toasts;
+  for (const listener of listeners) {
+    listener(toasts);
+  }
+}
+
+export function toast({
+  title,
+  description,
+  action,
+  variant,
+}: Omit<ToastData, "id" | "open">) {
+  const id = genId();
+  const newToast: ToastData = {
+    id,
+    title,
+    description,
+    action,
+    variant,
+    open: true,
+  };
+
+  dispatch([newToast, ...memoryToasts].slice(0, TOAST_LIMIT));
+
+  setTimeout(() => {
+    dispatch(
+      memoryToasts.map((t) => (t.id === id ? { ...t, open: false } : t)),
+    );
+  }, TOAST_REMOVE_DELAY);
+
+  return id;
+}
+
+function useToastState() {
+  const [toasts, setToasts] = useState<ToastData[]>(memoryToasts);
+
+  useEffect(() => {
+    listeners.push(setToasts);
+    return () => {
+      const index = listeners.indexOf(setToasts);
+      if (index > -1) listeners.splice(index, 1);
+    };
+  }, []);
+
+  return toasts;
+}
+
+export function Toaster() {
+  const toasts = useToastState();
+
+  return (
+    <ToastProvider>
+      {toasts.map(({ id, title, description, action, variant, open }) => (
+        <Toast key={id} open={open} variant={variant}>
+          <div className="grid gap-1">
+            {title && <ToastTitle>{title}</ToastTitle>}
+            {description && <ToastDescription>{description}</ToastDescription>}
+          </div>
+          {action}
+          <ToastClose />
+        </Toast>
+      ))}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -53,7 +53,9 @@ export function toast({
     open: true,
   };
 
-  dispatch([newToast, ...memoryToasts].slice(0, TOAST_LIMIT));
+  dispatch(
+    [newToast, ...memoryToasts.filter((t) => t.open)].slice(0, TOAST_LIMIT),
+  );
 
   setTimeout(() => {
     dispatch(

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useDebounce } from "./use-debounce";
+export { useGoogleAuthReturn } from "./use-google-auth-return";
 export { useIsMobile } from "./use-is-mobile";

--- a/src/hooks/use-google-auth-return.test.ts
+++ b/src/hooks/use-google-auth-return.test.ts
@@ -1,0 +1,89 @@
+import { renderHook } from "@testing-library/react";
+import { useGoogleAuthReturn } from "./use-google-auth-return";
+
+const mockToast = vi.fn();
+vi.mock("@/components/ui/toaster", () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+const mockOpenSidebar = vi.fn();
+vi.mock("@/stores", () => ({
+  useAppStore: {
+    getState: () => ({ openSidebar: mockOpenSidebar }),
+  },
+}));
+
+describe("useGoogleAuthReturn", () => {
+  let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    replaceStateSpy = vi
+      .spyOn(window.history, "replaceState")
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    replaceStateSpy.mockRestore();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "" },
+      writable: true,
+    });
+  });
+
+  it("does nothing when no google-auth query param", () => {
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("shows success toast on googleConnected=true", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?googleConnected=true" },
+      writable: true,
+    });
+
+    sessionStorage.setItem(
+      "google-auth-return",
+      JSON.stringify({
+        memberId: "m1",
+        returnTo: "member-profile",
+        timestamp: Date.now(),
+      }),
+    );
+
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringContaining("Connected") }),
+    );
+  });
+
+  it("shows error toast on error param", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?error=consent_denied" },
+      writable: true,
+    });
+
+    renderHook(() => useGoogleAuthReturn());
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    );
+  });
+
+  it("cleans up query params and sessionStorage", () => {
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, search: "?googleConnected=true" },
+      writable: true,
+    });
+
+    sessionStorage.setItem(
+      "google-auth-return",
+      JSON.stringify({ memberId: "m1", timestamp: Date.now() }),
+    );
+
+    renderHook(() => useGoogleAuthReturn());
+
+    expect(replaceStateSpy).toHaveBeenCalled();
+    expect(sessionStorage.getItem("google-auth-return")).toBeNull();
+  });
+});

--- a/src/hooks/use-google-auth-return.ts
+++ b/src/hooks/use-google-auth-return.ts
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { toast } from "@/components/ui/toaster";
+import { useAppStore } from "@/stores";
+
+const STORAGE_KEY = "google-auth-return";
+const STALE_THRESHOLD_MS = 10 * 60 * 1000; // 10 minutes
+
+interface GoogleAuthReturnState {
+  memberId: string;
+  returnTo: string;
+  timestamp: number;
+}
+
+export function useGoogleAuthReturn() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const success = params.get("googleConnected");
+    const error = params.get("error");
+
+    if (!success && !error) return;
+
+    // Clean up query params
+    const url = new URL(window.location.href);
+    url.searchParams.delete("googleConnected");
+    url.searchParams.delete("error");
+    window.history.replaceState({}, "", url.pathname + url.search);
+
+    // Read and clean up return state
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    sessionStorage.removeItem(STORAGE_KEY);
+
+    let returnState: GoogleAuthReturnState | null = null;
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as GoogleAuthReturnState;
+        if (Date.now() - parsed.timestamp < STALE_THRESHOLD_MS) {
+          returnState = parsed;
+        }
+      } catch {
+        // Ignore corrupt data
+      }
+    }
+
+    if (success === "true") {
+      toast({
+        title: "Google Calendar Connected",
+        description: "Your Google Calendar events will appear shortly.",
+      });
+
+      if (returnState) {
+        useAppStore.getState().openSidebar();
+        sessionStorage.setItem("open-member-profile", returnState.memberId);
+      }
+    } else if (error) {
+      const messages: Record<string, string> = {
+        consent_denied:
+          "Google Calendar access was denied. You can try again anytime.",
+        token_exchange_failed:
+          "Failed to connect Google Calendar. Please try again.",
+      };
+      toast({
+        title: "Connection failed",
+        description:
+          messages[error] ??
+          "Failed to connect Google Calendar. Please try again.",
+        variant: "destructive",
+      });
+    }
+  }, []);
+}

--- a/src/lib/types/calendar.ts
+++ b/src/lib/types/calendar.ts
@@ -11,6 +11,10 @@ export interface CalendarEvent {
   recurrenceRule?: string;
   recurringEventId?: string;
   isRecurring?: boolean;
+  // Google Calendar integration
+  source?: "NATIVE" | "GOOGLE";
+  description?: string;
+  htmlLink?: string;
 }
 
 /**
@@ -41,6 +45,7 @@ export interface CreateEventRequest {
   isAllDay?: boolean;
   location?: string;
   recurrenceRule?: string | null;
+  description?: string;
 }
 
 export interface UpdateEventRequest {
@@ -53,6 +58,7 @@ export interface UpdateEventRequest {
   isAllDay?: boolean;
   location?: string;
   recurrenceRule?: string | null;
+  description?: string;
 }
 
 export interface GetEventsParams {

--- a/src/lib/types/google-calendar.ts
+++ b/src/lib/types/google-calendar.ts
@@ -1,0 +1,20 @@
+export interface GoogleAuthUrl {
+  url: string;
+}
+
+export interface GoogleCalendarInfo {
+  id: string;
+  name: string;
+  primary: boolean;
+  enabled: boolean;
+}
+
+export interface GoogleConnectionStatus {
+  connected: boolean;
+  calendars: Array<{
+    id: string;
+    name: string;
+    enabled: boolean;
+    lastSyncedAt: string | null;
+  }>;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -3,4 +3,5 @@ export * from "./auth";
 export * from "./calendar";
 export * from "./chores";
 export * from "./family";
+export * from "./google-calendar";
 export * from "./meals";

--- a/src/lib/validations/calendar.ts
+++ b/src/lib/validations/calendar.ts
@@ -49,6 +49,10 @@ export const eventFormSchema = z
       .string()
       .max(255, "Location must be 255 characters or less")
       .optional(),
+    description: z
+      .string()
+      .max(2000, "Description must be 2000 characters or less")
+      .optional(),
     isAllDay: z.boolean().optional(),
     endDate: z
       .string()

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -454,4 +454,20 @@ export const handlers = [
 
     return HttpResponse.json(response);
   }),
+
+  // ============================================================================
+  // Google Calendar API Handlers (default: disconnected state)
+  // ============================================================================
+
+  // GET /google/status/:memberId - Connection status (default: disconnected)
+  http.get(`${API_BASE}/google/status/:memberId`, () => {
+    return HttpResponse.json(
+      createApiResponse({ connected: false, calendars: [] }),
+    );
+  }),
+
+  // GET /google/calendars/:memberId - Calendar list (default: empty)
+  http.get(`${API_BASE}/google/calendars/:memberId`, () => {
+    return HttpResponse.json(createApiResponse([]));
+  }),
 ];


### PR DESCRIPTION
## Summary

- Add read-only Google Calendar integration to the frontend
- Members can connect their Google account via OAuth, select which calendars to sync, and see Google events alongside native events
- Google events display with a Google badge and are read-only (edit/delete show a toast directing users to Google Calendar)
- Add toast notification system (Radix Toast), description field to events, and OAuth return handler with state restoration

## What's Included

**Types & Validation** — Google Calendar types (`GoogleAuthUrl`, `GoogleCalendarInfo`, `GoogleConnectionStatus`), `source`/`description`/`htmlLink` fields on `CalendarEvent`, description in Zod schema

**API Layer** — `googleCalendarService` with 6 endpoints, TanStack Query hooks (`useGoogleConnectionStatus`, `useGoogleCalendars`, `useUpdateGoogleCalendars`, `useSyncGoogleCalendar`, `useDisconnectGoogle`)

**UI Components:**
- Toast notification system (Radix Toast primitives + imperative `toast()` API)
- Google badge on event cards (all 3 size variants)
- Description + Google Calendar link in event detail modals (desktop + mobile)
- Edit/delete guards for Google events (toast instead of action)
- Collapsible description field in event form
- Google Calendar connection section in member profile
- Calendar picker modal for selecting which Google calendars to sync

**OAuth Flow** — `useGoogleAuthReturn` hook handles OAuth redirect, shows success/error toasts, restores UI state (sidebar + member profile)

## Test Plan

- [x] 603 unit tests passing (35 test files)
- [x] Build passes (`tsc` + Vite)
- [x] Lint passes (Biome)
- [x] 56 E2E tests passing (all browsers)

## Manual Smoke Test

### Description Field (no backend dependency)
- [x] Create event → "Add description" toggle is visible, textarea is collapsed
- [x] Click "Add description" → textarea expands with character counter area
- [x] Type 1901+ characters → character counter appears (e.g., "1901 / 2000")
- [x] Type 2001+ characters → validation error shown
- [x] Submit event with description → description included in request payload (check Network tab)
- [x] Edit an event that has a description → textarea auto-expands with existing text

### Event Detail Modal
- [x] Click a native event → detail modal shows event info, edit/delete buttons work normally
- [x] If a Google event exists: click it → shows description (if any), "Open in Google Calendar" link, Google badge
- [x] If a Google event exists: click Edit → toast appears: "This event is managed in Google Calendar"
- [x] If a Google event exists: click Delete → toast appears with same message
- [x] Verify on mobile: same behavior in mobile event detail sheet

### Event Cards
- [ ] If Google events exist: cards show Google "G" badge in all calendar views (daily, weekly, monthly, schedule)
- [ ] Badge sizes: small on compact cards, medium on default, larger on expanded cards

### Member Profile — Google Calendar Section
- [ ] Open sidebar (Menu button) → click a member name → profile modal opens
- [x] "Google Calendar" section is visible below email field
- [x] Without email: "Connect Google Calendar" button is disabled, helper text says "Add an email address..."
- [x] With email: "Connect Google Calendar" button is enabled
- [x] Click "Connect Google Calendar" → redirects to backend OAuth URL (may 404 if BE not deployed)
- [x] Email helper text reads "Used for notifications and Google Calendar sync"

### OAuth Return (requires backend)
- [x] After successful OAuth: redirected back with `?googleConnected=true` → success toast shown, sidebar opens, member profile re-opens
- [x] After failed OAuth: redirected back with `?error=access_denied` → error toast shown with mapped message
- [x] URL query params are cleaned up after processing
- [x] Stale return (> 10 min after redirect) → silently discarded

### Connected State (requires backend)
- [x] Connected member shows: "Connected" status, "Choose Calendars" button, "Sync Now" button, "Disconnect" button
- [x] "Choose Calendars" → picker modal opens with checkboxes, primary calendar marked
- [x] Toggle calendars, close modal, reopen → selections persisted (not reset)
- [x] "Sync Now" → triggers sync, toast on success/failure
- [x] "Disconnect" → disconnects, section reverts to "Connect" button

### Toast System
- [x] Toasts appear in bottom-right corner, stack up to 3
- [x] Toasts auto-dismiss after 5 seconds
- [x] Click X to dismiss manually
- [x] Destructive variant shows red styling