### PR TITLE
fix: unblock frontend release lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/src/components/calendar/components/edit-scope-dialog.tsx
+++ b/src/components/calendar/components/edit-scope-dialog.tsx
@@ -91,5 +91,5 @@ function EditScopeDialog({
   );
 }
 
-export { EditScopeDialog };
 export type { EditScopeDialogProps };
+export { EditScopeDialog };

--- a/src/components/calendar/components/recurrence-picker.tsx
+++ b/src/components/calendar/components/recurrence-picker.tsx
@@ -324,5 +324,5 @@ function RecurrencePicker({
   );
 }
 
-export { RecurrencePicker };
 export type { RecurrencePickerProps };
+export { RecurrencePicker };

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -66,5 +66,5 @@ function DatePicker({
   );
 }
 
-export { DatePicker };
 export type { DatePickerProps };
+export { DatePicker };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -111,13 +111,13 @@ function DialogDescription({
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
   DialogClose,
-  DialogTrigger,
   DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
 };

--- a/src/components/ui/member-selector.tsx
+++ b/src/components/ui/member-selector.tsx
@@ -55,5 +55,5 @@ function MemberSelector({
   );
 }
 
-export { MemberSelector };
 export type { MemberSelectorProps };
+export { MemberSelector };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -34,4 +34,4 @@ function PopoverContent({
   );
 }
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger };

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -401,5 +401,5 @@ function TimePicker({
   );
 }
 
-export { TimePicker };
 export type { TimePickerProps };
+export { TimePicker };

--- a/src/lib/recurrence-utils.ts
+++ b/src/lib/recurrence-utils.ts
@@ -168,9 +168,9 @@ export function formatRecurrenceLabel(rrule: string, eventDate: Date): string {
 
   if (state.endDate) {
     const endDate = new Date(
-      Number.parseInt(state.endDate.slice(0, 4)),
-      Number.parseInt(state.endDate.slice(5, 7)) - 1,
-      Number.parseInt(state.endDate.slice(8, 10)),
+      Number.parseInt(state.endDate.slice(0, 4), 10),
+      Number.parseInt(state.endDate.slice(5, 7), 10) - 1,
+      Number.parseInt(state.endDate.slice(8, 10), 10),
     );
     const formatted = format(endDate, "MMM d, yyyy");
     return `${base} until ${formatted}`;

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -151,10 +151,13 @@ function renderWithUser(ui: ReactElement, options?: CustomRenderOptions) {
 
 // Re-export everything from testing-library
 export * from "@testing-library/react";
-export { userEvent };
-
 // Export custom utilities
-export { customRender as render, renderWithUser, createTestQueryClient };
+export {
+  createTestQueryClient,
+  customRender as render,
+  renderWithUser,
+  userEvent,
+};
 
 // =============================================================================
 // Store Seeding Utilities


### PR DESCRIPTION
## Summary
- fix the released frontend lint blockers so deploy can pass its release gate
- add the missing radix arguments in `recurrence-utils`
- apply Biome's import/export ordering and update the Biome schema URL to match the installed CLI

## Verification
- `npm run lint`
- `npm test -- --run`

## Why
`family-hub-v0.3.7` could not be deployed because `deploy.sh` runs lint and tests before shipping, and the released commit failed Biome checks locally.
