### PR TITLE
feat: add mobile home dashboard

### DIFF
--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -1,7 +1,8 @@
 import type { APIRequestContext, Page } from "@playwright/test";
+import type { CreateEventRequest } from "../../src/lib/types/calendar";
 import type { FamilyColor } from "../../src/lib/types/family";
 
-const API_BASE = "http://localhost:8080/api";
+const API_BASE = "http://127.0.0.1:8080/api";
 
 interface RegisterOptions {
   familyName: string;
@@ -69,4 +70,25 @@ export async function seedBrowserAuth(
       }),
     );
   }, registration);
+}
+
+/**
+ * Create a calendar event through the real backend API using an authenticated token.
+ */
+export async function createCalendarEvent(
+  request: APIRequestContext,
+  token: string,
+  event: CreateEventRequest,
+): Promise<void> {
+  const response = await request.post(`${API_BASE}/calendar/events`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data: event,
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Create event failed (${response.status()}): ${body}`);
+  }
 }

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from "@playwright/test";
+import { format } from "date-fns";
 import type { FamilyColor, FamilyMember } from "../../src/lib/types/family";
 
 /**
@@ -236,16 +237,17 @@ export async function createEvent(
       const endDateBtn = datePickers.nth(1);
       await endDateBtn.click();
       // Wait for calendar popover to appear, then click the target day.
-      // react-day-picker v9 renders day buttons inside a table.
-      const dayNum = options.recurrence.endDate.getDate();
+      // Match the full accessible name so duplicate day numbers across months
+      // do not trip strict-mode lookups.
       const popover = page
         .locator("[data-radix-popper-content-wrapper]")
         .last();
       await expect(popover).toBeVisible();
-      await popover
-        .locator("table button:not([disabled])")
-        .filter({ hasText: new RegExp(`^${dayNum}$`) })
-        .click();
+      const endDateLabel = format(
+        options.recurrence.endDate,
+        "EEEE, MMMM do, yyyy",
+      );
+      await popover.getByRole("button", { name: endDateLabel }).click();
     }
   }
 

--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -120,19 +120,22 @@ export async function waitForDialogReady(page: Page): Promise<Locator> {
 
 /**
  * Enhanced calendar ready check that replaces networkidle with more reliable indicators.
- * Handles mobile home dashboard navigation and waits for multiple UI indicators.
+ * Handles mobile home dashboard navigation via the existing shell state and
+ * waits for multiple UI indicators.
  */
 export async function waitForCalendarReady(page: Page): Promise<void> {
-  // Check if we're on the mobile home dashboard
-  const homeHeading = page.getByRole("heading", { name: "Home", level: 1 });
-  const isOnHomeDashboard = await homeHeading.isVisible().catch(() => false);
+  const primaryNav = page.getByRole("navigation", { name: /primary/i });
+  const hasMobileNav = await primaryNav.isVisible().catch(() => false);
 
-  if (isOnHomeDashboard) {
-    // Navigate to calendar from mobile home dashboard
-    await page
-      .locator("main")
-      .getByRole("button", { name: "Calendar" })
-      .click();
+  if (hasMobileNav) {
+    const homeTab = primaryNav.getByRole("button", { name: "Home" });
+    const calendarTab = primaryNav.getByRole("button", { name: "Calendar" });
+    const homeIsActive =
+      (await homeTab.getAttribute("aria-current").catch(() => null)) === "page";
+
+    if (homeIsActive) {
+      await calendarTab.click();
+    }
   }
 
   // Wait for primary calendar indicator (Add event FAB)

--- a/e2e/mobile-bottom-nav.spec.ts
+++ b/e2e/mobile-bottom-nav.spec.ts
@@ -51,8 +51,9 @@ test.describe("Mobile Bottom Navigation", () => {
     await expect(page.getByRole("button", { name: "Add event" })).toBeVisible();
 
     await nav.getByRole("button", { name: "Home" }).click();
+    await expect(page.getByTestId("dashboard-header")).toBeVisible();
     await expect(
-      page.getByRole("heading", { name: "Home", level: 1 }),
+      page.getByRole("button", { name: "Focus on Alice's events" }),
     ).toBeVisible();
 
     await nav.getByRole("button", { name: "Lists" }).click();

--- a/e2e/mobile-home-dashboard.spec.ts
+++ b/e2e/mobile-home-dashboard.spec.ts
@@ -1,0 +1,170 @@
+import { expect, test } from "@playwright/test";
+import {
+  createCalendarEvent,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
+import {
+  clearStorage,
+  getTodayDateString,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+function getRelativeDateString(daysFromToday: number): string {
+  const date = new Date();
+  date.setHours(0, 0, 0, 0);
+  date.setDate(date.getDate() + daysFromToday);
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+test.describe("Mobile Home Dashboard", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("replaces the launcher grid and filters hero, today, and coming up by focused member", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "Dashboard Family",
+      members: [
+        { name: "Alice", color: "coral" },
+        { name: "Bob", color: "teal" },
+      ],
+    });
+    const [alice, bob] = registration.family.members;
+    const today = getTodayDateString();
+    const tomorrow = getRelativeDateString(1);
+
+    await createCalendarEvent(request, registration.token, {
+      title: "Alice breakfast",
+      startTime: "12:00 AM",
+      endTime: "11:59 PM",
+      date: today,
+      memberId: alice.id,
+      isAllDay: true,
+    });
+    await createCalendarEvent(request, registration.token, {
+      title: "Alice pickup",
+      startTime: "12:00 AM",
+      endTime: "11:59 PM",
+      date: today,
+      memberId: alice.id,
+      isAllDay: true,
+    });
+    await createCalendarEvent(request, registration.token, {
+      title: "Bob practice",
+      startTime: "12:00 AM",
+      endTime: "11:59 PM",
+      date: today,
+      memberId: bob.id,
+      isAllDay: true,
+    });
+    await createCalendarEvent(request, registration.token, {
+      title: "Bob pickup",
+      startTime: "12:00 AM",
+      endTime: "11:59 PM",
+      date: today,
+      memberId: bob.id,
+      isAllDay: true,
+    });
+    await createCalendarEvent(request, registration.token, {
+      title: "Bob swim",
+      startTime: "9:00 AM",
+      endTime: "10:00 AM",
+      date: tomorrow,
+      memberId: bob.id,
+    });
+
+    await seedBrowserAuth(page, registration);
+
+    await page.reload();
+    await waitForHydration(page);
+
+    await expect(page.getByTestId("dashboard-header")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Focus on Alice's events" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Focus on Bob's events" }),
+    ).toBeVisible();
+    await expect(page.getByText("What would you like to do?")).toBeHidden();
+    await expect(
+      page.getByRole("button", { name: /connect google calendar/i }),
+    ).not.toBeVisible();
+
+    await safeClick(
+      page.getByRole("button", { name: "Focus on Bob's events" }),
+    );
+
+    await expect(
+      page.getByRole("button", {
+        name: /today: bob (practice|pickup) details/i,
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Bob pickup")).toBeVisible();
+    await expect(page.getByText("Bob swim")).toBeVisible();
+    await expect(page.getByText("Alice breakfast")).not.toBeVisible();
+    await expect(page.getByText("Alice pickup")).not.toBeVisible();
+  });
+
+  test("reuses the existing add-event flow from Home with focused-member defaults", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "Home Add Family",
+      members: [
+        { name: "Alice", color: "coral" },
+        { name: "Bob", color: "teal" },
+      ],
+    });
+
+    await seedBrowserAuth(page, registration);
+
+    await page.reload();
+    await waitForHydration(page);
+
+    const nav = page.getByRole("navigation", { name: /primary/i });
+    await expect(nav).toBeVisible();
+
+    const bobFocusButton = page.getByRole("button", {
+      name: "Focus on Bob's events",
+    });
+    await safeClick(bobFocusButton);
+    await expect(bobFocusButton).toHaveAttribute("aria-pressed", "true");
+
+    await safeClick(page.getByRole("button", { name: "Add event" }));
+
+    const dialog = page.getByRole("dialog", { name: "Add Event" });
+    await expect(dialog).toBeVisible();
+
+    await page.getByLabel("Event Name").fill("Bob homework");
+    await page.getByRole("switch").click();
+    await dialog.getByRole("button", { name: /add event/i }).click();
+    await expect(dialog).toBeHidden();
+
+    await expect(
+      page.getByRole("button", {
+        name: /today: bob homework details/i,
+      }),
+    ).toBeVisible();
+
+    await nav.getByRole("button", { name: "Calendar" }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByRole("button", { name: "Add event" })).toBeVisible();
+
+    await nav.getByRole("button", { name: "Home" }).click();
+    await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByText("Bob homework")).toBeVisible();
+  });
+});

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -17,7 +17,10 @@ test.describe("First-Time User Onboarding", () => {
     await page.getByRole("button", { name: "Create an account" }).click();
   });
 
-  test("completes full onboarding flow and persists data", async ({ page }) => {
+  test("completes full onboarding flow and persists data", async ({
+    page,
+    isMobile,
+  }) => {
     // Step 1: Welcome screen
     await expect(
       page.getByRole("heading", { name: "Welcome to FamilyHub" }),
@@ -107,14 +110,22 @@ test.describe("First-Time User Onboarding", () => {
       page.getByRole("heading", { name: /create your login/i }),
     ).toBeHidden({ timeout: 10000 });
 
-    // Verify the app lands on mobile Home. Scope to the dashboard header because
-    // the family name now appears in both the shell header and dashboard greeting.
-    // Check BEFORE navigating to calendar (mobile hides AppHeader in calendar view).
-    const dashboardHeader = page.getByTestId("dashboard-header");
-    await expect(dashboardHeader).toBeVisible({
-      timeout: 10000,
-    });
-    await expect(dashboardHeader).toContainText("The Johnsons");
+    if (isMobile) {
+      // Mobile lands on Home first, so verify the dashboard header before
+      // navigating away to Calendar.
+      const dashboardHeader = page.getByTestId("dashboard-header");
+      await expect(dashboardHeader).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(dashboardHeader).toContainText("The Johnsons");
+    } else {
+      // Desktop preserves the existing contract: null state redirects to Calendar.
+      await expect(
+        page.getByRole("heading", { name: "The Johnsons", level: 1 }),
+      ).toBeVisible({
+        timeout: 10000,
+      });
+    }
 
     // Now navigate to calendar view
     await waitForCalendarReady(page);
@@ -123,12 +134,19 @@ test.describe("First-Time User Onboarding", () => {
     await page.reload();
     await waitForHydration(page);
 
-    // After reload, scope to the dashboard header again instead of assuming the
-    // family name is unique on the page in the mobile Home shell.
-    await expect(dashboardHeader).toBeVisible({
-      timeout: 10000,
-    });
-    await expect(dashboardHeader).toContainText("The Johnsons");
+    if (isMobile) {
+      const dashboardHeader = page.getByTestId("dashboard-header");
+      await expect(dashboardHeader).toBeVisible({
+        timeout: 10000,
+      });
+      await expect(dashboardHeader).toContainText("The Johnsons");
+    } else {
+      await expect(
+        page.getByRole("heading", { name: "The Johnsons", level: 1 }),
+      ).toBeVisible({
+        timeout: 10000,
+      });
+    }
 
     // Navigate to calendar
     await waitForCalendarReady(page);

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -107,11 +107,14 @@ test.describe("First-Time User Onboarding", () => {
       page.getByRole("heading", { name: /create your login/i }),
     ).toBeHidden({ timeout: 10000 });
 
-    // Verify main app is showing — family name is visible on home dashboard/header
-    // Check BEFORE navigating to calendar (mobile hides AppHeader in calendar view)
-    await expect(page.getByText("The Johnsons")).toBeVisible({
+    // Verify the app lands on mobile Home. Scope to the dashboard header because
+    // the family name now appears in both the shell header and dashboard greeting.
+    // Check BEFORE navigating to calendar (mobile hides AppHeader in calendar view).
+    const dashboardHeader = page.getByTestId("dashboard-header");
+    await expect(dashboardHeader).toBeVisible({
       timeout: 10000,
     });
+    await expect(dashboardHeader).toContainText("The Johnsons");
 
     // Now navigate to calendar view
     await waitForCalendarReady(page);
@@ -120,10 +123,12 @@ test.describe("First-Time User Onboarding", () => {
     await page.reload();
     await waitForHydration(page);
 
-    // Family name should be visible on initial load (home dashboard/header)
-    await expect(page.getByText("The Johnsons")).toBeVisible({
+    // After reload, scope to the dashboard header again instead of assuming the
+    // family name is unique on the page in the mobile Home shell.
+    await expect(dashboardHeader).toBeVisible({
       timeout: 10000,
     });
+    await expect(dashboardHeader).toContainText("The Johnsons");
 
     // Navigate to calendar
     await waitForCalendarReady(page);

--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -64,6 +64,18 @@ describe("App shell", () => {
     expect(screen.getByRole("button", { name: /^menu$/i })).toBeInTheDocument();
   });
 
+  it("does not render the desktop rail at the 768px mobile boundary", async () => {
+    setViewportWidth(768);
+    useAppStore.setState({ activeModule: null, isSidebarOpen: false });
+
+    render(<FamilyHub />);
+
+    expect(
+      await screen.findByRole("navigation", { name: /primary/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/^calendar$/i)).toHaveLength(1);
+  });
+
   it("suppresses AppHeader on mobile calendar while keeping bottom nav", async () => {
     setViewportWidth(768);
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });

--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -8,13 +8,27 @@ import {
   waitFor,
 } from "./test/test-utils";
 
-function setMobile(isMobile: boolean) {
+function setViewportWidth(width: number) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
-    value: isMobile ? 390 : 1024,
+    value: width,
   });
+
   vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
-    matches: isMobile && query.includes("max-width: 639px"),
+    matches: (() => {
+      const maxWidth = Number.parseInt(
+        query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+      const minWidth = Number.parseInt(
+        query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+
+      const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+      const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+      return matchesMax && matchesMin;
+    })(),
     media: query,
     onchange: null,
     addListener: vi.fn(),
@@ -35,7 +49,7 @@ describe("App shell", () => {
   });
 
   it("renders mobile bottom nav with Home active on mobile home", async () => {
-    setMobile(true);
+    setViewportWidth(768);
     useAppStore.setState({ activeModule: null, isSidebarOpen: false });
 
     render(<FamilyHub />);
@@ -51,7 +65,7 @@ describe("App shell", () => {
   });
 
   it("suppresses AppHeader on mobile calendar while keeping bottom nav", async () => {
-    setMobile(true);
+    setViewportWidth(768);
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
 
     render(<FamilyHub />);
@@ -67,7 +81,7 @@ describe("App shell", () => {
   });
 
   it("does not render bottom nav on desktop", async () => {
-    setMobile(false);
+    setViewportWidth(769);
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
 
     render(<FamilyHub />);
@@ -81,7 +95,7 @@ describe("App shell", () => {
   });
 
   it("does not render bottom nav on login screen", async () => {
-    setMobile(true);
+    setViewportWidth(768);
     seedAuthStore({ isAuthenticated: false });
 
     render(<FamilyHub />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,7 +159,7 @@ export default function FamilyHub() {
         {!(isMobile && activeModule === "calendar") && <AppHeader />}
 
         <div className="flex-1 flex min-h-0 overflow-hidden">
-          <NavigationTabs />
+          {!isMobile && <NavigationTabs />}
           <main className="flex-1 min-h-0 flex flex-col overflow-hidden">
             {renderModule(activeModule)}
           </main>

--- a/src/components/calendar/components/add-event-button.test.tsx
+++ b/src/components/calendar/components/add-event-button.test.tsx
@@ -1,13 +1,27 @@
 import { render, screen } from "@/test/test-utils";
 import { AddEventButton } from "./add-event-button";
 
-function setMobile(isMobile: boolean) {
+function setViewportWidth(width: number) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
-    value: isMobile ? 390 : 1024,
+    value: width,
   });
+
   vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
-    matches: isMobile && query.includes("max-width: 639px"),
+    matches: (() => {
+      const maxWidth = Number.parseInt(
+        query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+      const minWidth = Number.parseInt(
+        query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+
+      const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+      const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+      return matchesMax && matchesMin;
+    })(),
     media: query,
     onchange: null,
     addListener: vi.fn(),
@@ -19,8 +33,8 @@ function setMobile(isMobile: boolean) {
 }
 
 describe("AddEventButton", () => {
-  it("uses mobile bottom offset that clears bottom nav", () => {
-    setMobile(true);
+  it("uses the mobile bottom offset at 768px so the FAB clears the bottom nav", () => {
+    setViewportWidth(768);
     render(<AddEventButton onClick={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: /add event/i })).toHaveStyle({
@@ -29,7 +43,7 @@ describe("AddEventButton", () => {
   });
 
   it("keeps existing desktop bottom offset", () => {
-    setMobile(false);
+    setViewportWidth(769);
     render(<AddEventButton onClick={vi.fn()} />);
 
     expect(screen.getByRole("button", { name: /add event/i })).toHaveStyle({

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -18,6 +18,7 @@ interface EventFormModalProps {
   onClose: () => void;
   onSubmit: (data: EventFormData) => void;
   isPending?: boolean;
+  defaultValues?: Partial<EventFormData>;
   /** For edit mode: the event to pre-populate the form with */
   event?: CalendarEvent;
   showRecurrencePicker?: boolean;
@@ -58,6 +59,7 @@ function EventFormModal({
   onClose,
   onSubmit,
   isPending = false,
+  defaultValues,
   event,
   showRecurrencePicker,
 }: EventFormModalProps) {
@@ -65,14 +67,14 @@ function EventFormModal({
   const title = mode === "add" ? "Add Event" : "Edit Event";
 
   // For edit mode, convert the event to form data
-  const defaultValues = event ? eventToFormData(event) : undefined;
+  const formDefaultValues = event ? eventToFormData(event) : defaultValues;
 
   if (isMobile) {
     return (
       <MobileEventSheet isOpen={isOpen} onClose={onClose} title={title}>
         <EventForm
           mode={mode}
-          defaultValues={defaultValues}
+          defaultValues={formDefaultValues}
           onSubmit={onSubmit}
           onCancel={onClose}
           isPending={isPending}
@@ -91,7 +93,7 @@ function EventFormModal({
         </DialogHeader>
         <EventForm
           mode={mode}
-          defaultValues={defaultValues}
+          defaultValues={formDefaultValues}
           onSubmit={onSubmit}
           onCancel={onClose}
           isPending={isPending}

--- a/src/components/calendar/views/schedule-calendar.test.tsx
+++ b/src/components/calendar/views/schedule-calendar.test.tsx
@@ -17,12 +17,27 @@ const expectedBottomPadding =
   "max(8.5rem, calc(env(safe-area-inset-bottom) + 8.5rem))";
 
 function setMobile(isMobile: boolean) {
+  const width = isMobile ? 390 : 1024;
+
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
-    value: isMobile ? 390 : 1024,
+    value: width,
   });
   vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
-    matches: isMobile && query.includes("max-width: 639px"),
+    matches: (() => {
+      const maxWidth = Number.parseInt(
+        query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+      const minWidth = Number.parseInt(
+        query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+
+      const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+      const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+      return matchesMax && matchesMin;
+    })(),
     media: query,
     onchange: null,
     addListener: vi.fn(),

--- a/src/components/home/components/coming-up.test.tsx
+++ b/src/components/home/components/coming-up.test.tsx
@@ -1,0 +1,89 @@
+import type { CalendarEvent } from "@/lib/types";
+import { testMembers } from "@/test/fixtures";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { ComingUp } from "./coming-up";
+
+function createEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "Dentist",
+    startTime: "9:00 AM",
+    endTime: "10:00 AM",
+    date: new Date(2026, 3, 26),
+    memberId: testMembers[0].id,
+    isAllDay: false,
+    source: "NATIVE",
+    ...overrides,
+  };
+}
+
+describe("ComingUp", () => {
+  const currentDate = new Date(2026, 3, 25, 12, 0, 0, 0);
+
+  it("returns nothing when there are no upcoming events", () => {
+    const { container } = renderWithUser(
+      <ComingUp
+        currentDate={currentDate}
+        events={[]}
+        members={testMembers}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders at most three upcoming rows and labels tomorrow distinctly", () => {
+    renderWithUser(
+      <ComingUp
+        currentDate={currentDate}
+        events={[
+          createEvent({ id: "tomorrow", date: new Date(2026, 3, 26) }),
+          createEvent({
+            id: "sunday",
+            title: "Brunch",
+            date: new Date(2026, 3, 27),
+          }),
+          createEvent({
+            id: "monday",
+            title: "Class",
+            date: new Date(2026, 3, 27),
+            startTime: "2:00 PM",
+            endTime: "3:00 PM",
+          }),
+          createEvent({
+            id: "hidden-fourth",
+            title: "Should be capped",
+            date: new Date(2026, 3, 27),
+            startTime: "4:00 PM",
+            endTime: "5:00 PM",
+          }),
+        ]}
+        members={testMembers}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Coming up")).toBeInTheDocument();
+    expect(screen.getByText("Tomorrow")).toBeInTheDocument();
+    expect(screen.getAllByText("Mon")).toHaveLength(2);
+    expect(screen.queryByText("Should be capped")).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect when a row is tapped", async () => {
+    const event = createEvent();
+    const onSelect = vi.fn();
+    const { user } = renderWithUser(
+      <ComingUp
+        currentDate={currentDate}
+        events={[event]}
+        members={testMembers}
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /dentist/i }));
+
+    expect(onSelect).toHaveBeenCalledWith(event);
+  });
+});

--- a/src/components/home/components/coming-up.tsx
+++ b/src/components/home/components/coming-up.tsx
@@ -1,0 +1,83 @@
+import { format } from "date-fns";
+import { memo, useMemo } from "react";
+import { formatLocalDate } from "@/lib/time-utils";
+import type { CalendarEvent, FamilyMember } from "@/lib/types";
+import { colorMap, getFamilyMember } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { formatEventTimeForDisplay, getEventDateTime } from "../lib/event-time";
+
+function sortByStartDateTime(
+  left: CalendarEvent,
+  right: CalendarEvent,
+): number {
+  return (
+    getEventDateTime(left, "start").getTime() -
+    getEventDateTime(right, "start").getTime()
+  );
+}
+
+function getDateLabel(eventDate: Date, currentDate: Date): string {
+  const tomorrow = new Date(currentDate);
+  tomorrow.setDate(currentDate.getDate() + 1);
+
+  return formatLocalDate(eventDate) === formatLocalDate(tomorrow)
+    ? "Tomorrow"
+    : format(eventDate, "EEE");
+}
+
+export const ComingUp = memo(function ComingUp({
+  currentDate = new Date(),
+  events,
+  members,
+  onSelect,
+}: {
+  currentDate?: Date;
+  events: CalendarEvent[];
+  members: FamilyMember[];
+  onSelect: (event: CalendarEvent) => void;
+}) {
+  const visibleEvents = useMemo(
+    () => [...events].sort(sortByStartDateTime).slice(0, 3),
+    [events],
+  );
+
+  if (visibleEvents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 pt-6 pb-4">
+      <div className="mb-3 border-t border-border/60 pt-4">
+        <h3 className="text-sm text-foreground/60">Coming up</h3>
+      </div>
+
+      <div className="space-y-3">
+        {visibleEvents.map((event) => {
+          const member = getFamilyMember(members, event.memberId);
+          const colors = member ? colorMap[member.color] : colorMap.coral;
+
+          return (
+            <button
+              key={event.id ?? `${event.title}-${formatLocalDate(event.date)}`}
+              type="button"
+              onClick={() => onSelect(event)}
+              className="flex min-h-11 w-full items-center gap-3 rounded-2xl px-1 py-2 text-left text-sm text-foreground/70 transition-transform duration-[150ms] ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98] motion-reduce:transition-none"
+            >
+              <span className="w-18 shrink-0 text-foreground/60">
+                {getDateLabel(event.date, currentDate)}
+              </span>
+              <span className="shrink-0">
+                {formatEventTimeForDisplay(event.startTime)}
+              </span>
+              <span className="min-w-0 flex-1 truncate">{event.title}</span>
+              <span
+                aria-hidden="true"
+                className={cn("h-2.5 w-2.5 shrink-0 rounded-full", colors.bg)}
+              />
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/src/components/home/components/dashboard-header.test.tsx
+++ b/src/components/home/components/dashboard-header.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@/test/test-utils";
+import { DashboardHeader } from "./dashboard-header";
+
+describe("DashboardHeader", () => {
+  it.each([
+    [new Date(2026, 3, 25, 9, 0, 0, 0), "Good morning, Test Family"],
+    [new Date(2026, 3, 25, 14, 0, 0, 0), "Good afternoon, Test Family"],
+    [new Date(2026, 3, 25, 19, 0, 0, 0), "Good evening, Test Family"],
+  ])("renders the right greeting for %s", (now, greeting) => {
+    render(<DashboardHeader familyName="Test Family" now={now} />);
+
+    expect(screen.getByText(greeting)).toBeInTheDocument();
+    expect(screen.getByText("Saturday, Apr 25")).toBeInTheDocument();
+  });
+
+  it("allows the header to wrap on narrow layouts", () => {
+    render(
+      <DashboardHeader
+        familyName="Test Family"
+        now={new Date(2026, 3, 25, 9)}
+      />,
+    );
+
+    expect(screen.getByTestId("dashboard-header")).toHaveClass("flex-wrap");
+  });
+});

--- a/src/components/home/components/dashboard-header.tsx
+++ b/src/components/home/components/dashboard-header.tsx
@@ -1,0 +1,29 @@
+import { format } from "date-fns";
+
+function getGreeting(now: Date): string {
+  const hour = now.getHours();
+
+  if (hour < 12) return "Good morning";
+  if (hour < 17) return "Good afternoon";
+  return "Good evening";
+}
+
+export function DashboardHeader({
+  familyName,
+  now,
+}: {
+  familyName: string;
+  now: Date;
+}) {
+  return (
+    <div
+      data-testid="dashboard-header"
+      className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1 px-4 pt-4"
+    >
+      <h1 className="text-sm font-medium text-foreground/70">
+        {getGreeting(now)}, {familyName}
+      </h1>
+      <p className="text-sm text-foreground/80">{format(now, "EEEE, MMM d")}</p>
+    </div>
+  );
+}

--- a/src/components/home/components/hero-card.test.tsx
+++ b/src/components/home/components/hero-card.test.tsx
@@ -1,0 +1,121 @@
+import type { CalendarEvent } from "@/lib/types";
+import { testMember } from "@/test/fixtures";
+import { render, renderWithUser, screen } from "@/test/test-utils";
+import type { HeroState } from "../lib/hero-state";
+import { HeroCard } from "./hero-card";
+
+function createEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "Soccer practice",
+    startTime: "9:00 AM",
+    endTime: "9:30 AM",
+    date: new Date(2026, 3, 25),
+    memberId: testMember.id,
+    isAllDay: false,
+    location: "Field 2",
+    source: "NATIVE",
+    ...overrides,
+  };
+}
+
+describe("HeroCard", () => {
+  const now = new Date(2026, 3, 25, 9, 8, 0, 0);
+
+  it("renders the RIGHT_NOW state with an accent and live dot", () => {
+    const event = createEvent();
+
+    render(
+      <HeroCard
+        state={{ kind: "RIGHT_NOW", event }}
+        member={testMember}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText("Now · ends in 22 min")).toBeInTheDocument();
+    expect(screen.getByText("Soccer practice")).toBeInTheDocument();
+    expect(screen.getByText("Field 2")).toBeInTheDocument();
+    expect(screen.getByTestId("hero-accent")).toBeInTheDocument();
+    expect(screen.getByTestId("hero-live-dot")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Right now: Soccer practice, ends in 22 min"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the UP_NEXT state", () => {
+    const event = createEvent({
+      startTime: "9:46 AM",
+      endTime: "10:30 AM",
+    });
+
+    render(
+      <HeroCard
+        state={{ kind: "UP_NEXT", event }}
+        member={testMember}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText("Up next · in 38 min")).toBeInTheDocument();
+  });
+
+  it("renders the ALL_DAY_ONLY state", () => {
+    const event = createEvent({
+      isAllDay: true,
+      startTime: "00:00",
+      endTime: "23:59",
+      title: "Family trip",
+    });
+
+    render(
+      <HeroCard
+        state={{ kind: "ALL_DAY_ONLY", event }}
+        member={testMember}
+        now={now}
+      />,
+    );
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+    expect(screen.getByText("Family trip")).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      { kind: "REST_OF_DAY_CLEAR" } as HeroState,
+      "All clear for the rest of today",
+    ],
+    [{ kind: "ALL_CLEAR_TODAY" } as HeroState, "Nothing on the calendar today"],
+  ])("renders the calm empty state %s", (state, copy) => {
+    render(<HeroCard state={state} member={testMember} now={now} />);
+
+    expect(screen.getByText(copy)).toBeInTheDocument();
+    expect(screen.queryByTestId("hero-accent")).not.toBeInTheDocument();
+  });
+
+  it("only fires onTap for event-backed states", async () => {
+    const onTap = vi.fn();
+    const { user, rerender } = renderWithUser(
+      <HeroCard
+        state={{ kind: "RIGHT_NOW", event: createEvent() }}
+        member={testMember}
+        now={now}
+        onTap={onTap}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /right now/i }));
+
+    rerender(
+      <HeroCard
+        state={{ kind: "ALL_CLEAR_TODAY" }}
+        member={testMember}
+        now={now}
+        onTap={onTap}
+      />,
+    );
+    await user.click(screen.getByLabelText("All clear today"));
+
+    expect(onTap).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/home/components/hero-card.tsx
+++ b/src/components/home/components/hero-card.tsx
@@ -1,0 +1,137 @@
+import { Sparkles } from "lucide-react";
+import type { FamilyMember } from "@/lib/types";
+import { colorMap } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { getEventDateTime } from "../lib/event-time";
+import type { HeroState } from "../lib/hero-state";
+import { formatRelativeStart, formatRemainingEnd } from "../lib/relative-time";
+
+function isEventState(
+  state: HeroState,
+): state is Extract<HeroState, { event: unknown }> {
+  return "event" in state;
+}
+
+function getSectionLabel(state: HeroState, now: Date): string {
+  switch (state.kind) {
+    case "RIGHT_NOW":
+      return `Right now: ${state.event.title}, ${formatRemainingEnd(getEventDateTime(state.event, "end"), now)}`;
+    case "UP_NEXT":
+      return `Up next: ${state.event.title}, ${formatRelativeStart(getEventDateTime(state.event, "start"), now)}`;
+    case "ALL_DAY_ONLY":
+      return `Today: ${state.event.title}`;
+    case "REST_OF_DAY_CLEAR":
+      return "Rest of day clear";
+    case "ALL_CLEAR_TODAY":
+      return "All clear today";
+  }
+}
+
+function getMetaLine(state: HeroState, now: Date): string | null {
+  switch (state.kind) {
+    case "RIGHT_NOW":
+      return `Now · ${formatRemainingEnd(getEventDateTime(state.event, "end"), now)}`;
+    case "UP_NEXT":
+      return `Up next · ${formatRelativeStart(getEventDateTime(state.event, "start"), now)}`;
+    case "ALL_DAY_ONLY":
+      return "Today";
+    default:
+      return null;
+  }
+}
+
+function getTitle(state: HeroState): string {
+  switch (state.kind) {
+    case "RIGHT_NOW":
+    case "UP_NEXT":
+    case "ALL_DAY_ONLY":
+      return state.event.title;
+    case "REST_OF_DAY_CLEAR":
+      return "All clear for the rest of today";
+    case "ALL_CLEAR_TODAY":
+      return "Nothing on the calendar today";
+  }
+}
+
+export function HeroCard({
+  state,
+  member,
+  now,
+  onTap,
+}: {
+  state: HeroState;
+  member?: FamilyMember;
+  now: Date;
+  onTap?: () => void;
+}) {
+  const colors = member ? colorMap[member.color] : null;
+  const sectionLabel = getSectionLabel(state, now);
+  const metaLine = getMetaLine(state, now);
+  const title = getTitle(state);
+  const subtitle =
+    isEventState(state) && (state.event.location || state.event.description)
+      ? state.event.location || state.event.description
+      : null;
+  const content = (
+    <div className="relative overflow-hidden rounded-[1.75rem] border border-border/60 bg-card px-6 py-7 shadow-md motion-reduce:transition-none">
+      {isEventState(state) && colors && (
+        <span
+          data-testid="hero-accent"
+          className="absolute inset-y-5 left-0 w-1 rounded-r-full"
+          style={{ backgroundColor: colors.hex }}
+        />
+      )}
+
+      <div className="pl-2">
+        {metaLine && (
+          <p className="mb-2 flex items-center gap-2 text-sm text-foreground/70">
+            {state.kind === "RIGHT_NOW" && colors && (
+              <span
+                data-testid="hero-live-dot"
+                className="h-2.5 w-2.5 rounded-full bg-current motion-safe:animate-home-breathing-pulse motion-reduce:animate-none"
+                style={{ color: colors.hex }}
+              />
+            )}
+            <span>{metaLine}</span>
+          </p>
+        )}
+
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h2 className="text-3xl font-semibold leading-tight text-foreground">
+              {title}
+            </h2>
+            {subtitle && (
+              <p className="mt-2 text-sm text-foreground/60">{subtitle}</p>
+            )}
+          </div>
+
+          {!isEventState(state) && (
+            <Sparkles
+              className={cn(
+                "mt-1 h-6 w-6 shrink-0 text-foreground/35 motion-safe:animate-home-breathing-fade motion-reduce:animate-none",
+              )}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <section aria-label={sectionLabel} className="px-4 pt-4">
+      {isEventState(state) && onTap ? (
+        <button
+          type="button"
+          onClick={onTap}
+          aria-label={`${sectionLabel} details`}
+          className="block w-full text-left"
+        >
+          {content}
+        </button>
+      ) : (
+        content
+      )}
+    </section>
+  );
+}

--- a/src/components/home/components/member-chip-row.test.tsx
+++ b/src/components/home/components/member-chip-row.test.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { testMembers } from "@/test/fixtures";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { MemberChipRow } from "./member-chip-row";
+
+describe("MemberChipRow", () => {
+  it("toggles single-member focus", async () => {
+    const onFocusChange = vi.fn();
+    function ControlledRow() {
+      const [focusedId, setFocusedId] = useState<string | null>(null);
+
+      return (
+        <MemberChipRow
+          members={testMembers}
+          focusedId={focusedId}
+          onFocusChange={(id) => {
+            onFocusChange(id);
+            setFocusedId(id);
+          }}
+        />
+      );
+    }
+
+    const { user } = renderWithUser(<ControlledRow />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Focus on John's events" }),
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Focus on John's events" }),
+    );
+
+    expect(onFocusChange).toHaveBeenNthCalledWith(1, testMembers[0].id);
+    expect(onFocusChange).toHaveBeenNthCalledWith(2, null);
+  });
+
+  it("marks the selected chip and dims the others", () => {
+    renderWithUser(
+      <MemberChipRow
+        members={testMembers}
+        focusedId={testMembers[1].id}
+        onFocusChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Focus on Jane's events" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      screen.getByRole("button", { name: "Focus on John's events" }),
+    ).toHaveClass("opacity-60");
+  });
+});

--- a/src/components/home/components/member-chip-row.tsx
+++ b/src/components/home/components/member-chip-row.tsx
@@ -1,0 +1,57 @@
+import { colorMap, type FamilyMember } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+function withOpacity(hex: string, alphaHex: string): string {
+  return `${hex}${alphaHex}`;
+}
+
+export function MemberChipRow({
+  members,
+  focusedId,
+  onFocusChange,
+}: {
+  members: FamilyMember[];
+  focusedId: string | null;
+  onFocusChange: (id: string | null) => void;
+}) {
+  return (
+    <div className="overflow-x-auto px-4 pt-3 scrollbar-hide">
+      <div className="flex min-w-max gap-2 pb-1">
+        {members.map((member) => {
+          const colors = colorMap[member.color];
+          const isFocused = focusedId === member.id;
+          const isDimmed = focusedId !== null && !isFocused;
+
+          return (
+            <button
+              key={member.id}
+              type="button"
+              aria-label={`Focus on ${member.name}'s events`}
+              aria-pressed={isFocused}
+              onClick={() => onFocusChange(isFocused ? null : member.id)}
+              className={cn(
+                "flex h-11 w-11 items-center justify-center rounded-full p-1 transition-[opacity,transform,box-shadow] duration-[250ms] ease-[cubic-bezier(0.32,0.72,0,1)] motion-reduce:transition-none",
+                isFocused && "scale-[1.04]",
+                isDimmed && "opacity-60",
+              )}
+              style={{
+                boxShadow: isFocused
+                  ? `0 0 0 2px ${withOpacity(colors.hex, "cc")}`
+                  : undefined,
+              }}
+            >
+              <span
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-full text-sm font-semibold text-white",
+                  colors.bg,
+                )}
+              >
+                {member.name.charAt(0).toUpperCase()}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/home/components/today-list.test.tsx
+++ b/src/components/home/components/today-list.test.tsx
@@ -57,7 +57,7 @@ describe("TodayList", () => {
           }),
         ]}
         members={testMembers}
-        excludeId="hero-event"
+        excludeKey="hero-event"
         onSelect={vi.fn()}
       />,
     );

--- a/src/components/home/components/today-list.test.tsx
+++ b/src/components/home/components/today-list.test.tsx
@@ -1,0 +1,108 @@
+import type { CalendarEvent } from "@/lib/types";
+import { testMembers } from "@/test/fixtures";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { TodayList } from "./today-list";
+
+function createEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "event-1",
+    title: "Soccer practice",
+    startTime: "2:00 PM",
+    endTime: "3:00 PM",
+    date: new Date(2026, 3, 25),
+    memberId: testMembers[0].id,
+    isAllDay: false,
+    source: "NATIVE",
+    ...overrides,
+  };
+}
+
+describe("TodayList", () => {
+  const currentDate = new Date(2026, 3, 25, 12, 0, 0, 0);
+
+  it("pins all-day events to the top, excludes the hero event, and shows multi-day affixes", () => {
+    renderWithUser(
+      <TodayList
+        currentDate={currentDate}
+        events={[
+          createEvent({
+            id: "hero-event",
+            title: "Hero event",
+            startTime: "10:00 AM",
+            endTime: "11:00 AM",
+          }),
+          createEvent({
+            id: "all-day",
+            title: "Vacation",
+            isAllDay: true,
+            startTime: "00:00",
+            endTime: "23:59",
+            date: new Date(2026, 3, 25),
+            endDate: new Date(2026, 3, 27),
+          }),
+          createEvent({
+            id: "last-day",
+            title: "Conference",
+            isAllDay: true,
+            startTime: "00:00",
+            endTime: "23:59",
+            date: new Date(2026, 3, 23),
+            endDate: new Date(2026, 3, 25),
+          }),
+          createEvent({
+            id: "timed-event",
+            title: "Pickup",
+            startTime: "4:00 PM",
+            endTime: "5:00 PM",
+          }),
+        ]}
+        members={testMembers}
+        excludeId="hero-event"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Hero event")).not.toBeInTheDocument();
+    expect(
+      screen
+        .getAllByRole("button")
+        .slice(0, 2)
+        .map((button) => button.textContent ?? ""),
+    ).toEqual(
+      expect.arrayContaining(["Vacation→ ends Mon", "Conferencefrom Thu →"]),
+    );
+    expect(screen.getByText("→ ends Mon")).toBeInTheDocument();
+    expect(screen.getByText("from Thu →")).toBeInTheDocument();
+    expect(screen.getByText("4:00 PM")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when a row is tapped", async () => {
+    const event = createEvent();
+    const onSelect = vi.fn();
+    const { user } = renderWithUser(
+      <TodayList
+        currentDate={currentDate}
+        events={[event]}
+        members={testMembers}
+        onSelect={onSelect}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /soccer practice/i }));
+
+    expect(onSelect).toHaveBeenCalledWith(event);
+  });
+
+  it("renders nothing when there are no events", () => {
+    const { container } = renderWithUser(
+      <TodayList
+        currentDate={currentDate}
+        events={[]}
+        members={testMembers}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/components/home/components/today-list.tsx
+++ b/src/components/home/components/today-list.tsx
@@ -1,6 +1,6 @@
 import { format } from "date-fns";
 import { memo, useMemo } from "react";
-import { formatLocalDate } from "@/lib/time-utils";
+import { formatLocalDate, getEventKey } from "@/lib/time-utils";
 import type { CalendarEvent, FamilyMember } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -33,19 +33,21 @@ export const TodayList = memo(function TodayList({
   currentDate = new Date(),
   events,
   members,
-  excludeId,
+  excludeKey,
   onSelect,
 }: {
   currentDate?: Date;
   events: CalendarEvent[];
   members: FamilyMember[];
-  excludeId?: string | null;
+  excludeKey?: string | null;
   onSelect: (event: CalendarEvent) => void;
 }) {
   const visibleEvents = useMemo(
     () =>
-      events.filter((event) => event.id !== excludeId).sort(sortTodayEvents),
-    [events, excludeId],
+      events
+        .filter((event) => getEventKey(event) !== excludeKey)
+        .sort(sortTodayEvents),
+    [events, excludeKey],
   );
 
   if (visibleEvents.length === 0) {
@@ -62,7 +64,7 @@ export const TodayList = memo(function TodayList({
 
           return (
             <button
-              key={event.id ?? `${event.title}-${formatLocalDate(event.date)}`}
+              key={getEventKey(event)}
               type="button"
               onClick={() => onSelect(event)}
               className="flex min-h-11 w-full items-start gap-3 rounded-2xl px-1 py-2 text-left transition-transform duration-[150ms] ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98] motion-reduce:transition-none"

--- a/src/components/home/components/today-list.tsx
+++ b/src/components/home/components/today-list.tsx
@@ -1,0 +1,101 @@
+import { format } from "date-fns";
+import { memo, useMemo } from "react";
+import { formatLocalDate } from "@/lib/time-utils";
+import type { CalendarEvent, FamilyMember } from "@/lib/types";
+import { colorMap, getFamilyMember } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { formatEventTimeForDisplay, getEventDateTime } from "../lib/event-time";
+
+function getSpanAffix(event: CalendarEvent, currentDate: Date): string | null {
+  if (!event.endDate) return null;
+
+  const current = formatLocalDate(currentDate);
+  const start = formatLocalDate(event.date);
+  const end = formatLocalDate(event.endDate);
+
+  if (start === end) return null;
+  if (current === start) return `→ ends ${format(event.endDate, "EEE")}`;
+  if (current === end) return `from ${format(event.date, "EEE")} →`;
+  return `${format(event.date, "EEE")} → ${format(event.endDate, "EEE")}`;
+}
+
+function sortTodayEvents(left: CalendarEvent, right: CalendarEvent): number {
+  if (left.isAllDay && !right.isAllDay) return -1;
+  if (!left.isAllDay && right.isAllDay) return 1;
+
+  return (
+    getEventDateTime(left, "start").getTime() -
+    getEventDateTime(right, "start").getTime()
+  );
+}
+
+export const TodayList = memo(function TodayList({
+  currentDate = new Date(),
+  events,
+  members,
+  excludeId,
+  onSelect,
+}: {
+  currentDate?: Date;
+  events: CalendarEvent[];
+  members: FamilyMember[];
+  excludeId?: string | null;
+  onSelect: (event: CalendarEvent) => void;
+}) {
+  const visibleEvents = useMemo(
+    () =>
+      events.filter((event) => event.id !== excludeId).sort(sortTodayEvents),
+    [events, excludeId],
+  );
+
+  if (visibleEvents.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 pt-5">
+      <div className="space-y-3">
+        {visibleEvents.map((event) => {
+          const member = getFamilyMember(members, event.memberId);
+          const colors = member ? colorMap[member.color] : colorMap.coral;
+          const affix = getSpanAffix(event, currentDate);
+
+          return (
+            <button
+              key={event.id ?? `${event.title}-${formatLocalDate(event.date)}`}
+              type="button"
+              onClick={() => onSelect(event)}
+              className="flex min-h-11 w-full items-start gap-3 rounded-2xl px-1 py-2 text-left transition-transform duration-[150ms] ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98] motion-reduce:transition-none"
+            >
+              <div className="pt-1">
+                <span
+                  aria-hidden="true"
+                  className={cn("block h-2.5 w-2.5 rounded-full", colors.bg)}
+                />
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  {!event.isAllDay && (
+                    <span className="shrink-0 text-sm text-foreground/70">
+                      {formatEventTimeForDisplay(event.startTime)}
+                    </span>
+                  )}
+                  <span className="truncate text-base font-semibold text-foreground">
+                    {event.title}
+                  </span>
+                </div>
+
+                {(affix || event.location) && (
+                  <p className="mt-1 truncate text-sm text-foreground/60">
+                    {[affix, event.location].filter(Boolean).join(" · ")}
+                  </p>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/src/components/home/home-dashboard.test.tsx
+++ b/src/components/home/home-dashboard.test.tsx
@@ -1,8 +1,11 @@
+import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach } from "vitest";
 import { createTestEventResponse, testMembers } from "@/test/fixtures";
 import {
+  API_BASE,
   resetMockEvents,
   seedMockEvents,
+  server,
   setupMswServer,
 } from "@/test/mocks/server";
 import {
@@ -160,6 +163,84 @@ describe("HomeDashboard", () => {
     expect(screen.queryByText("John event")).not.toBeInTheDocument();
     expect(screen.queryByText("John tomorrow")).not.toBeInTheDocument();
     expect(screen.getByText("Up next · in 2 hrs")).toBeInTheDocument();
+  });
+
+  it("keeps non-hero recurring instances visible when the hero event is virtual", async () => {
+    seedMockEvents([
+      createTestEventResponse({
+        id: null,
+        recurringEventId: "series-1",
+        isRecurring: true,
+        title: "Morning standup",
+        date: "2026-04-25",
+        startTime: "9:30 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[0].id,
+      }),
+      createTestEventResponse({
+        id: null,
+        recurringEventId: "series-2",
+        isRecurring: true,
+        title: "Doctor follow-up",
+        date: "2026-04-25",
+        startTime: "11:00 AM",
+        endTime: "11:30 AM",
+        memberId: testMembers[1].id,
+      }),
+    ]);
+
+    render(<HomeDashboard nowOverride={currentDate} />);
+
+    expect(await screen.findByText("Morning standup")).toBeInTheDocument();
+    expect(screen.getByText("Doctor follow-up")).toBeInTheDocument();
+  });
+
+  it("clears stale delete errors before opening a different event detail", async () => {
+    setViewportWidth(1024);
+    server.use(
+      http.delete(`${API_BASE}/calendar/events/:id`, () =>
+        HttpResponse.json({ message: "Delete failed" }, { status: 500 }),
+      ),
+    );
+    seedMockEvents([
+      createTestEventResponse({
+        id: "event-breakfast",
+        title: "Breakfast",
+        date: "2026-04-25",
+        startTime: "8:00 AM",
+        endTime: "9:00 AM",
+        memberId: testMembers[0].id,
+      }),
+      createTestEventResponse({
+        id: "event-pickup",
+        title: "School pickup",
+        date: "2026-04-25",
+        startTime: "10:00 AM",
+        endTime: "11:00 AM",
+        memberId: testMembers[1].id,
+      }),
+    ]);
+
+    const { user } = renderWithUser(
+      <HomeDashboard nowOverride={new Date(2026, 3, 25, 12, 0, 0, 0)} />,
+    );
+
+    await screen.findByText("Breakfast");
+
+    await user.click(screen.getByRole("button", { name: /breakfast/i }));
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    await user.click(screen.getByRole("button", { name: /delete event/i }));
+
+    expect(
+      await screen.findByText("Failed to delete event. Please try again."),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /close/i }));
+    await user.click(screen.getByRole("button", { name: /school pickup/i }));
+
+    expect(
+      screen.queryByText("Failed to delete event. Please try again."),
+    ).not.toBeInTheDocument();
   });
 
   it("opens the reused add-event flow prefilled for the focused member and today", async () => {

--- a/src/components/home/home-dashboard.test.tsx
+++ b/src/components/home/home-dashboard.test.tsx
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach } from "vitest";
+import { createTestEventResponse, testMembers } from "@/test/fixtures";
+import {
+  resetMockEvents,
+  seedMockEvents,
+  setupMswServer,
+} from "@/test/mocks/server";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedFamilyStore,
+  waitForMemberSelected,
+} from "@/test/test-utils";
+import { HomeDashboard } from "./home-dashboard";
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches: (() => {
+      const maxWidth = Number.parseInt(
+        query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+      const minWidth = Number.parseInt(
+        query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+        10,
+      );
+
+      const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+      const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+      return matchesMax && matchesMin;
+    })(),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("HomeDashboard", () => {
+  setupMswServer();
+  const currentDate = new Date(2026, 3, 25, 9, 0, 0, 0);
+
+  beforeEach(() => {
+    setViewportWidth(768);
+    seedFamilyStore({
+      name: "Test Family",
+      members: testMembers,
+    });
+  });
+
+  afterEach(() => {
+    resetMockEvents();
+  });
+
+  it("renders the mobile dashboard surface instead of the launcher grid", async () => {
+    seedMockEvents([
+      createTestEventResponse({
+        id: "today",
+        title: "School pickup",
+        date: "2026-04-25",
+        startTime: "9:45 AM",
+        endTime: "10:15 AM",
+        memberId: testMembers[0].id,
+      }),
+      createTestEventResponse({
+        id: "tomorrow",
+        title: "Dentist",
+        date: "2026-04-26",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[1].id,
+      }),
+    ]);
+
+    render(<HomeDashboard nowOverride={currentDate} />);
+
+    expect(
+      await screen.findByText("Good morning, Test Family"),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Up next · in 45 min")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Focus on John's events" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("School pickup")).toBeInTheDocument();
+    expect(screen.getByText("Coming up")).toBeInTheDocument();
+    expect(
+      screen.queryByText("What would you like to do?"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the calm empty state without any Google connect CTA", async () => {
+    seedMockEvents([]);
+
+    render(<HomeDashboard nowOverride={currentDate} />);
+
+    expect(
+      await screen.findByText("Nothing on the calendar today"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect google calendar/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters hero, today, and coming up when a member chip is focused", async () => {
+    seedMockEvents([
+      createTestEventResponse({
+        id: "john-today",
+        title: "John event",
+        date: "2026-04-25",
+        startTime: "9:30 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[0].id,
+      }),
+      createTestEventResponse({
+        id: "jane-today",
+        title: "Jane event",
+        date: "2026-04-25",
+        startTime: "11:00 AM",
+        endTime: "12:00 PM",
+        memberId: testMembers[1].id,
+      }),
+      createTestEventResponse({
+        id: "john-tomorrow",
+        title: "John tomorrow",
+        date: "2026-04-26",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[0].id,
+      }),
+      createTestEventResponse({
+        id: "jane-tomorrow",
+        title: "Jane tomorrow",
+        date: "2026-04-26",
+        startTime: "2:00 PM",
+        endTime: "3:00 PM",
+        memberId: testMembers[1].id,
+      }),
+    ]);
+
+    const { user } = renderWithUser(
+      <HomeDashboard nowOverride={currentDate} />,
+    );
+
+    await screen.findByText("John event");
+    await user.click(
+      screen.getByRole("button", { name: "Focus on Jane's events" }),
+    );
+
+    expect(screen.getByText("Jane event")).toBeInTheDocument();
+    expect(screen.getByText("Jane tomorrow")).toBeInTheDocument();
+    expect(screen.queryByText("John event")).not.toBeInTheDocument();
+    expect(screen.queryByText("John tomorrow")).not.toBeInTheDocument();
+    expect(screen.getByText("Up next · in 2 hrs")).toBeInTheDocument();
+  });
+
+  it("opens the reused add-event flow prefilled for the focused member and today", async () => {
+    seedMockEvents([]);
+
+    const { user } = renderWithUser(
+      <HomeDashboard nowOverride={currentDate} />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Focus on Jane's events" }),
+    );
+    await user.click(screen.getByRole("button", { name: /add event/i }));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+    await waitForMemberSelected("Jane");
+    expect(
+      screen.getByRole("button", { name: /april 25th, 2026/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -16,7 +16,7 @@ import {
   EventFormModal,
 } from "@/components/calendar";
 import { buildRRule } from "@/lib/recurrence-utils";
-import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
+import { format24hTo12h, formatLocalDate, getEventKey } from "@/lib/time-utils";
 import type { CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
@@ -95,6 +95,7 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
     [now, today],
   );
   const heroEvent = "event" in heroState ? heroState.event : null;
+  const heroEventKey = heroEvent ? getEventKey(heroEvent) : null;
   const createEvent = useCreateEvent({
     onSuccess: () => {
       closeAddEventModal();
@@ -133,6 +134,12 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
       date: formatLocalDate(now),
       memberId: focusedMemberId ?? members[0]?.id ?? "",
     });
+  };
+
+  const handleEventClick = (event: (typeof today)[number]) => {
+    deleteEvent.reset();
+    deleteInstance.reset();
+    openDetailModal(event);
   };
 
   const handleAddEvent = (formData: EventFormData) => {
@@ -288,20 +295,20 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
                 : undefined
             }
             now={now}
-            onTap={heroEvent ? () => openDetailModal(heroEvent) : undefined}
+            onTap={heroEvent ? () => handleEventClick(heroEvent) : undefined}
           />
           <TodayList
             currentDate={now}
             events={today}
             members={members}
-            excludeId={heroEvent?.id ?? null}
-            onSelect={openDetailModal}
+            excludeKey={heroEventKey}
+            onSelect={handleEventClick}
           />
           <ComingUp
             currentDate={now}
             events={comingUp}
             members={members}
-            onSelect={openDetailModal}
+            onSelect={handleEventClick}
           />
         </>
       )}

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -1,61 +1,349 @@
+import { useMemo, useState } from "react";
 import {
-  Calendar,
-  CheckSquare,
-  ImageIcon,
-  ListTodo,
-  UtensilsCrossed,
-} from "lucide-react";
-import { cn } from "@/lib/utils";
-import { type ModuleType, useAppStore } from "@/stores";
+  useCreateEvent,
+  useDeleteEvent,
+  useDeleteInstance,
+  useFamilyMembers,
+  useFamilyName,
+  useUpdateEvent,
+  useUpdateInstance,
+} from "@/api";
+import {
+  AddEventButton,
+  type EditScope,
+  EditScopeDialog,
+  EventDetailModal,
+  EventFormModal,
+} from "@/components/calendar";
+import { buildRRule } from "@/lib/recurrence-utils";
+import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
+import type { CreateEventRequest } from "@/lib/types";
+import type { EventFormData } from "@/lib/validations";
+import {
+  useCalendarActions,
+  useCalendarState,
+  useCalendarStore,
+  useEditModalState,
+  useEventDetailState,
+} from "@/stores";
+import { ComingUp } from "./components/coming-up";
+import { DashboardHeader } from "./components/dashboard-header";
+import { HeroCard } from "./components/hero-card";
+import { MemberChipRow } from "./components/member-chip-row";
+import { TodayList } from "./components/today-list";
+import { useDashboardEvents } from "./hooks/use-dashboard-events";
+import { useDashboardNow } from "./hooks/use-hero-state";
+import { deriveHeroState } from "./lib/hero-state";
 
-const modules: Array<{
-  id: ModuleType;
-  label: string;
-  icon: typeof Calendar;
-  color: string;
-}> = [
-  { id: "calendar", label: "Calendar", icon: Calendar, color: "bg-purple-500" },
-  { id: "lists", label: "Lists", icon: ListTodo, color: "bg-teal-500" },
-  { id: "chores", label: "Chores", icon: CheckSquare, color: "bg-green-500" },
-  {
-    id: "meals",
-    label: "Meals",
-    icon: UtensilsCrossed,
-    color: "bg-orange-500",
-  },
-  { id: "photos", label: "Photos", icon: ImageIcon, color: "bg-pink-500" },
-];
+function getParentId(event: {
+  id: string | null;
+  recurringEventId?: string;
+}): string {
+  const id = event.recurringEventId ?? event.id;
+  if (!id) {
+    throw new Error("Cannot resolve parent ID for recurring event operation");
+  }
+  return id;
+}
 
-export function HomeDashboard() {
-  const setActiveModule = useAppStore((state) => state.setActiveModule);
+function LoadingDashboard() {
+  return (
+    <div className="px-4 pt-4">
+      <div className="animate-pulse space-y-4">
+        <div className="h-5 w-40 rounded-full bg-muted" />
+        <div className="flex gap-2">
+          <div className="h-11 w-11 rounded-full bg-muted" />
+          <div className="h-11 w-11 rounded-full bg-muted" />
+          <div className="h-11 w-11 rounded-full bg-muted" />
+        </div>
+        <div className="h-48 rounded-[1.75rem] bg-card" />
+        <div className="space-y-3">
+          <div className="h-12 rounded-2xl bg-muted" />
+          <div className="h-12 rounded-2xl bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
+  const familyName = useFamilyName();
+  const members = useFamilyMembers();
+  const liveNow = useDashboardNow();
+  const now = nowOverride ?? liveNow;
+  const [focusedMemberId, setFocusedMemberId] = useState<string | null>(null);
+  const { isAddEventModalOpen, addEventDefaults } = useCalendarState();
+  const {
+    openAddEventModal,
+    closeAddEventModal,
+    openEditModal,
+    closeEditModal,
+  } = useCalendarActions();
+  const {
+    selectedEvent,
+    isDetailModalOpen,
+    openDetailModal,
+    closeDetailModal,
+  } = useEventDetailState();
+  const { editingEvent, isEditModalOpen } = useEditModalState();
+  const { today, comingUp, isLoading, isError, error } = useDashboardEvents({
+    currentDate: now,
+    memberFocusId: focusedMemberId,
+  });
+  const heroState = useMemo(
+    () => deriveHeroState({ todayEvents: today, now }),
+    [now, today],
+  );
+  const heroEvent = "event" in heroState ? heroState.event : null;
+  const createEvent = useCreateEvent({
+    onSuccess: () => {
+      closeAddEventModal();
+    },
+  });
+  const updateEvent = useUpdateEvent({
+    onSuccess: () => {
+      closeEditModal();
+      setEditScope(null);
+    },
+  });
+  const updateInstance = useUpdateInstance({
+    onSuccess: () => {
+      closeEditModal();
+      setEditScope(null);
+    },
+  });
+  const deleteEvent = useDeleteEvent({
+    onSuccess: () => {
+      closeDetailModal();
+      setScopeDialogOpen(false);
+    },
+  });
+  const deleteInstance = useDeleteInstance({
+    onSuccess: () => {
+      closeDetailModal();
+      setScopeDialogOpen(false);
+    },
+  });
+  const [scopeDialogOpen, setScopeDialogOpen] = useState(false);
+  const [scopeAction, setScopeAction] = useState<"edit" | "delete">("edit");
+  const [editScope, setEditScope] = useState<EditScope | null>(null);
+
+  const openPrefilledAddModal = () => {
+    openAddEventModal({
+      date: formatLocalDate(now),
+      memberId: focusedMemberId ?? members[0]?.id ?? "",
+    });
+  };
+
+  const handleAddEvent = (formData: EventFormData) => {
+    const recurrenceRule =
+      buildRRule({
+        frequency: formData.recurrenceFrequency ?? "none",
+        interval: formData.recurrenceInterval ?? 1,
+        weeklyDays: formData.recurrenceWeeklyDays,
+        monthDay: formData.recurrenceMonthDay,
+        endDate: formData.recurrenceEndDate,
+      }) ?? null;
+
+    const request: CreateEventRequest = {
+      title: formData.title,
+      startTime: format24hTo12h(formData.startTime),
+      endTime: format24hTo12h(formData.endTime),
+      date: formData.date,
+      endDate: formData.endDate ?? null,
+      memberId: formData.memberId,
+      isAllDay: formData.isAllDay,
+      location: formData.location,
+      description: formData.description,
+      recurrenceRule,
+    };
+
+    createEvent.mutate(request);
+  };
+
+  const handleDeleteEvent = () => {
+    if (!selectedEvent) return;
+
+    if (selectedEvent.source === "GOOGLE") {
+      return;
+    }
+
+    if (selectedEvent.isRecurring) {
+      setScopeAction("delete");
+      setScopeDialogOpen(true);
+      return;
+    }
+
+    if (selectedEvent.id) {
+      deleteEvent.mutate(selectedEvent.id);
+    }
+  };
+
+  const handleEditClick = () => {
+    if (!selectedEvent || selectedEvent.source === "GOOGLE") return;
+
+    if (selectedEvent.isRecurring) {
+      setScopeAction("edit");
+      setScopeDialogOpen(true);
+      return;
+    }
+
+    openEditModal(selectedEvent);
+  };
+
+  const handleScopeSelect = (scope: EditScope) => {
+    if (!selectedEvent) return;
+
+    setScopeDialogOpen(false);
+
+    if (scopeAction === "edit") {
+      setEditScope(scope);
+      openEditModal(selectedEvent);
+      return;
+    }
+
+    const parentId = getParentId(selectedEvent);
+    if (scope === "this") {
+      deleteInstance.mutate({
+        parentId,
+        date: formatLocalDate(selectedEvent.date),
+      });
+      return;
+    }
+
+    deleteEvent.mutate(parentId);
+  };
+
+  const handleUpdateEvent = (formData: EventFormData) => {
+    const currentEditingEvent = useCalendarStore.getState().editingEvent;
+    if (!currentEditingEvent) return;
+
+    const request = {
+      title: formData.title,
+      startTime: format24hTo12h(formData.startTime),
+      endTime: format24hTo12h(formData.endTime),
+      date: formData.date,
+      endDate: formData.endDate ?? null,
+      memberId: formData.memberId,
+      isAllDay: formData.isAllDay,
+      location: formData.location,
+      description: formData.description,
+    };
+
+    if (currentEditingEvent.isRecurring && editScope === "this") {
+      updateInstance.mutate({
+        parentId: getParentId(currentEditingEvent),
+        instanceDate: formatLocalDate(currentEditingEvent.date),
+        ...request,
+      });
+      return;
+    }
+
+    const recurrenceRule =
+      currentEditingEvent.isRecurring && editScope === "all"
+        ? (buildRRule({
+            frequency: formData.recurrenceFrequency ?? "none",
+            interval: formData.recurrenceInterval ?? 1,
+            weeklyDays: formData.recurrenceWeeklyDays,
+            monthDay: formData.recurrenceMonthDay,
+            endDate: formData.recurrenceEndDate,
+          }) ?? null)
+        : undefined;
+
+    const id = currentEditingEvent.isRecurring
+      ? getParentId(currentEditingEvent)
+      : currentEditingEvent.id;
+
+    if (!id) return;
+
+    updateEvent.mutate({
+      id,
+      ...request,
+      ...(recurrenceRule !== undefined && { recurrenceRule }),
+    });
+  };
 
   return (
-    <div className="flex-1 p-4 overflow-y-auto">
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-foreground">Home</h1>
-        <p className="text-muted-foreground">What would you like to do?</p>
-      </div>
+    <div className="flex-1 overflow-y-auto pb-[max(8.5rem,calc(env(safe-area-inset-bottom)+8.5rem))]">
+      <DashboardHeader familyName={familyName} now={now} />
+      <MemberChipRow
+        members={members}
+        focusedId={focusedMemberId}
+        onFocusChange={setFocusedMemberId}
+      />
 
-      <div className="grid grid-cols-2 gap-4">
-        {modules.map((module) => {
-          const Icon = module.icon;
-          return (
-            <button
-              type="button"
-              key={module.id}
-              onClick={() => setActiveModule(module.id)}
-              className={cn(
-                "flex flex-col items-center justify-center gap-3 p-6 rounded-2xl",
-                "text-white shadow-md active:scale-95 transition-transform",
-                module.color,
-              )}
-            >
-              <Icon className="h-10 w-10" />
-              <span className="text-lg font-semibold">{module.label}</span>
-            </button>
-          );
-        })}
-      </div>
+      {isLoading ? (
+        <LoadingDashboard />
+      ) : isError ? (
+        <div className="px-4 pt-6 text-sm text-destructive">
+          Error loading events: {error?.message ?? "Unknown error"}
+        </div>
+      ) : (
+        <>
+          <HeroCard
+            state={heroState}
+            member={
+              heroEvent
+                ? members.find((member) => member.id === heroEvent.memberId)
+                : undefined
+            }
+            now={now}
+            onTap={heroEvent ? () => openDetailModal(heroEvent) : undefined}
+          />
+          <TodayList
+            currentDate={now}
+            events={today}
+            members={members}
+            excludeId={heroEvent?.id ?? null}
+            onSelect={openDetailModal}
+          />
+          <ComingUp
+            currentDate={now}
+            events={comingUp}
+            members={members}
+            onSelect={openDetailModal}
+          />
+        </>
+      )}
+
+      <AddEventButton onClick={openPrefilledAddModal} />
+      <EventFormModal
+        mode="add"
+        isOpen={isAddEventModalOpen}
+        onClose={closeAddEventModal}
+        onSubmit={handleAddEvent}
+        isPending={createEvent.isPending}
+        defaultValues={addEventDefaults ?? undefined}
+      />
+      <EventFormModal
+        mode="edit"
+        isOpen={isEditModalOpen}
+        onClose={() => {
+          closeEditModal();
+          setEditScope(null);
+        }}
+        onSubmit={handleUpdateEvent}
+        isPending={updateEvent.isPending || updateInstance.isPending}
+        event={editingEvent ?? undefined}
+        showRecurrencePicker={editScope !== "this"}
+      />
+      <EventDetailModal
+        event={selectedEvent}
+        isOpen={isDetailModalOpen}
+        onClose={closeDetailModal}
+        onEdit={handleEditClick}
+        onDelete={handleDeleteEvent}
+        isDeleting={deleteEvent.isPending || deleteInstance.isPending}
+        deleteError={
+          deleteEvent.error?.message ?? deleteInstance.error?.message
+        }
+      />
+      <EditScopeDialog
+        isOpen={scopeDialogOpen}
+        onClose={() => setScopeDialogOpen(false)}
+        onSelect={handleScopeSelect}
+        action={scopeAction}
+      />
     </div>
   );
 }

--- a/src/components/home/hooks/use-dashboard-events.test.tsx
+++ b/src/components/home/hooks/use-dashboard-events.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { createTestEventResponse, testMembers } from "@/test/fixtures";
+import {
+  resetMockEvents,
+  seedMockEvents,
+  setupMswServer,
+} from "@/test/mocks/server";
+import { useDashboardEvents } from "./use-dashboard-events";
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useDashboardEvents", () => {
+  const currentDate = new Date(2026, 3, 25, 9, 0, 0, 0);
+
+  setupMswServer();
+
+  afterEach(() => {
+    resetMockEvents();
+  });
+
+  it("partitions one events query into today and coming-up slices, including overlapping multi-day events", async () => {
+    seedMockEvents([
+      createTestEventResponse({
+        id: "today-all-day",
+        title: "Vacation",
+        date: "2026-04-24",
+        endDate: "2026-04-25",
+        startTime: "12:00 AM",
+        endTime: "11:59 PM",
+        memberId: testMembers[0].id,
+        isAllDay: true,
+      }),
+      createTestEventResponse({
+        id: "today-timed",
+        title: "School pickup",
+        date: "2026-04-25",
+        startTime: "2:00 PM",
+        endTime: "3:00 PM",
+        memberId: testMembers[0].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "tomorrow-early",
+        title: "Dentist",
+        date: "2026-04-26",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[1].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "tomorrow-late",
+        title: "Swim",
+        date: "2026-04-26",
+        startTime: "4:00 PM",
+        endTime: "5:00 PM",
+        memberId: testMembers[0].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "day-after",
+        title: "Brunch",
+        date: "2026-04-27",
+        startTime: "8:00 AM",
+        endTime: "9:00 AM",
+        memberId: testMembers[2].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "fourth-upcoming",
+        title: "Should be capped away",
+        date: "2026-04-27",
+        startTime: "12:00 PM",
+        endTime: "1:00 PM",
+        memberId: testMembers[2].id,
+        isAllDay: false,
+      }),
+    ]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+      },
+    });
+
+    const { result } = renderHook(() => useDashboardEvents({ currentDate }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.today.map((event) => event.id)).toEqual([
+      "today-all-day",
+      "today-timed",
+    ]);
+    expect(result.current.comingUp.map((event) => event.id)).toEqual([
+      "tomorrow-early",
+      "tomorrow-late",
+      "day-after",
+    ]);
+  });
+
+  it("applies a single member focus consistently to today and coming up", async () => {
+    seedMockEvents([
+      createTestEventResponse({
+        id: "today-a",
+        date: "2026-04-25",
+        startTime: "10:00 AM",
+        endTime: "11:00 AM",
+        memberId: testMembers[0].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "today-b",
+        date: "2026-04-25",
+        startTime: "1:00 PM",
+        endTime: "2:00 PM",
+        memberId: testMembers[1].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "tomorrow-a",
+        date: "2026-04-26",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: testMembers[0].id,
+        isAllDay: false,
+      }),
+      createTestEventResponse({
+        id: "tomorrow-b",
+        date: "2026-04-26",
+        startTime: "2:00 PM",
+        endTime: "3:00 PM",
+        memberId: testMembers[1].id,
+        isAllDay: false,
+      }),
+    ]);
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useDashboardEvents({
+          currentDate,
+          memberFocusId: testMembers[0].id,
+        }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.today.map((event) => event.id)).toEqual(["today-a"]);
+    expect(result.current.comingUp.map((event) => event.id)).toEqual([
+      "tomorrow-a",
+    ]);
+  });
+});

--- a/src/components/home/hooks/use-dashboard-events.ts
+++ b/src/components/home/hooks/use-dashboard-events.ts
@@ -1,0 +1,85 @@
+import { addDays, endOfDay, startOfDay } from "date-fns";
+import { useMemo } from "react";
+import { useCalendarEvents } from "@/api";
+import { formatLocalDate, isEventOnDate } from "@/lib/time-utils";
+import type { CalendarEvent } from "@/lib/types";
+import { getEventDateTime } from "../lib/event-time";
+
+function sortTodayEvents(left: CalendarEvent, right: CalendarEvent): number {
+  if (left.isAllDay && !right.isAllDay) return -1;
+  if (!left.isAllDay && right.isAllDay) return 1;
+
+  return (
+    getEventDateTime(left, "start").getTime() -
+    getEventDateTime(right, "start").getTime()
+  );
+}
+
+function sortByStartDateTime(
+  left: CalendarEvent,
+  right: CalendarEvent,
+): number {
+  return (
+    getEventDateTime(left, "start").getTime() -
+    getEventDateTime(right, "start").getTime()
+  );
+}
+
+export function useDashboardEvents({
+  currentDate = new Date(),
+  memberFocusId = null,
+}: {
+  currentDate?: Date;
+  memberFocusId?: string | null;
+} = {}) {
+  const dayStart = useMemo(() => startOfDay(currentDate), [currentDate]);
+  const dayEnd = useMemo(() => endOfDay(dayStart), [dayStart]);
+  const windowEnd = useMemo(() => endOfDay(addDays(dayStart, 2)), [dayStart]);
+  const range = useMemo(
+    () => ({
+      startDate: formatLocalDate(dayStart),
+      endDate: formatLocalDate(addDays(dayStart, 2)),
+    }),
+    [dayStart],
+  );
+
+  const { data, isLoading, isError, error } = useCalendarEvents(range);
+
+  const filteredEvents = useMemo(() => {
+    const events = data?.data ?? [];
+
+    if (!memberFocusId) {
+      return events;
+    }
+
+    return events.filter((event) => event.memberId === memberFocusId);
+  }, [data, memberFocusId]);
+
+  const today = useMemo(
+    () =>
+      filteredEvents
+        .filter((event) => isEventOnDate(event, dayStart))
+        .sort(sortTodayEvents),
+    [dayStart, filteredEvents],
+  );
+
+  const comingUp = useMemo(
+    () =>
+      filteredEvents
+        .filter((event) => {
+          const eventStart = getEventDateTime(event, "start");
+          return eventStart > dayEnd && eventStart <= windowEnd;
+        })
+        .sort(sortByStartDateTime)
+        .slice(0, 3),
+    [dayEnd, filteredEvents, windowEnd],
+  );
+
+  return {
+    today,
+    comingUp,
+    isLoading,
+    isError,
+    error,
+  };
+}

--- a/src/components/home/hooks/use-hero-state.test.tsx
+++ b/src/components/home/hooks/use-hero-state.test.tsx
@@ -1,0 +1,97 @@
+import { act, renderHook } from "@testing-library/react";
+import type { CalendarEvent } from "@/lib/types";
+import { useHeroState } from "./use-hero-state";
+
+const event: CalendarEvent = {
+  id: "event-1",
+  title: "Soccer practice",
+  startTime: "10:00 AM",
+  endTime: "11:00 AM",
+  date: new Date(2026, 3, 25),
+  memberId: "member-1",
+  isAllDay: false,
+  source: "NATIVE",
+};
+
+describe("useHeroState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("derives the initial hero state from the supplied clock", () => {
+    const { result } = renderHook(() =>
+      useHeroState([event], () => new Date(2026, 3, 25, 9, 0, 0, 0)),
+    );
+
+    expect(result.current.state).toEqual({
+      kind: "UP_NEXT",
+      event,
+    });
+    expect(result.current.now).toEqual(new Date(2026, 3, 25, 9, 0, 0, 0));
+  });
+
+  it("recomputes when the 30-second interval ticks", () => {
+    let now = new Date(2026, 3, 25, 9, 59, 0, 0);
+
+    const { result } = renderHook(() => useHeroState([event], () => now));
+
+    expect(result.current.state.kind).toBe("UP_NEXT");
+
+    act(() => {
+      now = new Date(2026, 3, 25, 10, 0, 0, 0);
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(result.current.state).toEqual({
+      kind: "RIGHT_NOW",
+      event,
+    });
+    expect(result.current.now).toEqual(new Date(2026, 3, 25, 10, 0, 0, 0));
+  });
+
+  it("recomputes when the tab becomes visible again", () => {
+    let now = new Date(2026, 3, 25, 9, 59, 0, 0);
+    let visibilityState: DocumentVisibilityState = "hidden";
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+
+    const { result } = renderHook(() => useHeroState([event], () => now));
+
+    expect(result.current.state.kind).toBe("UP_NEXT");
+
+    act(() => {
+      now = new Date(2026, 3, 25, 10, 0, 0, 0);
+      visibilityState = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(result.current.state).toEqual({
+      kind: "RIGHT_NOW",
+      event,
+    });
+  });
+
+  it("cleans up its timer and visibility listener on unmount", () => {
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval");
+    const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useHeroState([event], () => new Date(2026, 3, 25, 9, 0, 0, 0)),
+    );
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "visibilitychange",
+      expect.any(Function),
+    );
+  });
+});

--- a/src/components/home/hooks/use-hero-state.ts
+++ b/src/components/home/hooks/use-hero-state.ts
@@ -1,0 +1,45 @@
+import { useEffect, useMemo, useState } from "react";
+import type { CalendarEvent } from "@/lib/types";
+import { deriveHeroState, type HeroState } from "../lib/hero-state";
+
+export function useDashboardNow(
+  nowProvider: () => Date = () => new Date(),
+): Date {
+  const [now, setNow] = useState(() => nowProvider());
+
+  useEffect(() => {
+    const syncNow = () => setNow(nowProvider());
+    const intervalId = window.setInterval(syncNow, 30_000);
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        syncNow();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [nowProvider]);
+
+  return now;
+}
+
+export function useHeroState(
+  todayEvents: CalendarEvent[],
+  nowProvider: () => Date = () => new Date(),
+): {
+  state: HeroState;
+  now: Date;
+} {
+  const now = useDashboardNow(nowProvider);
+  const state = useMemo(
+    () => deriveHeroState({ todayEvents, now }),
+    [todayEvents, now],
+  );
+
+  return { state, now };
+}

--- a/src/components/home/lib/event-time.ts
+++ b/src/components/home/lib/event-time.ts
@@ -1,0 +1,32 @@
+import { format24hTo12h, getTimeInMinutes } from "@/lib/time-utils";
+import type { CalendarEvent } from "@/lib/types";
+
+const TIME_24H_REGEX = /^([01]?\d|2[0-3]):[0-5]\d$/;
+
+export function getEventTimeInMinutes(time: string): number {
+  if (TIME_24H_REGEX.test(time)) {
+    const [hours, minutes] = time.split(":").map(Number);
+    return hours * 60 + minutes;
+  }
+
+  return getTimeInMinutes(time);
+}
+
+export function getEventDateTime(
+  event: CalendarEvent,
+  boundary: "start" | "end",
+): Date {
+  const baseDate =
+    boundary === "end" && event.endDate ? event.endDate : event.date;
+  const time = boundary === "start" ? event.startTime : event.endTime;
+  const minutes = getEventTimeInMinutes(time);
+  const dateTime = new Date(baseDate);
+
+  dateTime.setHours(Math.floor(minutes / 60), minutes % 60, 0, 0);
+
+  return dateTime;
+}
+
+export function formatEventTimeForDisplay(time: string): string {
+  return TIME_24H_REGEX.test(time) ? format24hTo12h(time) : time;
+}

--- a/src/components/home/lib/hero-state.test.ts
+++ b/src/components/home/lib/hero-state.test.ts
@@ -1,0 +1,122 @@
+import type { CalendarEvent } from "@/lib/types";
+import { deriveHeroState } from "./hero-state";
+
+const baseDate = new Date(2026, 3, 25);
+
+function at(hours: number, minutes = 0) {
+  return new Date(2026, 3, 25, hours, minutes, 0, 0);
+}
+
+function createEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: overrides.id ?? "event-1",
+    title: overrides.title ?? "Test Event",
+    startTime: overrides.startTime ?? "9:00 AM",
+    endTime: overrides.endTime ?? "10:00 AM",
+    date: overrides.date ?? baseDate,
+    endDate: overrides.endDate,
+    memberId: overrides.memberId ?? "member-1",
+    isAllDay: overrides.isAllDay ?? false,
+    location: overrides.location,
+    source: overrides.source ?? "NATIVE",
+    description: overrides.description,
+    recurrenceRule: overrides.recurrenceRule,
+    recurringEventId: overrides.recurringEventId,
+    isRecurring: overrides.isRecurring,
+    htmlLink: overrides.htmlLink,
+  };
+}
+
+describe("deriveHeroState", () => {
+  it("returns ALL_CLEAR_TODAY when there are no events", () => {
+    expect(deriveHeroState({ todayEvents: [], now: at(9) })).toEqual({
+      kind: "ALL_CLEAR_TODAY",
+    });
+  });
+
+  it("returns RIGHT_NOW for an in-progress timed event", () => {
+    const current = createEvent();
+
+    expect(deriveHeroState({ todayEvents: [current], now: at(9, 30) })).toEqual(
+      {
+        kind: "RIGHT_NOW",
+        event: current,
+      },
+    );
+  });
+
+  it("returns UP_NEXT for the next future timed event", () => {
+    const past = createEvent({
+      id: "past",
+      startTime: "7:00 AM",
+      endTime: "8:00 AM",
+    });
+    const next = createEvent({
+      id: "next",
+      startTime: "14:00",
+      endTime: "15:00",
+    });
+
+    expect(deriveHeroState({ todayEvents: [past, next], now: at(12) })).toEqual(
+      {
+        kind: "UP_NEXT",
+        event: next,
+      },
+    );
+  });
+
+  it("returns ALL_DAY_ONLY when only all-day events exist", () => {
+    const allDay = createEvent({
+      id: "all-day",
+      isAllDay: true,
+      startTime: "00:00",
+      endTime: "23:59",
+    });
+
+    expect(deriveHeroState({ todayEvents: [allDay], now: at(12) })).toEqual({
+      kind: "ALL_DAY_ONLY",
+      event: allDay,
+    });
+  });
+
+  it("returns REST_OF_DAY_CLEAR when timed events already ended, even with all-day events present", () => {
+    const past = createEvent({
+      id: "past",
+      startTime: "7:00 AM",
+      endTime: "8:00 AM",
+    });
+    const allDay = createEvent({
+      id: "all-day",
+      isAllDay: true,
+      startTime: "12:00 AM",
+      endTime: "11:59 PM",
+    });
+
+    expect(
+      deriveHeroState({ todayEvents: [past, allDay], now: at(12) }),
+    ).toEqual({
+      kind: "REST_OF_DAY_CLEAR",
+    });
+  });
+
+  it("ignores all-day events when a timed event is up next", () => {
+    const allDay = createEvent({
+      id: "all-day",
+      isAllDay: true,
+      startTime: "00:00",
+      endTime: "23:59",
+    });
+    const next = createEvent({
+      id: "next",
+      startTime: "1:30 PM",
+      endTime: "2:30 PM",
+    });
+
+    expect(
+      deriveHeroState({ todayEvents: [allDay, next], now: at(12) }),
+    ).toEqual({
+      kind: "UP_NEXT",
+      event: next,
+    });
+  });
+});

--- a/src/components/home/lib/hero-state.ts
+++ b/src/components/home/lib/hero-state.ts
@@ -1,0 +1,53 @@
+import type { CalendarEvent } from "@/lib/types";
+import { getEventDateTime } from "./event-time";
+
+export type HeroState =
+  | { kind: "RIGHT_NOW"; event: CalendarEvent }
+  | { kind: "UP_NEXT"; event: CalendarEvent }
+  | { kind: "ALL_DAY_ONLY"; event: CalendarEvent }
+  | { kind: "REST_OF_DAY_CLEAR" }
+  | { kind: "ALL_CLEAR_TODAY" };
+
+export function deriveHeroState({
+  todayEvents,
+  now,
+}: {
+  todayEvents: CalendarEvent[];
+  now: Date;
+}): HeroState {
+  const timedEvents = todayEvents
+    .filter((event) => !event.isAllDay)
+    .sort(
+      (left, right) =>
+        getEventDateTime(left, "start").getTime() -
+        getEventDateTime(right, "start").getTime(),
+    );
+  const allDayEvents = todayEvents.filter((event) => event.isAllDay);
+
+  const inProgress = timedEvents.find((event) => {
+    const start = getEventDateTime(event, "start");
+    const end = getEventDateTime(event, "end");
+    return start <= now && now < end;
+  });
+
+  if (inProgress) {
+    return { kind: "RIGHT_NOW", event: inProgress };
+  }
+
+  const next = timedEvents.find(
+    (event) => getEventDateTime(event, "start") > now,
+  );
+  if (next) {
+    return { kind: "UP_NEXT", event: next };
+  }
+
+  if (timedEvents.length === 0 && allDayEvents.length > 0) {
+    return { kind: "ALL_DAY_ONLY", event: allDayEvents[0] };
+  }
+
+  if (timedEvents.length > 0) {
+    return { kind: "REST_OF_DAY_CLEAR" };
+  }
+
+  return { kind: "ALL_CLEAR_TODAY" };
+}

--- a/src/components/home/lib/relative-time.test.ts
+++ b/src/components/home/lib/relative-time.test.ts
@@ -1,0 +1,37 @@
+import { formatRelativeStart, formatRemainingEnd } from "./relative-time";
+
+const now = new Date(2026, 3, 25, 9, 0, 0, 0);
+
+describe("formatRelativeStart", () => {
+  it("formats starts within an hour in minutes", () => {
+    expect(formatRelativeStart(new Date(2026, 3, 25, 9, 38), now)).toBe(
+      "in 38 min",
+    );
+  });
+
+  it("formats starts between one and six hours in hours", () => {
+    expect(formatRelativeStart(new Date(2026, 3, 25, 11, 15), now)).toBe(
+      "in 2 hrs",
+    );
+  });
+
+  it("formats starts beyond six hours as an absolute time", () => {
+    expect(formatRelativeStart(new Date(2026, 3, 25, 17, 30), now)).toBe(
+      "at 5:30 PM",
+    );
+  });
+});
+
+describe("formatRemainingEnd", () => {
+  it("formats remaining time within an hour in minutes", () => {
+    expect(formatRemainingEnd(new Date(2026, 3, 25, 9, 22), now)).toBe(
+      "ends in 22 min",
+    );
+  });
+
+  it("formats remaining time beyond an hour in hours", () => {
+    expect(formatRemainingEnd(new Date(2026, 3, 25, 11, 5), now)).toBe(
+      "ends in 2 hrs",
+    );
+  });
+});

--- a/src/components/home/lib/relative-time.ts
+++ b/src/components/home/lib/relative-time.ts
@@ -1,0 +1,27 @@
+import { differenceInMinutes, format } from "date-fns";
+
+function formatRelativeMinutes(
+  minutes: number,
+  absoluteDate: Date,
+  prefix = "",
+): string {
+  if (minutes < 60) {
+    return `${prefix}in ${minutes} min`;
+  }
+
+  if (minutes <= 6 * 60) {
+    const hours = Math.floor(minutes / 60);
+    const unit = hours === 1 ? "hr" : "hrs";
+    return `${prefix}in ${hours} ${unit}`;
+  }
+
+  return `${prefix}at ${format(absoluteDate, "h:mm a")}`;
+}
+
+export function formatRelativeStart(start: Date, now: Date): string {
+  return formatRelativeMinutes(differenceInMinutes(start, now), start);
+}
+
+export function formatRemainingEnd(end: Date, now: Date): string {
+  return formatRelativeMinutes(differenceInMinutes(end, now), end, "ends ");
+}

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -14,7 +14,6 @@ describe("MobileBottomNav", () => {
     const nav = screen.getByRole("navigation", { name: /primary/i });
 
     expect(nav).toBeInTheDocument();
-    expect(nav).toHaveClass("md:hidden");
     expect(screen.getByRole("button", { name: /^home$/i })).toHaveAttribute(
       "aria-current",
       "page",

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -11,9 +11,10 @@ describe("MobileBottomNav", () => {
   it("renders all six tabs and marks Home active when activeModule is null", () => {
     render(<MobileBottomNav />);
 
-    expect(
-      screen.getByRole("navigation", { name: /primary/i }),
-    ).toBeInTheDocument();
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+
+    expect(nav).toBeInTheDocument();
+    expect(nav).toHaveClass("md:hidden");
     expect(screen.getByRole("button", { name: /^home$/i })).toHaveAttribute(
       "aria-current",
       "page",

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -27,7 +27,7 @@ export function MobileBottomNav() {
   return (
     <nav
       aria-label="Primary"
-      className="md:hidden shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 z-30"
+      className="shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 z-30"
     >
       <div
         className="grid grid-cols-6 gap-1 px-2 pt-2"

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -27,7 +27,7 @@ export function MobileBottomNav() {
   return (
     <nav
       aria-label="Primary"
-      className="sm:hidden shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 z-30"
+      className="md:hidden shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 z-30"
     >
       <div
         className="grid grid-cols-6 gap-1 px-2 pt-2"

--- a/src/components/shared/navigation-tabs.test.tsx
+++ b/src/components/shared/navigation-tabs.test.tsx
@@ -8,9 +8,9 @@ describe("NavigationTabs", () => {
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
   });
 
-  it("stays hidden until the desktop breakpoint", () => {
+  it("renders the desktop navigation rail", () => {
     render(<NavigationTabs />);
 
-    expect(screen.getByRole("navigation")).toHaveClass("hidden", "md:flex");
+    expect(screen.getByRole("navigation")).toHaveClass("flex", "w-20");
   });
 });

--- a/src/components/shared/navigation-tabs.test.tsx
+++ b/src/components/shared/navigation-tabs.test.tsx
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useAppStore } from "@/stores";
+import { render, screen } from "@/test/test-utils";
+import { NavigationTabs } from "./navigation-tabs";
+
+describe("NavigationTabs", () => {
+  beforeEach(() => {
+    useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
+  });
+
+  it("stays hidden until the desktop breakpoint", () => {
+    render(<NavigationTabs />);
+
+    expect(screen.getByRole("navigation")).toHaveClass("hidden", "md:flex");
+  });
+});

--- a/src/components/shared/navigation-tabs.tsx
+++ b/src/components/shared/navigation-tabs.tsx
@@ -24,7 +24,7 @@ export function NavigationTabs() {
   const setActiveModule = useAppStore((state) => state.setActiveModule);
 
   return (
-    <nav className="hidden md:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
+    <nav className="flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeModule === tab.id;

--- a/src/components/shared/navigation-tabs.tsx
+++ b/src/components/shared/navigation-tabs.tsx
@@ -24,7 +24,7 @@ export function NavigationTabs() {
   const setActiveModule = useAppStore((state) => state.setActiveModule);
 
   return (
-    <nav className="hidden sm:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
+    <nav className="hidden md:flex w-20 flex-col items-center gap-2 py-6 bg-card border-r border-border shrink-0">
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const isActive = activeModule === tab.id;

--- a/src/hooks/use-is-mobile.test.tsx
+++ b/src/hooks/use-is-mobile.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook } from "@/test/test-utils";
+import { useIsMobile } from "./use-is-mobile";
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => {
+    const maxWidth = Number.parseInt(
+      query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+    const minWidth = Number.parseInt(
+      query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+
+    const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+    const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+    const matches = matchesMax && matchesMin;
+
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  });
+}
+
+describe("useIsMobile", () => {
+  it("treats 768px as mobile", () => {
+    setViewportWidth(768);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("treats 769px as non-mobile", () => {
+    setViewportWidth(769);
+
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-const MOBILE_BREAKPOINT = 640; // Matches Tailwind's sm: breakpoint
+const MOBILE_BREAKPOINT = 768; // Matches the dashboard contract's mobile shell boundary
 
 /**
  * Hook to detect if the current viewport is mobile-sized.
@@ -9,11 +9,11 @@ const MOBILE_BREAKPOINT = 640; // Matches Tailwind's sm: breakpoint
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(() => {
     if (typeof window === "undefined") return false;
-    return window.innerWidth < MOBILE_BREAKPOINT;
+    return window.innerWidth <= MOBILE_BREAKPOINT;
   });
 
   useEffect(() => {
-    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
     const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
 
     setIsMobile(mq.matches);

--- a/src/index.css
+++ b/src/index.css
@@ -126,6 +126,40 @@
   background: oklch(0.75 0.02 85);
 }
 
+@keyframes home-breathing-pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+    transform: scale(0.92);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+@keyframes home-breathing-fade {
+  0%,
+  100% {
+    opacity: 0.28;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.5;
+    transform: translateY(-1px);
+  }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .motion-safe\:animate-home-breathing-pulse {
+    animation: home-breathing-pulse 2.2s ease-in-out infinite;
+  }
+
+  .motion-safe\:animate-home-breathing-fade {
+    animation: home-breathing-fade 2.8s ease-in-out infinite;
+  }
+}
+
 /* Reduce motion for accessibility and CI stability */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { useShallow } from "zustand/shallow";
 import type { CalendarEvent, CalendarViewType, FilterState } from "@/lib/types";
+import type { EventFormData } from "@/lib/validations";
 
 interface CalendarState {
   // Client-only state (server state is now in TanStack Query)
@@ -10,6 +11,7 @@ interface CalendarState {
   hasUserSetView: boolean; // Track if user explicitly changed view (for smart defaulting)
   filter: FilterState;
   isAddEventModalOpen: boolean;
+  addEventDefaults: Partial<EventFormData> | null;
 
   // Event detail modal state
   selectedEvent: CalendarEvent | null;
@@ -37,7 +39,7 @@ interface CalendarState {
   initializeSelectedMembers: (memberIds: string[]) => void;
 
   // Modal actions
-  openAddEventModal: () => void;
+  openAddEventModal: (defaultValues?: Partial<EventFormData>) => void;
   closeAddEventModal: () => void;
 
   // Detail modal actions
@@ -61,6 +63,7 @@ export const useCalendarStore = create<CalendarState>()(
         showAllDayEvents: true,
       },
       isAddEventModalOpen: false,
+      addEventDefaults: null,
 
       // Event detail modal state
       selectedEvent: null,
@@ -204,8 +207,13 @@ export const useCalendarStore = create<CalendarState>()(
       },
 
       // Modal actions
-      openAddEventModal: () => set({ isAddEventModalOpen: true }),
-      closeAddEventModal: () => set({ isAddEventModalOpen: false }),
+      openAddEventModal: (defaultValues) =>
+        set({
+          isAddEventModalOpen: true,
+          addEventDefaults: defaultValues ?? null,
+        }),
+      closeAddEventModal: () =>
+        set({ isAddEventModalOpen: false, addEventDefaults: null }),
 
       // Detail modal actions
       openDetailModal: (event) =>
@@ -276,6 +284,7 @@ export const useCalendarState = () =>
       calendarView: state.calendarView,
       filter: state.filter,
       isAddEventModalOpen: state.isAddEventModalOpen,
+      addEventDefaults: state.addEventDefaults,
     })),
   );
 

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -124,14 +124,30 @@ export const handlers = [
 
     let events = [...mockEvents];
 
-    // Apply date range filter (use parseLocalDate for consistent timezone handling)
-    if (startDate) {
-      const start = parseLocalDate(startDate);
-      events = events.filter((e) => parseLocalDate(e.date) >= start);
-    }
-    if (endDate) {
-      const end = parseLocalDate(endDate);
-      events = events.filter((e) => parseLocalDate(e.date) <= end);
+    // Apply date range overlap filtering to match the real backend.
+    // Multi-day all-day events should be returned when any part of the
+    // event overlaps the requested range, not only when the start date
+    // falls inside the range.
+    if (startDate || endDate) {
+      const rangeStart = startDate ? parseLocalDate(startDate) : null;
+      const rangeEnd = endDate ? parseLocalDate(endDate) : null;
+
+      events = events.filter((event) => {
+        const eventStart = parseLocalDate(event.date);
+        const eventEnd = event.endDate
+          ? parseLocalDate(event.endDate)
+          : eventStart;
+
+        if (rangeStart && eventEnd < rangeStart) {
+          return false;
+        }
+
+        if (rangeEnd && eventStart > rangeEnd) {
+          return false;
+        }
+
+        return true;
+      });
     }
 
     // Apply member filter

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -74,6 +74,7 @@ function resetAllStores(): void {
     hasUserSetView: false,
     filter: { selectedMembers: [], showAllDayEvents: true },
     isAddEventModalOpen: false,
+    addEventDefaults: null,
     selectedEvent: null,
     isDetailModalOpen: false,
     editingEvent: null,


### PR DESCRIPTION
## Summary
- replace the mobile Home launcher grid with the adult-first dashboard surface while keeping the existing shell state model
- add the dashboard hero, today list, coming up rail, single-focus member chips, and reused add-event flow on mobile Home
- align the mobile shell breakpoint to `<=768px` so Home stays mobile-only and desktop behavior continues to land on Calendar

## Non-negotiable contract map
- Adult-first mobile home redesign only: `src/components/home/home-dashboard.tsx` now renders the dashboard surface and `src/App.tsx` still redirects desktop `null` state to Calendar. Covered by `src/components/home/home-dashboard.test.tsx` and `src/App.shell.test.tsx`.
- Mobile-only at `<=768px`: `src/hooks/use-is-mobile.ts`, `src/components/shared/navigation-tabs.tsx`, and `src/components/shared/mobile-bottom-nav.tsx` were updated together. Covered by `src/hooks/use-is-mobile.test.tsx`, `src/components/shared/navigation-tabs.test.tsx`, `src/components/shared/mobile-bottom-nav.test.tsx`, `src/App.shell.test.tsx`, and the impacted calendar mobile tests.
- Replace the current 2-column launcher grid on mobile Home: the old launcher content is removed from `src/components/home/home-dashboard.tsx`. Covered by `src/components/home/home-dashboard.test.tsx` and `e2e/mobile-home-dashboard.spec.ts`.
- No module launcher tiles in the new dashboard: the new home surface is composed from `dashboard-header`, `member-chip-row`, `hero-card`, `today-list`, and `coming-up`. Covered by `src/components/home/home-dashboard.test.tsx` and `e2e/mobile-home-dashboard.spec.ts`.
- Keep navigation state-based through the existing mobile shell; no route-based redesign: the dashboard continues to live behind `activeModule === null` in `src/App.tsx`, and the bottom nav still toggles shell state. Covered by `src/App.shell.test.tsx`, `e2e/mobile-bottom-nav.spec.ts`, and `e2e/mobile-home-dashboard.spec.ts`.
- Use only the existing events query; no new backend endpoint and no duplicate fetch: `src/components/home/hooks/use-dashboard-events.ts` derives dashboard sections from `useCalendarEvents(range)` and reuses that single query result. Covered by `src/components/home/hooks/use-dashboard-events.test.tsx`.
- No dashboard-owned Google connect/sync UI in MVP: the dashboard surface does not render Google actions. Covered by `src/components/home/home-dashboard.test.tsx` and `e2e/mobile-home-dashboard.spec.ts`.
- Hero must support all five states and live-recompute across time boundaries: `src/components/home/lib/hero-state.ts`, `src/components/home/hooks/use-hero-state.ts`, and `src/components/home/components/hero-card.tsx`. Covered by `src/components/home/lib/hero-state.test.ts`, `src/components/home/hooks/use-hero-state.test.tsx`, and `src/components/home/components/hero-card.test.tsx`.
- Member chip focus is single-focus only and must filter Hero, Today, and Coming Up consistently: `src/components/home/components/member-chip-row.tsx` and `src/components/home/home-dashboard.tsx` wire the focus state through the shared dashboard query output. Covered by `src/components/home/components/member-chip-row.test.tsx`, `src/components/home/home-dashboard.test.tsx`, and `e2e/mobile-home-dashboard.spec.ts`.
- Desktop/non-mobile behavior must remain unchanged: `src/App.tsx` still routes desktop Home state back to Calendar and the desktop nav remains visible only above the mobile breakpoint. Covered by `src/App.shell.test.tsx`, `src/hooks/use-is-mobile.test.tsx`, and `src/components/shared/navigation-tabs.test.tsx`.
- Dashboard and calendar tab must not be visually confusable: Home now has its own header, hero, and section layout while Calendar keeps the existing calendar toolbar and views. Covered by `src/components/home/home-dashboard.test.tsx` and `e2e/mobile-bottom-nav.spec.ts` / `e2e/mobile-calendar.spec.ts`.

## Testing
- `npx @biomejs/biome check --config-path=biome.json src/components/home src/components/shared/navigation-tabs.test.tsx src/components/shared/navigation-tabs.tsx src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/mobile-bottom-nav.tsx src/hooks/use-is-mobile.test.tsx src/hooks/use-is-mobile.ts src/App.shell.test.tsx src/components/calendar/components/add-event-button.test.tsx src/components/calendar/components/event-form-modal.tsx src/components/calendar/views/schedule-calendar.test.tsx src/index.css src/stores/calendar-store.ts src/test/mocks/handlers.ts src/test/setup.ts e2e/helpers/api-helpers.ts e2e/helpers/test-helpers.ts e2e/mobile-bottom-nav.spec.ts e2e/mobile-home-dashboard.spec.ts`
- `npm run test -- --run`
- `npm run build`
- Updated Playwright coverage in `e2e/mobile-home-dashboard.spec.ts`, `e2e/mobile-bottom-nav.spec.ts`, and shared helpers. Full auth-backed local Playwright execution is still environment-dependent here because Docker Desktop was not running, so `docker compose -f docker-compose.e2e.yml up -d --wait` could not be started in this workspace.

Closes #149