### PR TITLE
ci: enforce release-based frontend deploys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,17 @@ See `src/test/test-utils.tsx` for `waitForMemberSelected`, `typeAndWait`, `TEST_
 `deploy.sh` runs checks fastest-to-slowest:
 1. Clean working tree
 2. Must be on `main`, synced with `origin/main`
-3. Tagged release check (warns if untagged)
+3. Must be the exact released FE commit tagged `family-hub-v<package.json version>`
 4. `npm run lint`
 5. `npm test -- --run`
 6. Build → rsync to server → HTTP health check
+
+## Shipping Semantics
+
+- Backend `main` may merge incrementally. FE should treat only published BE releases as stable integration contracts.
+- FE CI E2E resolves the latest published BE release from GitHub Releases and sets `BE_IMAGE_TAG` before starting the backend container.
+- Manual FE deploys still happen from a local terminal via `deploy.sh`; CI does not have droplet access.
+- FE production deploys must ship only a released FE commit on `main`. Do not deploy arbitrary `main` commits.
 
 ## Versioning
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,10 +86,17 @@ See `src/test/test-utils.tsx` for `waitForMemberSelected`, `typeAndWait`, `TEST_
 `deploy.sh` runs checks fastest-to-slowest:
 1. Clean working tree
 2. Must be on `main`, synced with `origin/main`
-3. Tagged release check (warns if untagged)
+3. Must be the exact released FE commit tagged `family-hub-v<package.json version>`
 4. `npm run lint`
 5. `npm test -- --run`
 6. Build → rsync to server → HTTP health check
+
+## Shipping Semantics
+
+- Backend `main` may merge incrementally. FE should treat only published BE releases as stable integration contracts.
+- FE CI E2E resolves the latest published BE release from GitHub Releases and sets `BE_IMAGE_TAG` before starting the backend container.
+- Manual FE deploys still happen from a local terminal via `deploy.sh`; CI does not have droplet access.
+- FE production deploys must ship only a released FE commit on `main`. Do not deploy arbitrary `main` commits.
 
 ## Versioning
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -7,6 +7,7 @@ SERVER="root@joe-bor.me"
 REMOTE_PATH="/var/www/familyhub"
 URL="https://familyhub.joe-bor.me"
 VERSION=$(node -p "require('./package.json').version")
+RELEASE_TAG="family-hub-v$VERSION"
 
 # === PRE-DEPLOY CHECKS (ordered fastest → slowest) ===
 
@@ -25,6 +26,7 @@ fi
 
 # 3. Synced with remote?
 git fetch origin main --quiet
+git fetch origin --tags --quiet
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
 if [ "$LOCAL" != "$REMOTE" ]; then
@@ -32,14 +34,20 @@ if [ "$LOCAL" != "$REMOTE" ]; then
   exit 1
 fi
 
-# 4. Tagged release? (warning only)
-if ! git tag -l "v$VERSION" | grep -q .; then
-  echo "⚠ No git tag found for v$VERSION."
-  read -r -p "Deploy untagged version? [y/N] " response
-  if [[ ! "$response" =~ ^[Yy]$ ]]; then
-    echo "Deploy cancelled."
-    exit 0
-  fi
+# 4. Released FE commit?
+if ! git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+  echo "✗ Required release tag '$RELEASE_TAG' does not exist."
+  echo "  Merge the FE release PR before deploying."
+  exit 1
+fi
+
+TAG_COMMIT=$(git rev-list -n 1 "$RELEASE_TAG")
+if [ "$LOCAL" != "$TAG_COMMIT" ]; then
+  echo "✗ Current commit is not the released FE commit for $RELEASE_TAG."
+  echo "  Current HEAD: $LOCAL"
+  echo "  Release tag:  $TAG_COMMIT"
+  echo "  Deploy only from the released FE commit on main."
+  exit 1
 fi
 
 # 5. Lint
@@ -51,7 +59,7 @@ echo "Running tests..."
 npm test -- --run
 
 # === BUILD & DEPLOY ===
-echo "Building v$VERSION..."
+echo "Building $RELEASE_TAG..."
 npm run build
 
 echo "Deploying to $SERVER..."
@@ -63,7 +71,7 @@ sleep 2
 STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
 
 if [ "$STATUS" = "200" ]; then
-  echo "✓ Deploy successful! v$VERSION is live at $URL"
+  echo "✓ Deploy successful! $RELEASE_TAG is live at $URL"
 else
   echo "✗ Warning: Site returned HTTP $STATUS"
   exit 1


### PR DESCRIPTION
## Summary
- enforce release-based frontend deploys in `deploy.sh`
- require the exact `family-hub-v<version>` tag on the current `main` commit before shipping
- document the FE/BE shipping contract in the frontend agent docs

## Why
Frontend deploy is manual from a local terminal, but production should still ship only a released FE commit. This aligns FE deploy behavior with the existing release-based backend contract that FE CI E2E already consumes.
