### PR TITLE
fix: force-ignore frontend .worktrees in Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -66,7 +66,8 @@
       "!!node_modules",
       "!!.husky",
       "!!coverage",
-      "!!test-results"
+      "!!test-results",
+      "!!.worktrees"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add `!!.worktrees` to `frontend/biome.json` `files.includes`
- force-ignore nested worktree configs so `biome check .` does not descend into `frontend/.worktrees/*/biome.json`
- keep deploy behavior and runtime/UI behavior unchanged

## Verification
- `npm run lint`
  - `Checked 239 files in 98ms. No fixes applied.`
- replayed the old config against the same checkout with a temporary ignored `.worktrees/lint-fixture/biome.json`
  - old config failed with `Found a nested root configuration, but there's already a root configuration.`
  - new config passed via `npm run lint`

## Why this works
Biome's scanner treats nested `biome.json` files specially, so a normal ignore is not enough. The documented `!!` force-ignore pattern prevents scanner traversal into `.worktrees`, which stops nested worktree `biome.json` files from being discovered during deploy linting.