### PR TITLE
Add mobile bottom navigation, safe-area layout fixes, and tests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,7 +155,7 @@ export default function FamilyHub() {
 
         <div className="flex-1 flex overflow-hidden">
           <NavigationTabs />
-          <main className="flex-1 flex flex-col overflow-hidden">
+          <main className="flex-1 flex flex-col overflow-hidden pb-[calc(env(safe-area-inset-bottom)+4rem)] sm:pb-0">
             {renderModule(activeModule)}
           </main>
         </div>

--- a/src/components/calendar/components/add-event-button.tsx
+++ b/src/components/calendar/components/add-event-button.tsx
@@ -9,8 +9,7 @@ export function AddEventButton({ onClick }: AddEventButtonProps) {
   return (
     <Button
       onClick={onClick}
-      className="fixed right-8 z-40 w-14 h-14 rounded-full bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all"
-      style={{ bottom: "max(2rem, calc(env(safe-area-inset-bottom) + 1rem))" }}
+      className="fixed right-8 z-40 w-14 h-14 rounded-full bg-primary hover:bg-primary/90 shadow-lg hover:shadow-xl transition-all bottom-[calc(env(safe-area-inset-bottom)+5rem)] sm:bottom-8"
       size="icon"
       aria-label="Add event"
     >

--- a/src/components/shared/navigation-tabs.test.tsx
+++ b/src/components/shared/navigation-tabs.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "@/stores";
+import { NavigationTabs } from "./navigation-tabs";
+
+describe("NavigationTabs", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
+  });
+
+  it("renders 5 mobile destinations", () => {
+    const { container } = render(<NavigationTabs />);
+    const navs = container.querySelectorAll("nav");
+    const mobileNav = navs[1];
+
+    expect(mobileNav).toBeTruthy();
+    const buttons = within(mobileNav as HTMLElement).getAllByRole("button");
+
+    expect(buttons).toHaveLength(5);
+    expect(within(mobileNav as HTMLElement).queryByText("Home")).toBeNull();
+  });
+
+  it("changes active module when a mobile tab is pressed", () => {
+    const { container } = render(<NavigationTabs />);
+    const navs = container.querySelectorAll("nav");
+    const mobileNav = navs[1] as HTMLElement;
+
+    fireEvent.click(within(mobileNav).getByRole("button", { name: "Meals" }));
+
+    expect(useAppStore.getState().activeModule).toBe("meals");
+  });
+});

--- a/src/components/shared/navigation-tabs.tsx
+++ b/src/components/shared/navigation-tabs.tsx
@@ -24,27 +24,59 @@ export function NavigationTabs() {
   const setActiveModule = useAppStore((state) => state.setActiveModule);
 
   return (
-    <nav className="hidden sm:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
-      {tabs.map((tab) => {
-        const Icon = tab.icon;
-        const isActive = activeModule === tab.id;
+    <>
+      <nav className="hidden sm:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
+        {tabs.map((tab) => {
+          const Icon = tab.icon;
+          const isActive = activeModule === tab.id;
 
-        return (
-          <button
-            key={tab.id}
-            onClick={() => setActiveModule(tab.id)}
-            className={cn(
-              "flex flex-col items-center gap-1 px-2 py-3 rounded-xl w-16 transition-colors",
-              isActive
-                ? "bg-primary text-primary-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
-            )}
-          >
-            <Icon className="h-5 w-5" />
-            <span className="text-[10px] font-medium">{tab.label}</span>
-          </button>
-        );
-      })}
-    </nav>
+          return (
+            <button
+              type="button"
+              key={tab.id}
+              onClick={() => setActiveModule(tab.id)}
+              className={cn(
+                "flex flex-col items-center gap-1 px-2 py-3 rounded-xl w-16 transition-colors",
+                isActive
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
+              )}
+            >
+              <Icon className="h-5 w-5" />
+              <span className="text-[10px] font-medium">{tab.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+
+      <nav className="sm:hidden fixed inset-x-0 bottom-0 z-30 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80 pb-[env(safe-area-inset-bottom)]">
+        <div className="grid grid-cols-5">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeModule === tab.id;
+
+            return (
+              <button
+                type="button"
+                key={tab.id}
+                onClick={() => setActiveModule(tab.id)}
+                className={cn(
+                  "flex min-h-16 flex-col items-center justify-center gap-1 px-1 py-2 transition-colors",
+                  isActive
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <Icon className="h-5 w-5" />
+                <span className="text-[10px] font-medium leading-none">
+                  {tab.label}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
### Motivation

- Ensure the UI works cleanly on mobile devices with safe-area insets by providing a dedicated bottom navigation and spacing so content and floating controls don't overlap system indicators. 
- Provide an accessible, responsive navigation experience that mirrors the desktop tabs on small screens. 
- Add a unit test to prevent regressions in the navigation behavior.

### Description

- Implemented a fixed mobile bottom navigation in `NavigationTabs` that mirrors the desktop tabs and uses `env(safe-area-inset-bottom)` for safe-area support, including `aria-current` for the active item and `type="button"` on tab buttons. 
- Kept the existing desktop sidebar and returned a fragment containing both desktop and mobile navs in `src/components/shared/navigation-tabs.tsx`. 
- Adjusted layout padding in `src/App.tsx` by adding `pb-[calc(env(safe-area-inset-bottom)+4rem)] sm:pb-0` to the main area so content is not obscured by the mobile nav. 
- Updated the floating add-event button in `src/components/calendar/components/add-event-button.tsx` to use Tailwind classes for bottom positioning with safe-area consideration and responsive fallback, removing the inline `style`. 
- Added `src/components/shared/navigation-tabs.test.tsx` with `vitest`/`@testing-library/react` tests that assert the mobile nav renders five destinations and that clicking a mobile tab updates the `useAppStore` active module.

### Testing

- Ran the new unit tests with `vitest` and the added tests in `src/components/shared/navigation-tabs.test.tsx` passed. 
- Executed the existing front-end test suite with `vitest` and all tests completed successfully (including the newly added navigation tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2ab0e82c832e9a889499349d7f76)