### PR TITLE
feat: add recipes frontend foundation

### DIFF
--- a/docs/superpowers/plans/2026-06-04-recipes-frontend-foundation.md
+++ b/docs/superpowers/plans/2026-06-04-recipes-frontend-foundation.md
@@ -233,7 +233,8 @@ Add tests covering:
 - Search matches recipe title and tags.
 - Favorites filter shows favorites and keeps favorites first in search/picker-style results.
 - Tag filter stays lightweight and mobile-friendly.
-- Opening a card switches to detail mode by recipe id, while detail implementation can still be minimal until Task 5.
+- Library cards are visible browse results without unfinished detail navigation until Task 5.
+- No nonfunctional `Add recipe` control is rendered until the real add flow lands in Task 4.
 
 Run:
 
@@ -247,7 +248,7 @@ Expected: FAIL because library UI does not exist.
 
 Build a mobile-first library screen with:
 
-- Header: `Recipes` and `Add recipe` button.
+- Header: `Recipes` with discovery copy.
 - Search input.
 - Favorites toggle.
 - Tag filter chips derived from recipe summaries.
@@ -265,7 +266,7 @@ Run:
 env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx
 ```
 
-Expected: PASS for library states, favorites, search, tags, and card-open behavior.
+Expected: PASS for library states, favorites, search, tags, normalized tag filtering, and no unfinished create/detail controls.
 
 Commit:
 

--- a/docs/superpowers/plans/2026-06-04-recipes-frontend-foundation.md
+++ b/docs/superpowers/plans/2026-06-04-recipes-frontend-foundation.md
@@ -1,0 +1,588 @@
+# Recipes Frontend Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the frontend Recipes foundation for FamilyHub issue #183: standalone Recipes module, released `/api/recipes` contract integration, mobile-first recipe library/detail/create/edit/import UX, and shared Recipes/Meals handoff state without building Meals.
+
+**Architecture:** Keep server state in `src/api`, reusable data shapes in `src/lib/types`, validation in `src/lib/validations`, UI state in Zustand `app-store`, and Recipes UI in `src/components/recipes/`. The UI remains mobile-first and cook-first, while shared Meals handoff state is intentionally thin and owned by the app shell until the follow-on Meals frontend issue consumes it.
+
+**Tech Stack:** React 19, TypeScript, Vite, Tailwind CSS v4, shadcn/Radix-style local UI primitives, TanStack Query, React Hook Form, Zod, MSW, Vitest, Playwright.
+
+---
+
+## Released Backend Contract
+
+Read from `family-hub-api v1.5.0`.
+
+- `GET /api/recipes` -> `ApiResponse<RecipeSummaryResponse[]>`
+- `GET /api/recipes/{id}` -> `ApiResponse<RecipeDetailResponse>`
+- `POST /api/recipes` -> `ApiResponse<RecipeDetailResponse>`
+- `PATCH /api/recipes/{id}` -> `ApiResponse<RecipeDetailResponse>`
+- `POST /api/recipes/import` with `{ url: string }` -> `ApiResponse<RecipeDetailResponse>`
+
+Frontend response fields:
+
+```ts
+export interface RecipeSummary {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  favorite: boolean;
+  tags: string[];
+  updatedAt: string;
+}
+
+export interface RecipeDetail extends RecipeSummary {
+  ingredients: string[];
+  instructions: string[];
+  note: string | null;
+  sourceUrl: string | null;
+}
+```
+
+Frontend request fields:
+
+```ts
+export interface CreateRecipeRequest {
+  title: string;
+  imageUrl?: string | null;
+  ingredients?: string[];
+  instructions?: string[];
+  note?: string | null;
+  sourceUrl?: string | null;
+  tags?: string[];
+  favorite?: boolean;
+}
+
+export interface UpdateRecipeRequest {
+  title?: string;
+  imageUrl?: string | null;
+  ingredients?: string[];
+  instructions?: string[];
+  note?: string | null;
+  sourceUrl?: string | null;
+  tags?: string[];
+  favorite?: boolean;
+}
+```
+
+## Task 1: Frontend Recipe Contract Layer
+
+**Files:**
+- Create: `src/lib/types/recipes.ts`
+- Modify: `src/lib/types/index.ts`
+- Create: `src/api/services/recipes.service.ts`
+- Modify: `src/api/services/index.ts`
+- Create: `src/api/hooks/use-recipes.ts`
+- Modify: `src/api/hooks/index.ts`
+- Modify: `src/api/index.ts`
+- Create: `src/lib/validations/recipes.ts`
+- Modify: `src/lib/validations/index.ts`
+- Create: `src/lib/validations/recipes.test.ts`
+- Create: `src/test/fixtures/recipes.ts`
+- Modify: `src/test/mocks/handlers.ts`
+- Modify: `src/test/mocks/server.ts`
+- Create: `src/api/hooks/use-recipes.test.tsx`
+
+- [ ] **Step 1: Write failing contract and validation tests**
+
+Add tests covering:
+
+- `useRecipes` loads summary data from MSW.
+- `useRecipe` loads detail data.
+- `useCreateRecipe` seeds detail cache and invalidates the library query.
+- `useUpdateRecipe` updates detail cache and invalidates the library query.
+- `useImportRecipe` posts `{ url }`, auto-saves by receiving created detail, seeds detail cache, invalidates the library query, and surfaces import errors.
+- `recipeFormSchema` requires a nonblank title.
+- Optional image URL, note, source URL, ingredients, instructions, tags, and favorite normalize to API-ready values.
+- Ordered ingredients, instructions, and tags are preserved.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/api/hooks/use-recipes.test.tsx src/lib/validations/recipes.test.ts
+```
+
+Expected: FAIL because recipe hooks, service, fixtures, and schema do not exist.
+
+- [ ] **Step 2: Implement the contract layer**
+
+Use `httpClient` paths without `/api` prefix, matching existing services:
+
+```ts
+export const recipesService = {
+  getRecipes: () => httpClient.get<RecipesApiResponse>("/recipes"),
+  getRecipe: (id: string) =>
+    httpClient.get<RecipeDetailApiResponse>(`/recipes/${id}`),
+  createRecipe: (request: CreateRecipeRequest) =>
+    httpClient.post<RecipeDetailApiResponse>("/recipes", request),
+  updateRecipe: (id: string, request: UpdateRecipeRequest) =>
+    httpClient.patch<RecipeDetailApiResponse>(`/recipes/${id}`, request),
+  importRecipe: (url: string) =>
+    httpClient.post<RecipeDetailApiResponse>("/recipes/import", { url }),
+};
+```
+
+Add `recipesKeys` with `list()` and `detail(id)`. On create/update/import success, set detail cache and invalidate list. On update, keep the implementation conservative rather than optimistic.
+
+Validation rules:
+
+- `title`: trimmed, 1-160 chars.
+- `imageUrl` and `sourceUrl`: optional empty string -> `null`, otherwise valid URL.
+- `ingredients`: trim, remove blank rows, preserve order, max 500 chars each.
+- `instructions`: trim, remove blank rows, preserve order.
+- `tags`: trim, remove blank rows, preserve order, max 60 chars each.
+- `note`: optional empty string -> `null`.
+- `favorite`: default `false`.
+
+MSW handlers must keep in-memory recipe data, reset between tests, support list/detail/create/patch/import, and return a 400-style import failure for a known bad URL.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/api/hooks/use-recipes.test.tsx src/lib/validations/recipes.test.ts
+```
+
+Expected: PASS for recipe query/mutation/cache behavior, validation, ordered fields, and error handling.
+
+Commit:
+
+```bash
+git add src/lib/types/recipes.ts src/lib/types/index.ts src/api/services/recipes.service.ts src/api/services/index.ts src/api/hooks/use-recipes.ts src/api/hooks/index.ts src/api/index.ts src/lib/validations/recipes.ts src/lib/validations/index.ts src/lib/validations/recipes.test.ts src/test/fixtures/recipes.ts src/test/mocks/handlers.ts src/test/mocks/server.ts src/api/hooks/use-recipes.test.tsx
+git commit -m "feat(recipes): add frontend recipe contracts"
+```
+
+## Task 2: Shell Registration And Navigation
+
+**Files:**
+- Modify: `src/App.tsx`
+- Modify: `src/stores/app-store.ts`
+- Modify: `src/components/shared/mobile-bottom-nav.tsx`
+- Modify: `src/components/shared/navigation-tabs.tsx`
+- Modify: `src/components/shared/mobile-bottom-nav.test.tsx`
+- Modify: `src/components/shared/navigation-tabs.test.tsx`
+- Create: `src/components/recipes-view.tsx` with temporary minimal shell content only if needed for route rendering
+
+- [ ] **Step 1: Write failing shell/navigation tests**
+
+Add tests covering:
+
+- `ModuleType` accepts `recipes`.
+- Desktop navigation includes `Recipes` and keeps `Meals`.
+- Mobile bottom nav includes `Recipes` and keeps `Meals`.
+- Mobile bottom nav remains readable/tappable with seven destinations; use a horizontally scrollable or otherwise stable layout instead of squeezing text into an unreadable seven-column grid.
+- `App` renders the Recipes module when `activeModule` is `recipes`.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx src/App.shell.test.tsx
+```
+
+Expected: FAIL because `recipes` is not registered.
+
+- [ ] **Step 2: Implement shell registration**
+
+Add `recipes` to `ModuleType`, lazy-load `RecipesView`, register the `recipes` render branch, and add a `BookOpenText` icon destination in desktop and mobile navigation.
+
+For mobile bottom nav, keep stable touch targets and readable labels. Prefer:
+
+```tsx
+<div className="flex gap-1 overflow-x-auto px-2 pt-2">
+  <button className="flex min-h-14 min-w-[64px] flex-1 flex-col ..." />
+</div>
+```
+
+Do not remove `Meals`.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx src/App.shell.test.tsx
+```
+
+Expected: PASS for shell registration and navigation readability coverage.
+
+Commit:
+
+```bash
+git add src/App.tsx src/stores/app-store.ts src/components/shared/mobile-bottom-nav.tsx src/components/shared/navigation-tabs.tsx src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx src/App.shell.test.tsx src/components/recipes-view.tsx
+git commit -m "feat(recipes): register recipes module"
+```
+
+## Task 3: Recipe Library And Lightweight Discovery
+
+**Files:**
+- Replace/minimally expand: `src/components/recipes-view.tsx`
+- Create: `src/components/recipes/recipe-library-card.tsx`
+- Create: `src/components/recipes/recipe-filter-bar.tsx`
+- Create: `src/components/recipes-view.test.tsx`
+
+- [ ] **Step 1: Write failing library tests**
+
+Add tests covering:
+
+- Loading state.
+- Error state with retry.
+- Empty state invites adding the first recipe.
+- Summary cards render image/title/tags/favorite state.
+- Search matches recipe title and tags.
+- Favorites filter shows favorites and keeps favorites first in search/picker-style results.
+- Tag filter stays lightweight and mobile-friendly.
+- Opening a card switches to detail mode by recipe id, while detail implementation can still be minimal until Task 5.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx
+```
+
+Expected: FAIL because library UI does not exist.
+
+- [ ] **Step 2: Implement library UI**
+
+Build a mobile-first library screen with:
+
+- Header: `Recipes` and `Add recipe` button.
+- Search input.
+- Favorites toggle.
+- Tag filter chips derived from recipe summaries.
+- Visual recipe cards using image when present and a calm fallback when absent.
+- Empty/loading/error/filtered-empty states.
+- `buildVisibleRecipes(recipes, filters)` helper exported for focused tests if useful.
+
+Use `cn()` for class merging and existing UI primitives.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx
+```
+
+Expected: PASS for library states, favorites, search, tags, and card-open behavior.
+
+Commit:
+
+```bash
+git add src/components/recipes-view.tsx src/components/recipes/recipe-library-card.tsx src/components/recipes/recipe-filter-bar.tsx src/components/recipes-view.test.tsx
+git commit -m "feat(recipes): add recipe library"
+```
+
+## Task 4: Manual Create And URL Import Add Flow
+
+**Files:**
+- Modify: `src/components/recipes-view.tsx`
+- Create: `src/components/recipes/recipe-form.tsx`
+- Create: `src/components/recipes/recipe-create-sheet.tsx`
+- Create: `src/components/recipes/recipe-import-sheet.tsx`
+- Modify: `src/components/recipes-view.test.tsx`
+
+- [ ] **Step 1: Write failing add-flow tests**
+
+Add tests covering:
+
+- `Add recipe` opens a single add flow with choices `Create manually` and `Import from URL`.
+- URL import is not visible as a peer action on the library home.
+- Manual creation can submit title-only.
+- Manual creation preserves ordered ingredients, instructions, and tags.
+- Successful manual creation lands in recipe detail.
+- Import posts the URL, successful import auto-saves, closes the add/import sheet, and lands in recipe detail.
+- Import failure shows a clear error and does not create a partial local recipe.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx src/lib/validations/recipes.test.ts
+```
+
+Expected: FAIL because create/import UI does not exist.
+
+- [ ] **Step 2: Implement add flow**
+
+Build:
+
+- `RecipeForm`: shared ordered fields with add/remove controls for ingredients, instructions, and tags.
+- `RecipeCreateSheet`: add-flow sheet with mode selection and manual form.
+- `RecipeImportSheet` or nested import mode inside create sheet: URL input, import mutation, error display.
+
+Keep URL import inside add flow. On create/import success:
+
+- Close sheet.
+- Select created/imported recipe id.
+- Let detail query/cache display the saved recipe.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx src/lib/validations/recipes.test.ts
+```
+
+Expected: PASS for manual create, ordered fields, import auto-save, import error, and URL import placement.
+
+Commit:
+
+```bash
+git add src/components/recipes-view.tsx src/components/recipes/recipe-form.tsx src/components/recipes/recipe-create-sheet.tsx src/components/recipes/recipe-import-sheet.tsx src/components/recipes-view.test.tsx src/lib/validations/recipes.test.ts
+git commit -m "feat(recipes): add recipe create and import flows"
+```
+
+## Task 5: Cook-First Detail, Edit, And Favorite
+
+**Files:**
+- Create: `src/components/recipes/recipe-detail-view.tsx`
+- Create: `src/components/recipes/recipe-edit-sheet.tsx`
+- Modify: `src/components/recipes-view.tsx`
+- Modify: `src/components/recipes-view.test.tsx`
+
+- [ ] **Step 1: Write failing detail/edit/favorite tests**
+
+Add tests covering:
+
+- Detail renders image, title, ingredients, and instructions before action controls in DOM order.
+- Detail handles missing optional image/ingredients/instructions gracefully.
+- Favorite toggle patches saved recipe state and updates visible detail state.
+- Edit opens saved recipe form with existing values.
+- Save changes patches fields and keeps ordered ingredients/instructions/tags.
+- Back returns to library.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx
+```
+
+Expected: FAIL because full detail/edit/favorite UI does not exist.
+
+- [ ] **Step 2: Implement cook-first detail**
+
+Build detail in this order:
+
+1. Image or visual fallback.
+2. Title and tags/source metadata.
+3. Ingredients.
+4. Instructions.
+5. Note.
+6. Secondary actions area with `Favorite`, `Edit`, and `Add to Meals` placeholder that Task 6 wires.
+
+Use `useUpdateRecipe` for favorite toggle and edit save. Convert a loaded `RecipeDetail` to an update request without losing ordered arrays.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx
+```
+
+Expected: PASS for cook-first detail, favorite, edit, and back navigation.
+
+Commit:
+
+```bash
+git add src/components/recipes/recipe-detail-view.tsx src/components/recipes/recipe-edit-sheet.tsx src/components/recipes-view.tsx src/components/recipes-view.test.tsx
+git commit -m "feat(recipes): add cook-first recipe detail"
+```
+
+## Task 6: Shared Recipes/Meals Handoff And Sunday Week Start
+
+**Files:**
+- Modify: `src/stores/app-store.ts`
+- Modify: `src/stores/index.ts`
+- Modify: `src/test/setup.ts`
+- Modify: `src/lib/time-utils.ts`
+- Modify: `src/lib/time-utils.test.ts`
+- Modify: `src/components/recipes-view.tsx`
+- Modify: `src/components/recipes/recipe-detail-view.tsx`
+- Modify: `src/components/recipes-view.test.tsx`
+
+- [ ] **Step 1: Write failing handoff and time tests**
+
+Add tests covering:
+
+- `getWeekStartSunday(new Date(2026, 5, 10))` formats to `2026-06-07`.
+- `getWeekStartSunday` returns the same local date when given a Sunday.
+- `Add to Meals` on recipe detail sets `mealPlacementDraft`, switches active module to `meals`, and uses source `{ kind: "recipes-library" }`.
+- A `recipeCreationDraft` with lowercase `mealType: "breakfast" | "lunch" | "dinner"` opens the Recipes add flow prefilled from `typedTitle`.
+- Creating a recipe from that draft switches back to `meals` and creates a `mealPlacementDraft` with source `{ kind: "meals-slot", dayIndex, mealType }`.
+- Test setup resets new draft store fields.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx src/lib/time-utils.test.ts src/stores/app-store.test.ts
+```
+
+Expected: FAIL because handoff state and Sunday helper do not exist.
+
+- [ ] **Step 2: Implement handoff state and helper**
+
+Add:
+
+```ts
+export type MealType = "breakfast" | "lunch" | "dinner";
+
+export interface MealPlacementDraft {
+  recipeId: string;
+  requestedAtWeekStartDate: string;
+  source:
+    | { kind: "recipes-library" }
+    | { kind: "meals-slot"; dayIndex: number; mealType: MealType };
+}
+
+export interface RecipeCreationDraft {
+  requestedAtWeekStartDate: string;
+  dayIndex: number;
+  mealType: MealType;
+  typedTitle: string;
+}
+```
+
+Store actions:
+
+- `startMealPlacementFromRecipe(draft)` sets draft and `activeModule: "meals"`.
+- `consumeMealPlacementDraft()` returns and clears the draft.
+- `startRecipeCreationFromMealSlot(draft)` sets draft and `activeModule: "recipes"`.
+- `consumeRecipeCreationDraft()` returns and clears the draft.
+
+Time helper:
+
+```ts
+export function getWeekStartSunday(date: Date): Date {
+  const start = startOfDay(date);
+  start.setDate(start.getDate() - start.getDay());
+  return start;
+}
+```
+
+Wire `Add to Meals` in detail using `formatLocalDate(getWeekStartSunday(new Date()))`.
+
+When Recipes view sees `recipeCreationDraft`, open manual create prefilled with `typedTitle`. On successful create/import started from Meals, consume the draft and start a `meals-slot` placement draft. Do not build any slot picker, board, collision UI, or persistence.
+
+- [ ] **Step 3: Verify and commit**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/components/recipes-view.test.tsx src/lib/time-utils.test.ts src/stores/app-store.test.ts
+```
+
+Expected: PASS for Sunday helper and both handoff directions, with lowercase meal types.
+
+Commit:
+
+```bash
+git add src/stores/app-store.ts src/stores/index.ts src/test/setup.ts src/lib/time-utils.ts src/lib/time-utils.test.ts src/components/recipes-view.tsx src/components/recipes/recipe-detail-view.tsx src/components/recipes-view.test.tsx
+git commit -m "feat(recipes): add meals handoff draft"
+```
+
+## Task 7: Mobile Recipe E2E And Final Verification
+
+**Files:**
+- Create: `e2e/mobile-recipes.spec.ts`
+- Read/modify as needed: `e2e/helpers/*`
+- Modify only if needed: recipe UI selectors from earlier tasks
+
+- [ ] **Step 1: Write mobile recipe E2E**
+
+Cover:
+
+- Navigate to Recipes from mobile bottom nav.
+- Empty or seeded library renders.
+- Add recipe opens create flow.
+- Manual title-only create lands in detail.
+- URL import is reachable inside add flow and successful import lands in detail.
+- Favorite toggle works on detail.
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run test:e2e -- e2e/mobile-recipes.spec.ts
+```
+
+Expected:
+
+- PASS if local backend test environment is available and points to `family-hub-api v1.5.0` or newer.
+- If the environment is unavailable, record the blocker and keep MSW/unit coverage as the completed frontend verification.
+
+- [ ] **Step 2: Run focused issue verification**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/api/hooks/use-recipes.test.tsx src/lib/validations/recipes.test.ts src/components/recipes-view.test.tsx src/lib/time-utils.test.ts src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader frontend verification required by `AGENTS.md`**
+
+Run:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build
+```
+
+Expected: PASS for lint, Vitest, and production build.
+
+- [ ] **Step 4: Final review and commit**
+
+Use `superpowers:verification-before-completion` before any completion claim.
+
+Use `superpowers:requesting-code-review` for final review. Fix Critical and Important findings in scope.
+
+Commit:
+
+```bash
+git add e2e/mobile-recipes.spec.ts
+git commit -m "test(recipes): add mobile recipe coverage"
+```
+
+If review fixes are needed, commit them separately:
+
+```bash
+git add <review-fix-files>
+git commit -m "fix(recipes): address recipes review findings"
+```
+
+## Task 8: PR Handoff
+
+**Files:**
+- No code changes unless the final checklist reveals a gap.
+
+- [ ] **Step 1: Build final issue-contract checklist**
+
+Map every issue execution-contract bullet to code and tests in the final response and PR body.
+
+- [ ] **Step 2: Push and open PR**
+
+Use `superpowers:finishing-a-development-branch`.
+
+Run:
+
+```bash
+git status --short
+git push -u origin codex/recipes-frontend
+gh pr create --repo joe-bor/FamilyHub --base main --head codex/recipes-frontend --title "feat: add recipes frontend foundation" --body-file <prepared-pr-body>
+```
+
+Expected: PR opens against `joe-bor/FamilyHub` with `Closes #183`.
+
+## Scope Guardrails
+
+- Do not implement Meals board UI.
+- Do not implement Meals composer.
+- Do not implement meal persistence or meal snapshot behavior.
+- Do not implement collision UX.
+- Do not implement grocery/list generation or pantry features.
+- Do not edit backend or root production code.
+- Stop and report if a Recipes/Meals contract gap appears.

--- a/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
+++ b/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
@@ -56,3 +56,51 @@ Notes:
 ## Task 3 Scope Refinement
 
 Task 3 code review found that disabled `Add recipe` controls and selected-recipe placeholder navigation made the library slice look interactive before the real add/detail flows existed. The plan is refined so Task 3 remains discovery-only: cards render as browseable articles, Task 4 owns the functional `Add recipe` flow, and Task 5 owns card-to-detail navigation.
+
+## Final Verification Notes
+
+Run from isolated worktree `/Users/joe.bor/code/family-hub/frontend/.worktrees/codex/recipes-frontend` with bundled Node after commit `d5cb0d1` on 2026-06-05:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/api/hooks/use-recipes.test.tsx src/lib/validations/recipes.test.ts src/components/recipes-view.test.tsx src/lib/time-utils.test.ts src/stores/app-store.test.ts src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx src/App.shell.test.tsx
+```
+
+Observed result: 8 test files passed, 153 tests passed.
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint
+```
+
+Observed result: exit 0; existing Biome schema-version informational note only.
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run
+```
+
+Observed result: 61 test files passed, 769 tests passed.
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build
+```
+
+Observed result: exit 0; existing bundle-size and Browserslist freshness warnings only.
+
+Backend release check:
+
+```bash
+gh api repos/joe-bor/family-hub-api/releases/latest --jq '{tag:.tag_name,name:.name,published:.published_at}'
+```
+
+Observed result: `family-hub-api` latest release is `v1.5.0`, published 2026-06-04T19:06:25Z.
+
+Real-backend recipe E2E status:
+
+- `docker info` could not reach the Docker daemon.
+- Focused Playwright runs could not complete locally because browser binaries were missing after the dev-server sandbox issue was bypassed.
+- `e2e/mobile-recipes.spec.ts` was added for the mobile recipe flow. Successful URL-import auto-save is covered by MSW-backed component and hook tests; real-backend recipe E2E should run once the local backend/browser environment is available on `family-hub-api v1.5.0` or newer.
+
+Code review status:
+
+- A `gpt-5.4` review found Important issues in recipe metadata editing, mobile nav readability, detail error recovery, and array validation messages.
+- Those findings were fixed in `d5cb0d1`.
+- A second final review attempt was unavailable because the subagent errored with the environment usage-limit message. The errored agent was closed.

--- a/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
+++ b/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
@@ -52,3 +52,7 @@ Notes:
 - The issue narrows the root plan to frontend Tasks 3-5, plus Recipes-owned review from Task 6.
 - Backend `v1.5.0` exposes `GET /api/recipes`, `GET /api/recipes/{id}`, `POST /api/recipes`, `PATCH /api/recipes/{id}`, and `POST /api/recipes/import`, wrapped in `ApiResponse`.
 - Backend `v1.5.0` recipe DTOs expose `title`, `imageUrl`, ordered `ingredients`, ordered `instructions`, `note`, `sourceUrl`, ordered `tags`, `favorite`, and `updatedAt`; `id` is returned on summary/detail responses.
+
+## Task 3 Scope Refinement
+
+Task 3 code review found that disabled `Add recipe` controls and selected-recipe placeholder navigation made the library slice look interactive before the real add/detail flows existed. The plan is refined so Task 3 remains discovery-only: cards render as browseable articles, Task 4 owns the functional `Add recipe` flow, and Task 5 owns card-to-detail navigation.

--- a/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
+++ b/docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md
@@ -1,0 +1,54 @@
+# Recipes Frontend Foundation Work Log
+
+## Source Artifacts Read Before Coding
+
+- `frontend/AGENTS.md`
+- FamilyHub issue #183, "Implement Recipes frontend foundation"
+- Story: `docs/product/backlog/module-foundations/module-surface-foundations.md`
+- Spec: `docs/superpowers/specs/2026-06-01-meals-and-recipes-foundation-design.md`
+- Root plan: `docs/superpowers/plans/2026-06-01-recipes-module-foundation.md`
+- Released backend contract: `family-hub-api` `v1.5.0`, including release metadata and the tagged recipe controller/DTO files
+
+## Baseline Verification
+
+Run from isolated worktree `/Users/joe.bor/code/family-hub/frontend/.worktrees/codex/recipes-frontend` with bundled Node on 2026-06-04:
+
+```bash
+env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run
+```
+
+Observed result: 58 test files passed, 722 tests passed.
+
+## Non-Negotiable Execution Contract
+
+- Work only in `frontend`.
+- Use branch `codex/recipes-frontend`.
+- Keep implementation scoped to Recipes frontend only.
+- Add `Recipes` as a standalone top-level module; do not hide recipe behavior inside `Meals`.
+- Keep `Meals` as a separate module destination and preserve mobile bottom-nav readability after adding `Recipes`.
+- Consume the released backend contract `family-hub-api v1.5.0` or newer for real `/api/recipes` verification. Do not depend on unreleased backend `main`.
+- Implement frontend `/api/recipes` types, services, hooks, validation, fixtures, and MSW handlers against the released backend fields and endpoints.
+- Manual recipe creation requires only a nonblank title. Image URL, ingredients, instructions, note, source URL, tags, and favorite are optional.
+- Preserve ordered ingredients, ordered instructions, and ordered tags in form state and API payloads.
+- Keep URL import inside the add flow. It is not a peer library-home action.
+- Successful URL imports auto-save and then land in recipe detail.
+- Recipe detail is cook-first: image, title, ingredients, instructions first. `Favorite`, `Edit`, and `Add to Meals` must be reachable without overtaking cooking content.
+- Favorites are editable saved-recipe state and must matter in search/pickers.
+- Tags and filters stay lightweight and mobile-friendly.
+- Add shared handoff state for both directions:
+  - `Recipes -> Meals`: saved recipe creates a meal-placement draft and switches to `Meals`.
+  - `Meals -> Recipes -> back to Meals`: recipe creation can start from a meal slot draft and return to planning context.
+- Shared meal type values must stay lowercase: `breakfast`, `lunch`, `dinner`.
+- Add the Sunday week-start helper in shared frontend utilities for later Meals consumption.
+- Do not implement the Meals board, composer, collision UX, meal persistence, meal snapshot behavior, grocery/list generation, pantry management, backend code, or production code outside the frontend repo.
+- If the issue, story, spec, root plan, or released backend contract disagree, stop and report the drift before coding.
+
+## Contract Drift Check
+
+No blocking drift found before implementation.
+
+Notes:
+
+- The issue narrows the root plan to frontend Tasks 3-5, plus Recipes-owned review from Task 6.
+- Backend `v1.5.0` exposes `GET /api/recipes`, `GET /api/recipes/{id}`, `POST /api/recipes`, `PATCH /api/recipes/{id}`, and `POST /api/recipes/import`, wrapped in `ApiResponse`.
+- Backend `v1.5.0` recipe DTOs expose `title`, `imageUrl`, ordered `ingredients`, ordered `instructions`, `note`, `sourceUrl`, ordered `tags`, `favorite`, and `updatedAt`; `id` is returned on summary/detail responses.

--- a/e2e/mobile-recipes.spec.ts
+++ b/e2e/mobile-recipes.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+test.describe("Mobile Recipes", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("creates a recipe, favorites it, filters the library, and keeps URL import in the add flow", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "Recipes E2E Family",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    const nav = page.getByRole("navigation", { name: /primary/i });
+    await safeClick(nav.getByRole("button", { name: "Recipes" }));
+
+    await expect(
+      page.getByRole("heading", { name: "Recipes", level: 1 }),
+    ).toBeVisible();
+    await expect(page.getByText("No recipes yet")).toBeVisible();
+
+    await page.getByRole("button", { name: "Add recipe" }).click();
+    const addDialog = page.getByRole("dialog", { name: "Add Recipe" });
+    await expect(addDialog).toBeVisible();
+    await addDialog.getByRole("button", { name: "Create manually" }).click();
+
+    const createDialog = page.getByRole("dialog", { name: "Create Recipe" });
+    await expect(createDialog).toBeVisible();
+    await createDialog.getByLabel("Title").fill("Sunday Pancakes");
+    await createDialog.getByLabel("Ingredient 1").fill("1 cup flour");
+    await createDialog.getByLabel("Instruction 1").fill("Whisk and griddle");
+    await createDialog.getByLabel("Tag 1").fill("Breakfast");
+    await createDialog.getByRole("button", { name: "Save recipe" }).click();
+
+    await expect(createDialog).toBeHidden();
+    await expect(
+      page.getByRole("heading", { name: "Sunday Pancakes" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Ingredients" }),
+    ).toBeVisible();
+    await expect(page.getByText("1 cup flour")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Instructions" }),
+    ).toBeVisible();
+    await expect(page.getByText("Whisk and griddle")).toBeVisible();
+
+    const favoriteButton = page.getByRole("button", {
+      name: "Favorite recipe: Sunday Pancakes",
+    });
+    await expect(favoriteButton).toHaveAttribute("aria-pressed", "false");
+    await favoriteButton.click();
+    await expect(favoriteButton).toHaveAttribute("aria-pressed", "true");
+
+    await page.getByRole("button", { name: "Back to recipes" }).click();
+    await expect(
+      page.getByRole("button", { name: "Open recipe: Sunday Pancakes" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Search recipes").fill("breakfast");
+    await expect(
+      page.getByRole("button", { name: "Open recipe: Sunday Pancakes" }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Favorites only" }).click();
+    await expect(
+      page.getByRole("button", { name: "Open recipe: Sunday Pancakes" }),
+    ).toBeVisible();
+
+    await page.getByLabel("Search recipes").clear();
+    await page.getByRole("button", { name: "Add recipe" }).click();
+    const secondAddDialog = page.getByRole("dialog", { name: "Add Recipe" });
+    await expect(secondAddDialog).toBeVisible();
+    await secondAddDialog
+      .getByRole("button", { name: "Import from URL" })
+      .click();
+
+    const importDialog = page.getByRole("dialog", { name: "Import Recipe" });
+    await expect(importDialog).toBeVisible();
+    await importDialog.getByLabel("Recipe URL").fill("not-a-url");
+    await importDialog.getByRole("button", { name: "Import recipe" }).click();
+    await expect(importDialog.getByText("Enter a valid URL")).toBeVisible();
+  });
+});

--- a/e2e/mobile-recipes.spec.ts
+++ b/e2e/mobile-recipes.spec.ts
@@ -7,6 +7,9 @@ import {
 } from "./helpers/test-helpers";
 
 test.describe("Mobile Recipes", () => {
+  const IMPORTABLE_RECIPE_URL =
+    "https://www.loveandlemons.com/pancakes-recipe/";
+
   test.beforeEach(async ({ page, isMobile }) => {
     test.skip(!isMobile, "Mobile-only tests");
 
@@ -14,10 +17,12 @@ test.describe("Mobile Recipes", () => {
     await clearStorage(page);
   });
 
-  test("creates a recipe, favorites it, filters the library, and keeps URL import in the add flow", async ({
+  test("creates a recipe, favorites it, filters the library, and imports from URL inside the add flow", async ({
     page,
     request,
   }) => {
+    test.setTimeout(60000);
+
     const registration = await registerFamily(request, {
       familyName: "Recipes E2E Family",
       members: [{ name: "Sam", color: "teal" }],
@@ -95,5 +100,16 @@ test.describe("Mobile Recipes", () => {
     await importDialog.getByLabel("Recipe URL").fill("not-a-url");
     await importDialog.getByRole("button", { name: "Import recipe" }).click();
     await expect(importDialog.getByText("Enter a valid URL")).toBeVisible();
+
+    await importDialog.getByLabel("Recipe URL").fill(IMPORTABLE_RECIPE_URL);
+    await importDialog.getByRole("button", { name: "Import recipe" }).click();
+
+    await expect(importDialog).toBeHidden({ timeout: 30000 });
+    await expect(
+      page.getByRole("heading", { name: /pancakes/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Back to recipes" }),
+    ).toBeVisible();
   });
 });

--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -106,6 +106,17 @@ describe("App shell", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders the Recipes module when recipes is active", async () => {
+    setViewportWidth(769);
+    useAppStore.setState({ activeModule: "recipes", isSidebarOpen: false });
+
+    render(<FamilyHub />);
+
+    expect(
+      await screen.findByRole("heading", { name: /^recipes$/i }),
+    ).toBeInTheDocument();
+  });
+
   it("does not render bottom nav on login screen", async () => {
     setViewportWidth(768);
     seedAuthStore({ isAuthenticated: false });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,11 @@ const ChoresView = lazy(() =>
 const MealsView = lazy(() =>
   import("@/components/meals-view").then((m) => ({ default: m.MealsView })),
 );
+const RecipesView = lazy(() =>
+  import("@/components/recipes-view").then((m) => ({
+    default: m.RecipesView,
+  })),
+);
 const ListsView = lazy(() =>
   import("@/components/lists-view").then((m) => ({ default: m.ListsView })),
 );
@@ -66,6 +71,12 @@ function renderModule(activeModule: ModuleType | null) {
       return (
         <Suspense fallback={<ModuleLoader />}>
           <MealsView />
+        </Suspense>
+      );
+    case "recipes":
+      return (
+        <Suspense fallback={<ModuleLoader />}>
+          <RecipesView />
         </Suspense>
       );
     case "lists":

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -72,3 +72,12 @@ export {
   useUpdateListItem,
   useUpdateListPreferences,
 } from "./use-lists";
+
+export {
+  recipesKeys,
+  useCreateRecipe,
+  useImportRecipe,
+  useRecipe,
+  useRecipes,
+  useUpdateRecipe,
+} from "./use-recipes";

--- a/src/api/hooks/use-recipes.test.tsx
+++ b/src/api/hooks/use-recipes.test.tsx
@@ -1,0 +1,178 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import type { ApiResponse, RecipeDetail } from "@/lib/types";
+import {
+  importedRecipeDetail,
+  testRecipeDetail,
+  testRecipeSummary,
+} from "@/test/fixtures/recipes";
+import { resetMockRecipes, seedMockRecipes, server } from "@/test/mocks/server";
+import {
+  recipesKeys,
+  useCreateRecipe,
+  useImportRecipe,
+  useRecipe,
+  useRecipes,
+  useUpdateRecipe,
+} from "./use-recipes";
+
+describe("useRecipes", () => {
+  let queryClient: QueryClient;
+
+  function createWrapper() {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+  afterEach(() => {
+    server.resetHandlers();
+    resetMockRecipes();
+    queryClient.clear();
+  });
+  afterAll(() => server.close());
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  it("loads recipe summaries from MSW", async () => {
+    seedMockRecipes([testRecipeDetail]);
+
+    const { result } = renderHook(() => useRecipes(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.data).toEqual([testRecipeSummary]);
+    });
+  });
+
+  it("loads recipe detail data", async () => {
+    seedMockRecipes([testRecipeDetail]);
+
+    const { result } = renderHook(() => useRecipe(testRecipeDetail.id), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.data).toEqual(testRecipeDetail);
+    });
+  });
+
+  it("seeds detail cache and invalidates the library query after create", async () => {
+    seedMockRecipes([]);
+    await queryClient.setQueryData(recipesKeys.list(), { data: [] });
+
+    const { result } = renderHook(() => useCreateRecipe(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      title: "  Tomato Pasta  ",
+      ingredients: ["pasta", "tomatoes"],
+      instructions: ["boil", "toss"],
+      tags: ["dinner", "quick"],
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.data.title).toBe("Tomato Pasta");
+    });
+
+    const created = result.current.data?.data;
+    expect(created?.ingredients).toEqual(["pasta", "tomatoes"]);
+    expect(
+      queryClient.getQueryData<ApiResponse<RecipeDetail>>(
+        recipesKeys.detail(created!.id),
+      )?.data,
+    ).toEqual(created);
+    expect(queryClient.getQueryState(recipesKeys.list())?.isInvalidated).toBe(
+      true,
+    );
+  });
+
+  it("updates detail cache and invalidates the library query after update", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    queryClient.setQueryData(recipesKeys.list(), { data: [testRecipeSummary] });
+    queryClient.setQueryData(recipesKeys.detail(testRecipeDetail.id), {
+      data: testRecipeDetail,
+    } satisfies ApiResponse<RecipeDetail>);
+
+    const { result } = renderHook(() => useUpdateRecipe(testRecipeDetail.id), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      title: "Sheet Pan Salmon and Veg",
+      favorite: false,
+      ingredients: ["Salmon", "Broccoli"],
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.data.title).toBe("Sheet Pan Salmon and Veg");
+    });
+
+    expect(
+      queryClient.getQueryData<ApiResponse<RecipeDetail>>(
+        recipesKeys.detail(testRecipeDetail.id),
+      )?.data,
+    ).toMatchObject({
+      title: "Sheet Pan Salmon and Veg",
+      favorite: false,
+      ingredients: ["Salmon", "Broccoli"],
+    });
+    expect(queryClient.getQueryState(recipesKeys.list())?.isInvalidated).toBe(
+      true,
+    );
+  });
+
+  it("imports a recipe, seeds detail cache, invalidates the library, and surfaces import errors", async () => {
+    seedMockRecipes([]);
+    queryClient.setQueryData(recipesKeys.list(), { data: [] });
+
+    const { result } = renderHook(() => useImportRecipe(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ url: importedRecipeDetail.sourceUrl! });
+
+    await waitFor(() => {
+      expect(result.current.data?.data).toEqual(importedRecipeDetail);
+    });
+
+    expect(
+      queryClient.getQueryData<ApiResponse<RecipeDetail>>(
+        recipesKeys.detail(importedRecipeDetail.id),
+      )?.data,
+    ).toEqual(importedRecipeDetail);
+    expect(queryClient.getQueryState(recipesKeys.list())?.isInvalidated).toBe(
+      true,
+    );
+
+    result.current.mutate({ url: "https://example.com/import-error" });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("Could not import recipe");
+    });
+  });
+});

--- a/src/api/hooks/use-recipes.test.tsx
+++ b/src/api/hooks/use-recipes.test.tsx
@@ -175,4 +175,49 @@ describe("useRecipes", () => {
       expect(result.current.error?.message).toBe("Could not import recipe");
     });
   });
+
+  it("matches backend import URL guardrails in MSW", async () => {
+    const { result } = renderHook(() => useImportRecipe(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ url: "ftp://example.com/recipe" });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("Could not import recipe");
+    });
+
+    result.current.reset();
+    result.current.mutate({ url: "http://127.0.0.1/private" });
+
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("Could not import recipe");
+    });
+  });
+
+  it("resets recipe-generated ids independently from list mocks", async () => {
+    resetMockRecipes();
+
+    const { result } = renderHook(() => useCreateRecipe(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ title: "First Recipe" });
+
+    await waitFor(() => {
+      expect(result.current.data?.data.id).toBe(
+        "00000000-0000-4000-8000-000000001001",
+      );
+    });
+
+    resetMockRecipes();
+    result.current.reset();
+    result.current.mutate({ title: "Second Recipe" });
+
+    await waitFor(() => {
+      expect(result.current.data?.data.id).toBe(
+        "00000000-0000-4000-8000-000000001001",
+      );
+    });
+  });
 });

--- a/src/api/hooks/use-recipes.ts
+++ b/src/api/hooks/use-recipes.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { recipesService } from "@/api/services";
+import type {
+  CreateRecipeRequest,
+  ImportRecipeRequest,
+  RecipeDetailApiResponse,
+  UpdateRecipeRequest,
+} from "@/lib/types";
+
+export const recipesKeys = {
+  all: ["recipes"] as const,
+  list: () => [...recipesKeys.all, "list"] as const,
+  detail: (id: string) => [...recipesKeys.all, "detail", id] as const,
+};
+
+function cacheRecipeDetail(
+  queryClient: ReturnType<typeof useQueryClient>,
+  response: RecipeDetailApiResponse,
+) {
+  queryClient.setQueryData(recipesKeys.detail(response.data.id), response);
+  queryClient.invalidateQueries({ queryKey: recipesKeys.list() });
+}
+
+export function useRecipes() {
+  return useQuery({
+    queryKey: recipesKeys.list(),
+    queryFn: recipesService.getRecipes,
+  });
+}
+
+export function useRecipe(id: string | null) {
+  return useQuery({
+    queryKey: recipesKeys.detail(id ?? "none"),
+    queryFn: () => recipesService.getRecipe(id!),
+    enabled: id !== null,
+  });
+}
+
+export function useCreateRecipe(callbacks?: {
+  onSuccess?: (data: RecipeDetailApiResponse) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateRecipeRequest) =>
+      recipesService.createRecipe(request),
+    onSuccess: (response) => {
+      cacheRecipeDetail(queryClient, response);
+      callbacks?.onSuccess?.(response);
+    },
+  });
+}
+
+export function useUpdateRecipe(id: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateRecipeRequest) =>
+      recipesService.updateRecipe(id, request),
+    onSuccess: (response) => {
+      cacheRecipeDetail(queryClient, response);
+    },
+  });
+}
+
+export function useImportRecipe(callbacks?: {
+  onSuccess?: (data: RecipeDetailApiResponse) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: ImportRecipeRequest) =>
+      recipesService.importRecipe(request),
+    onSuccess: (response) => {
+      cacheRecipeDetail(queryClient, response);
+      callbacks?.onSuccess?.(response);
+    },
+  });
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,7 @@ export {
   isStaleChorePeriodError,
   listsKeys,
   readFamilyFromStorage,
+  recipesKeys,
   setStoredToken,
   syncFamilyFromStorage,
   useAddMember,
@@ -33,6 +34,7 @@ export {
   useCreateEvent,
   useCreateList,
   useCreateListItem,
+  useCreateRecipe,
   useDeleteEvent,
   useDeleteFamily,
   useDeleteInstance,
@@ -47,11 +49,14 @@ export {
   useFamilyName,
   useGoogleCalendars,
   useGoogleConnectionStatus,
+  useImportRecipe,
   useList,
   useListPreferences,
   useLists,
   useLogin,
   useLogout,
+  useRecipe,
+  useRecipes,
   useRegister,
   useRemoveMember,
   useSetupComplete,
@@ -67,6 +72,7 @@ export {
   useUpdateListItem,
   useUpdateListPreferences,
   useUpdateMember,
+  useUpdateRecipe,
 } from "./hooks";
 // Services
 export {
@@ -76,4 +82,5 @@ export {
   familyService,
   googleCalendarService,
   listsService,
+  recipesService,
 } from "./services";

--- a/src/api/services/index.ts
+++ b/src/api/services/index.ts
@@ -4,3 +4,4 @@ export { choreService } from "./chores.service";
 export { familyService } from "./family.service";
 export { googleCalendarService } from "./google-calendar.service";
 export { listsService } from "./lists.service";
+export { recipesService } from "./recipes.service";

--- a/src/api/services/recipes.service.ts
+++ b/src/api/services/recipes.service.ts
@@ -1,0 +1,33 @@
+import { httpClient } from "@/api/client";
+import type {
+  CreateRecipeRequest,
+  ImportRecipeRequest,
+  RecipeDetailApiResponse,
+  RecipesApiResponse,
+  UpdateRecipeRequest,
+} from "@/lib/types";
+
+export const recipesService = {
+  getRecipes(): Promise<RecipesApiResponse> {
+    return httpClient.get<RecipesApiResponse>("/recipes");
+  },
+
+  getRecipe(id: string): Promise<RecipeDetailApiResponse> {
+    return httpClient.get<RecipeDetailApiResponse>(`/recipes/${id}`);
+  },
+
+  createRecipe(request: CreateRecipeRequest): Promise<RecipeDetailApiResponse> {
+    return httpClient.post<RecipeDetailApiResponse>("/recipes", request);
+  },
+
+  updateRecipe(
+    id: string,
+    request: UpdateRecipeRequest,
+  ): Promise<RecipeDetailApiResponse> {
+    return httpClient.patch<RecipeDetailApiResponse>(`/recipes/${id}`, request);
+  },
+
+  importRecipe(request: ImportRecipeRequest): Promise<RecipeDetailApiResponse> {
+    return httpClient.post<RecipeDetailApiResponse>("/recipes/import", request);
+  },
+};

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -89,9 +89,7 @@ describe("RecipesView", () => {
     expect(
       screen.getByText("Add your first recipe to get started."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Add recipe" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add recipe" })).toBeDisabled();
   });
 
   it("renders summary cards with image, title, tags, and favorite state", async () => {
@@ -194,6 +192,29 @@ describe("RecipesView", () => {
     expect(screen.queryByText("Imported Tomato Soup")).not.toBeInTheDocument();
   });
 
+  it("normalizes tag chips and filtering across casing and whitespace", async () => {
+    seedMockRecipes([
+      {
+        ...testRecipeDetail,
+        tags: [" Quick ", "Dinner"],
+      },
+      {
+        ...importedRecipeDetail,
+        tags: ["quick", "lunch"],
+      },
+    ]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("Sheet Pan Salmon");
+
+    expect(screen.getAllByRole("button", { name: "quick" })).toHaveLength(1);
+    await user.click(screen.getByRole("button", { name: "quick" }));
+
+    expect(screen.getByText("Sheet Pan Salmon")).toBeInTheDocument();
+    expect(screen.getByText("Imported Tomato Soup")).toBeInTheDocument();
+  });
+
   it("opens a selected recipe placeholder mode when a card is tapped", async () => {
     seedMockRecipes(testRecipeDetails);
 
@@ -211,6 +232,7 @@ describe("RecipesView", () => {
     expect(
       screen.getByRole("button", { name: "Back to recipes" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add recipe" })).toBeDisabled();
 
     await user.click(screen.getByRole("button", { name: "Back to recipes" }));
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -272,6 +272,39 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows a manual create error without selecting a partial recipe", async () => {
+    seedMockRecipes([]);
+    server.use(
+      http.post(`${API_BASE}/recipes`, () =>
+        HttpResponse.json(
+          { message: "Recipe title already exists" },
+          { status: 409 },
+        ),
+      ),
+    );
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+    await typeAndWait(user, screen.getByLabelText("Title"), "Skillet Eggs");
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(
+      await screen.findByText("Recipe title already exists"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Create Recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Back to recipes" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Skillet Eggs" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("preserves ordered manual ingredients, instructions, and tags when saving", async () => {
     seedMockRecipes([]);
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -122,6 +122,92 @@ describe("RecipesView", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens recipe detail from the library with cook-first content order and returns back", async () => {
+    seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+
+    const image = screen.getByRole("img", { name: testRecipeDetail.title });
+    const title = screen.getByRole("heading", { name: testRecipeDetail.title });
+    const ingredientsHeading = screen.getByRole("heading", {
+      name: "Ingredients",
+    });
+    const instructionsHeading = screen.getByRole("heading", {
+      name: "Instructions",
+    });
+    const editButton = screen.getByRole("button", { name: "Edit recipe" });
+
+    expect(screen.getByText("Salmon fillets")).toBeInTheDocument();
+    expect(screen.getByText("Heat oven to 425F")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View source" })).toHaveAttribute(
+      "href",
+      testRecipeDetail.sourceUrl,
+    );
+
+    expect(
+      image.compareDocumentPosition(title) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      title.compareDocumentPosition(ingredientsHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      ingredientsHeading.compareDocumentPosition(instructionsHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      instructionsHeading.compareDocumentPosition(editButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Back to recipes" }));
+
+    expect(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders recipe detail gracefully when optional image and cook steps are missing", async () => {
+    seedMockRecipes([
+      {
+        ...importedRecipeDetail,
+        ingredients: [],
+        instructions: [],
+        sourceUrl: null,
+      },
+    ]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${importedRecipeDetail.title}`,
+      }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: importedRecipeDetail.title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("No photo", { selector: "span" })).toBeVisible();
+    expect(
+      screen.queryByRole("heading", { name: "Ingredients" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Instructions" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View source" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("matches recipes by title and tags when searching", async () => {
     seedMockRecipes(testRecipeDetails);
 
@@ -440,5 +526,165 @@ describe("RecipesView", () => {
     expect(
       screen.queryByRole("heading", { name: importedRecipeDetail.title }),
     ).not.toBeInTheDocument();
+  });
+
+  it("toggles favorite from detail and updates the visible saved state", async () => {
+    seedMockRecipes([importedRecipeDetail]);
+    const updateRecipe = vi.fn(async ({ request }) => {
+      const body = await request.json();
+
+      expect(body).toEqual({ favorite: true });
+
+      return HttpResponse.json({
+        data: {
+          ...importedRecipeDetail,
+          favorite: true,
+        },
+      });
+    });
+    server.use(
+      http.patch(
+        `${API_BASE}/recipes/${importedRecipeDetail.id}`,
+        updateRecipe,
+      ),
+    );
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${importedRecipeDetail.title}`,
+      }),
+    );
+
+    const favoriteButton = screen.getByRole("button", {
+      name: `Favorite recipe: ${importedRecipeDetail.title}`,
+    });
+    expect(favoriteButton).toHaveAttribute("aria-pressed", "false");
+
+    await user.click(favoriteButton);
+
+    expect(await screen.findByText("Favorite")).toBeInTheDocument();
+    expect(updateRecipe).toHaveBeenCalledTimes(1);
+    expect(favoriteButton).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("opens edit with existing values and saves ordered fields back to the recipe", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    const updateRecipe = vi.fn(async ({ request }) => {
+      const body = await request.json();
+
+      expect(body).toEqual({
+        title: "Sheet Pan Salmon with Dill",
+        imageUrl: testRecipeDetail.imageUrl,
+        ingredients: [
+          "Salmon fillets",
+          "Asparagus",
+          "Lemon slices",
+          "Fresh dill",
+        ],
+        instructions: [
+          "Heat oven to 425F",
+          "Roast salmon and asparagus together",
+          "Finish with dill",
+        ],
+        note: testRecipeDetail.note,
+        sourceUrl: testRecipeDetail.sourceUrl,
+        tags: ["dinner", "quick", "sheet-pan"],
+        favorite: testRecipeDetail.favorite,
+      });
+
+      return HttpResponse.json({
+        data: {
+          ...testRecipeDetail,
+          title: "Sheet Pan Salmon with Dill",
+          ingredients: [
+            "Salmon fillets",
+            "Asparagus",
+            "Lemon slices",
+            "Fresh dill",
+          ],
+          instructions: [
+            "Heat oven to 425F",
+            "Roast salmon and asparagus together",
+            "Finish with dill",
+          ],
+          tags: ["dinner", "quick", "sheet-pan"],
+        },
+      });
+    });
+    server.use(
+      http.patch(`${API_BASE}/recipes/${testRecipeDetail.id}`, updateRecipe),
+    );
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Edit recipe" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Edit Recipe" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Title")).toHaveValue(testRecipeDetail.title);
+    expect(screen.getByLabelText("Ingredient 1")).toHaveValue(
+      testRecipeDetail.ingredients[0],
+    );
+    expect(screen.getByLabelText("Instruction 2")).toHaveValue(
+      testRecipeDetail.instructions[1],
+    );
+    expect(screen.getByLabelText("Tag 2")).toHaveValue(
+      testRecipeDetail.tags[1],
+    );
+
+    await user.clear(screen.getByLabelText("Title"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Title"),
+      "Sheet Pan Salmon with Dill",
+    );
+    await user.clear(screen.getByLabelText("Ingredient 3"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Ingredient 3"),
+      "Lemon slices",
+    );
+    await user.click(screen.getByRole("button", { name: "Add ingredient" }));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Ingredient 4"),
+      "Fresh dill",
+    );
+    await user.clear(screen.getByLabelText("Instruction 2"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Instruction 2"),
+      "Roast salmon and asparagus together",
+    );
+    await user.click(screen.getByRole("button", { name: "Add instruction" }));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Instruction 3"),
+      "Finish with dill",
+    );
+    await user.click(screen.getByRole("button", { name: "Add tag" }));
+    await typeAndWait(user, screen.getByLabelText("Tag 3"), "sheet-pan");
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Sheet Pan Salmon with Dill",
+      }),
+    ).toBeInTheDocument();
+    expect(updateRecipe).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("dialog", { name: "Edit Recipe" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Fresh dill")).toBeInTheDocument();
+    expect(screen.getByText("Finish with dill")).toBeInTheDocument();
+    expect(screen.getByText("sheet-pan")).toBeInTheDocument();
   });
 });

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -11,7 +11,7 @@ import {
   server,
   setupMswServer,
 } from "@/test/mocks/server";
-import { render, renderWithUser, screen, waitFor } from "@/test/test-utils";
+import { render, renderWithUser, screen } from "@/test/test-utils";
 import { RecipesView } from "./recipes-view";
 
 describe("RecipesView", () => {
@@ -89,7 +89,9 @@ describe("RecipesView", () => {
     expect(
       screen.getByText("Add your first recipe to get started."),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add recipe" })).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: "Add recipe" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders summary cards with image, title, tags, and favorite state", async () => {
@@ -98,7 +100,9 @@ describe("RecipesView", () => {
     render(<RecipesView />);
 
     expect(
-      await screen.findByRole("button", { name: /sheet pan salmon/i }),
+      await screen.findByRole("article", {
+        name: "Recipe card: Sheet Pan Salmon",
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("img", { name: testRecipeDetail.title }),
@@ -157,7 +161,7 @@ describe("RecipesView", () => {
 
     const getTitles = () =>
       screen
-        .getAllByRole("button", { name: /recipe card:/i })
+        .getAllByRole("article", { name: /recipe card:/i })
         .map((card) => card.getAttribute("aria-label"));
 
     await screen.findByText("Sheet Pan Salmon");
@@ -215,31 +219,24 @@ describe("RecipesView", () => {
     expect(screen.getByText("Imported Tomato Soup")).toBeInTheDocument();
   });
 
-  it("opens a selected recipe placeholder mode when a card is tapped", async () => {
+  it("does not expose unfinished create or detail controls in the discovery slice", async () => {
     seedMockRecipes(testRecipeDetails);
 
-    const { user } = renderWithUser(<RecipesView />);
+    render(<RecipesView />);
 
-    await user.click(
-      await screen.findByRole("button", {
+    expect(
+      await screen.findByRole("article", {
         name: "Recipe card: Sheet Pan Salmon",
       }),
-    );
-
-    expect(
-      screen.getByText(`Selected recipe: ${testRecipeDetail.id}`),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Back to recipes" }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Add recipe" })).toBeDisabled();
-
-    await user.click(screen.getByRole("button", { name: "Back to recipes" }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Recipe card: Sheet Pan Salmon" }),
-      ).toBeInTheDocument();
-    });
+      screen.queryByRole("button", { name: "Add recipe" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Back to recipes" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(`Selected recipe: ${testRecipeDetail.id}`),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -435,6 +435,34 @@ describe("RecipesView", () => {
     });
   });
 
+  it("cancels a meals draft create without leaving stale handoff state", async () => {
+    seedMockRecipes([]);
+    useAppStore.getState().startRecipeCreationFromMealSlot({
+      requestedAtWeekStartDate: "2026-06-07",
+      dayIndex: 2,
+      mealType: "lunch",
+      typedTitle: "Soup idea",
+    });
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Create Recipe" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(useAppStore.getState().recipeCreationDraft).toBe(null);
+    expect(useAppStore.getState().mealPlacementDraft).toBe(null);
+    expect(useAppStore.getState().activeModule).toBe("recipes");
+    expect(
+      screen.queryByRole("dialog", { name: "Create Recipe" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Add Recipe" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a manual create error without selecting a partial recipe", async () => {
     seedMockRecipes([]);
     server.use(

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -141,6 +141,7 @@ describe("RecipesView", () => {
     const instructionsHeading = screen.getByRole("heading", {
       name: "Instructions",
     });
+    const backButton = screen.getByRole("button", { name: "Back to recipes" });
     const editButton = screen.getByRole("button", { name: "Edit recipe" });
 
     expect(screen.getByText("Salmon fillets")).toBeInTheDocument();
@@ -162,7 +163,11 @@ describe("RecipesView", () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     expect(
-      instructionsHeading.compareDocumentPosition(editButton) &
+      instructionsHeading.compareDocumentPosition(backButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      backButton.compareDocumentPosition(editButton) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -4,6 +4,7 @@ import type {
   CreateRecipeRequest,
   ImportRecipeRequest,
 } from "@/lib/types/recipes";
+import { useAppStore } from "@/stores/app-store";
 import {
   importedRecipeDetail,
   testRecipeDetail,
@@ -23,6 +24,46 @@ describe("RecipesView", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("adds a recipe to meals from detail and stores a library handoff draft", async () => {
+    const fixedNow = new Date(2026, 5, 10, 9, 15, 0);
+    const RealDate = Date;
+    class MockDate extends RealDate {
+      constructor(...args: ConstructorParameters<DateConstructor>) {
+        if (args.length === 0) {
+          super(fixedNow);
+          return;
+        }
+
+        super(...(args as ConstructorParameters<typeof RealDate>));
+      }
+
+      static now() {
+        return fixedNow.getTime();
+      }
+    }
+
+    vi.stubGlobal("Date", MockDate as DateConstructor);
+    seedMockRecipes([testRecipeDetail]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Add to Meals" }));
+
+    expect(useAppStore.getState().activeModule).toBe("meals");
+    expect(useAppStore.getState().mealPlacementDraft).toEqual({
+      recipeId: testRecipeDetail.id,
+      requestedAtWeekStartDate: "2026-06-07",
+      source: { kind: "recipes-library" },
+    });
+
+    vi.unstubAllGlobals();
   });
 
   it("shows a loading state while the recipe library is fetching", async () => {
@@ -361,6 +402,37 @@ describe("RecipesView", () => {
     expect(
       screen.queryByRole("dialog", { name: "Add Recipe" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("opens manual create from a meals draft and returns to meals with a slot handoff after save", async () => {
+    seedMockRecipes([]);
+    useAppStore.getState().startRecipeCreationFromMealSlot({
+      requestedAtWeekStartDate: "2026-06-07",
+      dayIndex: 3,
+      mealType: "dinner",
+      typedTitle: "Skillet Eggs",
+    });
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Create Recipe" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Title")).toHaveValue("Skillet Eggs");
+
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(useAppStore.getState().activeModule).toBe("meals");
+    expect(useAppStore.getState().recipeCreationDraft).toBe(null);
+    expect(useAppStore.getState().mealPlacementDraft).toEqual({
+      recipeId: "00000000-0000-4000-8000-000000001001",
+      requestedAtWeekStartDate: "2026-06-07",
+      source: {
+        kind: "meals-slot",
+        dayIndex: 3,
+        mealType: "dinner",
+      },
+    });
   });
 
   it("shows a manual create error without selecting a partial recipe", async () => {

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -156,7 +156,7 @@ describe("RecipesView", () => {
     expect(screen.getAllByText("dinner").length).toBeGreaterThan(0);
     expect(screen.getAllByText("quick").length).toBeGreaterThan(0);
     expect(
-      screen.getByLabelText(`Favorite recipe: ${testRecipeDetail.title}`),
+      screen.getByLabelText(`${testRecipeDetail.title} is a favorite`),
     ).toBeInTheDocument();
     expect(
       screen.getByText("No photo", { selector: "span" }),
@@ -391,6 +391,52 @@ describe("RecipesView", () => {
     expect(getTitles()).toEqual([
       "Recipe card: Sheet Pan Salmon",
       "Recipe card: Imported Tomato Soup",
+    ]);
+  });
+
+  it("orders the library by most recent activity by default, favorites-first only when searching", async () => {
+    const olderFavorite = {
+      ...testRecipeDetail,
+      id: "00000000-0000-4000-8000-000000000901",
+      title: "Older Favorite",
+      favorite: true,
+      tags: ["weeknight"],
+      updatedAt: "2026-06-01T08:00:00",
+    };
+    const newerPlain = {
+      ...testRecipeDetail,
+      id: "00000000-0000-4000-8000-000000000902",
+      title: "Newer Plain",
+      favorite: false,
+      tags: ["weeknight"],
+      updatedAt: "2026-06-05T08:00:00",
+    };
+    seedMockRecipes([olderFavorite, newerPlain]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    const getTitles = () =>
+      screen
+        .getAllByRole("article", { name: /recipe card:/i })
+        .map((card) => card.getAttribute("aria-label"));
+
+    await screen.findByText("Newer Plain");
+
+    // Default browse is recency-first even though the older recipe is favorited.
+    expect(getTitles()).toEqual([
+      "Recipe card: Newer Plain",
+      "Recipe card: Older Favorite",
+    ]);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search recipes" }),
+      "weeknight",
+    );
+
+    // Searching surfaces favorites first.
+    expect(getTitles()).toEqual([
+      "Recipe card: Older Favorite",
+      "Recipe card: Newer Plain",
     ]);
   });
 
@@ -791,7 +837,7 @@ describe("RecipesView", () => {
 
     await user.click(favoriteButton);
 
-    expect(await screen.findByText("Favorite")).toBeInTheDocument();
+    expect(await screen.findByText("Favorited")).toBeInTheDocument();
     expect(updateRecipe).toHaveBeenCalledTimes(1);
     expect(favoriteButton).toHaveAttribute("aria-pressed", "true");
   });

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -1,0 +1,223 @@
+import { delay, HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  importedRecipeDetail,
+  testRecipeDetail,
+  testRecipeDetails,
+} from "@/test/fixtures/recipes";
+import {
+  API_BASE,
+  seedMockRecipes,
+  server,
+  setupMswServer,
+} from "@/test/mocks/server";
+import { render, renderWithUser, screen, waitFor } from "@/test/test-utils";
+import { RecipesView } from "./recipes-view";
+
+describe("RecipesView", () => {
+  setupMswServer();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a loading state while the recipe library is fetching", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    server.use(
+      http.get(`${API_BASE}/recipes`, async () => {
+        await delay(200);
+        return HttpResponse.json({
+          data: [testRecipeDetail].map((recipe) => ({
+            id: recipe.id,
+            title: recipe.title,
+            imageUrl: recipe.imageUrl,
+            favorite: recipe.favorite,
+            tags: recipe.tags,
+            updatedAt: recipe.updatedAt,
+          })),
+        });
+      }),
+    );
+
+    render(<RecipesView />);
+
+    expect(screen.getByText("Loading recipes...")).toBeInTheDocument();
+    expect(screen.queryByText(testRecipeDetail.title)).not.toBeInTheDocument();
+    expect(await screen.findByText(testRecipeDetail.title)).toBeInTheDocument();
+  });
+
+  it("shows an error state with retry when the library request fails", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    const getRecipes = vi.fn(() =>
+      HttpResponse.json({ message: "Server error" }, { status: 500 }),
+    );
+    server.use(http.get(`${API_BASE}/recipes`, getRecipes));
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    expect(
+      await screen.findByText("Recipes could not be loaded"),
+    ).toBeInTheDocument();
+
+    server.use(
+      http.get(`${API_BASE}/recipes`, () =>
+        HttpResponse.json({
+          data: [testRecipeDetail].map((recipe) => ({
+            id: recipe.id,
+            title: recipe.title,
+            imageUrl: recipe.imageUrl,
+            favorite: recipe.favorite,
+            tags: recipe.tags,
+            updatedAt: recipe.updatedAt,
+          })),
+        }),
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText(testRecipeDetail.title)).toBeInTheDocument();
+    expect(getRecipes).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an empty state that invites adding the first recipe", async () => {
+    seedMockRecipes([]);
+
+    render(<RecipesView />);
+
+    expect(await screen.findByText("No recipes yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add your first recipe to get started."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add recipe" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders summary cards with image, title, tags, and favorite state", async () => {
+    seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
+
+    render(<RecipesView />);
+
+    expect(
+      await screen.findByRole("button", { name: /sheet pan salmon/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: testRecipeDetail.title }),
+    ).toHaveAttribute("src", testRecipeDetail.imageUrl);
+    expect(screen.getAllByText("dinner").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("quick").length).toBeGreaterThan(0);
+    expect(
+      screen.getByLabelText(`Favorite recipe: ${testRecipeDetail.title}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("No photo", { selector: "span" }),
+    ).toBeInTheDocument();
+  });
+
+  it("matches recipes by title and tags when searching", async () => {
+    seedMockRecipes(testRecipeDetails);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("Sheet Pan Salmon");
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search recipes" }),
+      "lunch",
+    );
+
+    expect(screen.getByText("Imported Tomato Soup")).toBeInTheDocument();
+    expect(screen.queryByText("Sheet Pan Salmon")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByRole("searchbox", { name: "Search recipes" }));
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search recipes" }),
+      "salmon",
+    );
+
+    expect(screen.getByText("Sheet Pan Salmon")).toBeInTheDocument();
+    expect(screen.queryByText("Imported Tomato Soup")).not.toBeInTheDocument();
+  });
+
+  it("shows only favorites when the favorites filter is enabled", async () => {
+    seedMockRecipes(testRecipeDetails);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("Sheet Pan Salmon");
+    await user.click(screen.getByRole("button", { name: "Favorites only" }));
+
+    expect(screen.getByText("Sheet Pan Salmon")).toBeInTheDocument();
+    expect(screen.getByText("Berry Yogurt Parfaits")).toBeInTheDocument();
+    expect(screen.queryByText("Imported Tomato Soup")).not.toBeInTheDocument();
+  });
+
+  it("sorts favorites ahead of non-favorites in browse and search results", async () => {
+    seedMockRecipes(testRecipeDetails);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    const getTitles = () =>
+      screen
+        .getAllByRole("button", { name: /recipe card:/i })
+        .map((card) => card.getAttribute("aria-label"));
+
+    await screen.findByText("Sheet Pan Salmon");
+
+    expect(getTitles()).toEqual([
+      "Recipe card: Berry Yogurt Parfaits",
+      "Recipe card: Sheet Pan Salmon",
+      "Recipe card: Imported Tomato Soup",
+    ]);
+
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search recipes" }),
+      "quick",
+    );
+
+    expect(getTitles()).toEqual([
+      "Recipe card: Sheet Pan Salmon",
+      "Recipe card: Imported Tomato Soup",
+    ]);
+  });
+
+  it("filters the library by tag chip", async () => {
+    seedMockRecipes(testRecipeDetails);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("Sheet Pan Salmon");
+    await user.click(screen.getByRole("button", { name: "breakfast" }));
+
+    expect(screen.getByText("Berry Yogurt Parfaits")).toBeInTheDocument();
+    expect(screen.queryByText("Sheet Pan Salmon")).not.toBeInTheDocument();
+    expect(screen.queryByText("Imported Tomato Soup")).not.toBeInTheDocument();
+  });
+
+  it("opens a selected recipe placeholder mode when a card is tapped", async () => {
+    seedMockRecipes(testRecipeDetails);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Recipe card: Sheet Pan Salmon",
+      }),
+    );
+
+    expect(
+      screen.getByText(`Selected recipe: ${testRecipeDetail.id}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Back to recipes" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Recipe card: Sheet Pan Salmon" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -1,5 +1,9 @@
 import { delay, HttpResponse, http } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CreateRecipeRequest,
+  ImportRecipeRequest,
+} from "@/lib/types/recipes";
 import {
   importedRecipeDetail,
   testRecipeDetail,
@@ -11,7 +15,7 @@ import {
   server,
   setupMswServer,
 } from "@/test/mocks/server";
-import { render, renderWithUser, screen } from "@/test/test-utils";
+import { render, renderWithUser, screen, typeAndWait } from "@/test/test-utils";
 import { RecipesView } from "./recipes-view";
 
 describe("RecipesView", () => {
@@ -89,8 +93,9 @@ describe("RecipesView", () => {
     expect(
       screen.getByText("Add your first recipe to get started."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add recipe" })).toBeVisible();
     expect(
-      screen.queryByRole("button", { name: "Add recipe" }),
+      screen.queryByRole("button", { name: "Import from URL" }),
     ).not.toBeInTheDocument();
   });
 
@@ -219,24 +224,188 @@ describe("RecipesView", () => {
     expect(screen.getByText("Imported Tomato Soup")).toBeInTheDocument();
   });
 
-  it("does not expose unfinished create or detail controls in the discovery slice", async () => {
+  it("opens the add flow with manual and import choices", async () => {
     seedMockRecipes(testRecipeDetails);
 
-    render(<RecipesView />);
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByRole("article", {
+      name: "Recipe card: Sheet Pan Salmon",
+    });
 
     expect(
-      await screen.findByRole("article", {
-        name: "Recipe card: Sheet Pan Salmon",
-      }),
+      screen.queryByRole("button", { name: "Import from URL" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Add Recipe" }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Add recipe" }),
+      screen.getByRole("button", { name: "Create manually" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Import from URL" }),
+    ).toBeVisible();
+  });
+
+  it("creates a recipe manually with only a title and lands on its saved detail", async () => {
+    seedMockRecipes([]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+    await typeAndWait(user, screen.getByLabelText("Title"), "Skillet Eggs");
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Skillet Eggs" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("dialog", { name: "Add Recipe" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("preserves ordered manual ingredients, instructions, and tags when saving", async () => {
+    seedMockRecipes([]);
+
+    const createRecipe = vi.fn(async ({ request }) => {
+      const body = (await request.json()) as CreateRecipeRequest;
+
+      expect(body).toMatchObject({
+        title: "Layered Salad",
+        ingredients: ["lettuce", "dressing", "seeds"],
+        instructions: ["wash", "stack", "serve"],
+        tags: ["make-ahead", "side", "summer"],
+      });
+
+      return HttpResponse.json({
+        data: {
+          id: "00000000-0000-4000-8000-000000000599",
+          title: body.title,
+          imageUrl: null,
+          ingredients: body.ingredients ?? [],
+          instructions: body.instructions ?? [],
+          note: null,
+          sourceUrl: null,
+          tags: body.tags ?? [],
+          favorite: false,
+          updatedAt: "2026-06-04T10:00:00",
+        },
+      });
+    });
+
+    server.use(http.post(`${API_BASE}/recipes`, createRecipe));
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+
+    await typeAndWait(user, screen.getByLabelText("Title"), "Layered Salad");
+    await typeAndWait(user, screen.getByLabelText("Ingredient 1"), " lettuce ");
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Ingredient 2"),
+      " dressing ",
+    );
+    await user.click(screen.getByRole("button", { name: "Add ingredient" }));
+    await typeAndWait(user, screen.getByLabelText("Ingredient 3"), " seeds ");
+
+    await typeAndWait(user, screen.getByLabelText("Instruction 1"), " wash ");
+    await typeAndWait(user, screen.getByLabelText("Instruction 2"), " stack ");
+    await user.click(screen.getByRole("button", { name: "Add instruction" }));
+    await typeAndWait(user, screen.getByLabelText("Instruction 3"), " serve ");
+
+    await typeAndWait(user, screen.getByLabelText("Tag 1"), " make-ahead ");
+    await typeAndWait(user, screen.getByLabelText("Tag 2"), " side ");
+    await user.click(screen.getByRole("button", { name: "Add tag" }));
+    await typeAndWait(user, screen.getByLabelText("Tag 3"), " summer ");
+
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Layered Salad" }),
+    ).toBeInTheDocument();
+    expect(createRecipe).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports a recipe from url through the add flow and lands on its saved detail", async () => {
+    seedMockRecipes([]);
+
+    const importRecipe = vi.fn(async ({ request }) => {
+      const body = (await request.json()) as ImportRecipeRequest;
+
+      expect(body).toEqual({
+        url: "https://example.com/roasted-carrots",
+      });
+
+      return HttpResponse.json({
+        data: {
+          ...importedRecipeDetail,
+          id: "00000000-0000-4000-8000-000000000601",
+          title: "Roasted Carrots",
+          sourceUrl: body.url,
+        },
+      });
+    });
+
+    server.use(http.post(`${API_BASE}/recipes/import`, importRecipe));
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Import from URL" }));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Recipe URL"),
+      "https://example.com/roasted-carrots",
+    );
+    await user.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    expect(
+      await screen.findByRole("heading", { name: "Roasted Carrots" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeVisible();
+    expect(importRecipe).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an import error without selecting a partial recipe", async () => {
+    seedMockRecipes([]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Import from URL" }));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Recipe URL"),
+      "https://example.com/import-error",
+    );
+    await user.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    expect(
+      await screen.findByText("Could not import recipe"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("dialog", { name: "Import Recipe" }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Back to recipes" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(`Selected recipe: ${testRecipeDetail.id}`),
+      screen.queryByRole("heading", { name: importedRecipeDetail.title }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -254,6 +254,40 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders duplicate ordered recipe lines without duplicate React key warnings", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    seedMockRecipes([
+      {
+        ...testRecipeDetail,
+        ingredients: ["Salt", "Salt"],
+        instructions: ["Mix", "Mix"],
+        tags: ["quick", "quick"],
+      },
+    ]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+
+    expect(screen.getAllByText("Salt")).toHaveLength(2);
+    expect(screen.getAllByText("Mix")).toHaveLength(2);
+    expect(
+      consoleError.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.includes("Encountered two children with the same key"),
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("lets users recover when recipe detail loading fails", async () => {
     seedMockRecipes([testRecipeDetail]);
     const getDetail = vi.fn(() =>
@@ -624,7 +658,7 @@ describe("RecipesView", () => {
     expect(createRecipe).toHaveBeenCalledTimes(1);
   });
 
-  it("shows validation messages for long ingredients, instructions, and tags", async () => {
+  it("shows validation messages for long ingredients and tags", async () => {
     seedMockRecipes([]);
 
     const { user } = renderWithUser(<RecipesView />);
@@ -638,19 +672,11 @@ describe("RecipesView", () => {
       screen.getByLabelText("Ingredient 1"),
       "a".repeat(501),
     );
-    await typeAndWait(
-      user,
-      screen.getByLabelText("Instruction 1"),
-      "b".repeat(1001),
-    );
     await typeAndWait(user, screen.getByLabelText("Tag 1"), "c".repeat(61));
     await user.click(screen.getByRole("button", { name: "Save recipe" }));
 
     expect(
       await screen.findByText("Ingredient must be 500 characters or less"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("Instruction must be 1000 characters or less"),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Tag must be 60 characters or less"),

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -254,6 +254,46 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("lets users recover when recipe detail loading fails", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    const getDetail = vi.fn(() =>
+      HttpResponse.json({ message: "Detail request failed" }, { status: 500 }),
+    );
+    server.use(
+      http.get(`${API_BASE}/recipes/${testRecipeDetail.id}`, getDetail),
+    );
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+
+    expect(
+      await screen.findByText("Recipe could not be loaded"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Detail request failed")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeVisible();
+
+    server.use(
+      http.get(`${API_BASE}/recipes/${testRecipeDetail.id}`, () =>
+        HttpResponse.json({ data: testRecipeDetail }),
+      ),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(
+      await screen.findByRole("heading", { name: testRecipeDetail.title }),
+    ).toBeInTheDocument();
+    expect(getDetail).toHaveBeenCalledTimes(1);
+  });
+
   it("matches recipes by title and tags when searching", async () => {
     seedMockRecipes(testRecipeDetails);
 
@@ -504,8 +544,11 @@ describe("RecipesView", () => {
 
       expect(body).toMatchObject({
         title: "Layered Salad",
+        imageUrl: "https://example.com/layered-salad.jpg",
         ingredients: ["lettuce", "dressing", "seeds"],
         instructions: ["wash", "stack", "serve"],
+        note: "Best chilled before dinner",
+        sourceUrl: "https://example.com/layered-salad",
         tags: ["make-ahead", "side", "summer"],
       });
 
@@ -513,11 +556,11 @@ describe("RecipesView", () => {
         data: {
           id: "00000000-0000-4000-8000-000000000599",
           title: body.title,
-          imageUrl: null,
+          imageUrl: body.imageUrl ?? null,
           ingredients: body.ingredients ?? [],
           instructions: body.instructions ?? [],
-          note: null,
-          sourceUrl: null,
+          note: body.note ?? null,
+          sourceUrl: body.sourceUrl ?? null,
           tags: body.tags ?? [],
           favorite: false,
           updatedAt: "2026-06-04T10:00:00",
@@ -534,6 +577,21 @@ describe("RecipesView", () => {
     await user.click(screen.getByRole("button", { name: "Create manually" }));
 
     await typeAndWait(user, screen.getByLabelText("Title"), "Layered Salad");
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Image URL"),
+      "https://example.com/layered-salad.jpg",
+    );
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Note"),
+      "Best chilled before dinner",
+    );
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Source URL"),
+      "https://example.com/layered-salad",
+    );
     await typeAndWait(user, screen.getByLabelText("Ingredient 1"), " lettuce ");
     await typeAndWait(
       user,
@@ -558,7 +616,45 @@ describe("RecipesView", () => {
     expect(
       await screen.findByRole("heading", { name: "Layered Salad" }),
     ).toBeInTheDocument();
+    expect(screen.getByText("Best chilled before dinner")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View source" })).toHaveAttribute(
+      "href",
+      "https://example.com/layered-salad",
+    );
     expect(createRecipe).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows validation messages for long ingredients, instructions, and tags", async () => {
+    seedMockRecipes([]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+    await user.click(screen.getByRole("button", { name: "Add recipe" }));
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+    await typeAndWait(user, screen.getByLabelText("Title"), "Big Recipe");
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Ingredient 1"),
+      "a".repeat(501),
+    );
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Instruction 1"),
+      "b".repeat(1001),
+    );
+    await typeAndWait(user, screen.getByLabelText("Tag 1"), "c".repeat(61));
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    expect(
+      await screen.findByText("Ingredient must be 500 characters or less"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Instruction must be 1000 characters or less"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Tag must be 60 characters or less"),
+    ).toBeInTheDocument();
   });
 
   it("imports a recipe from url through the add flow and lands on its saved detail", async () => {
@@ -681,7 +777,7 @@ describe("RecipesView", () => {
 
       expect(body).toEqual({
         title: "Sheet Pan Salmon with Dill",
-        imageUrl: testRecipeDetail.imageUrl,
+        imageUrl: "https://example.com/salmon-dill.jpg",
         ingredients: [
           "Salmon fillets",
           "Asparagus",
@@ -693,8 +789,8 @@ describe("RecipesView", () => {
           "Roast salmon and asparagus together",
           "Finish with dill",
         ],
-        note: testRecipeDetail.note,
-        sourceUrl: testRecipeDetail.sourceUrl,
+        note: "Add extra dill before serving",
+        sourceUrl: "https://example.com/salmon-dill",
         tags: ["dinner", "quick", "sheet-pan"],
         favorite: testRecipeDetail.favorite,
       });
@@ -703,6 +799,7 @@ describe("RecipesView", () => {
         data: {
           ...testRecipeDetail,
           title: "Sheet Pan Salmon with Dill",
+          imageUrl: "https://example.com/salmon-dill.jpg",
           ingredients: [
             "Salmon fillets",
             "Asparagus",
@@ -714,6 +811,8 @@ describe("RecipesView", () => {
             "Roast salmon and asparagus together",
             "Finish with dill",
           ],
+          note: "Add extra dill before serving",
+          sourceUrl: "https://example.com/salmon-dill",
           tags: ["dinner", "quick", "sheet-pan"],
         },
       });
@@ -735,6 +834,13 @@ describe("RecipesView", () => {
       screen.getByRole("dialog", { name: "Edit Recipe" }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Title")).toHaveValue(testRecipeDetail.title);
+    expect(screen.getByLabelText("Image URL")).toHaveValue(
+      testRecipeDetail.imageUrl,
+    );
+    expect(screen.getByLabelText("Note")).toHaveValue(testRecipeDetail.note);
+    expect(screen.getByLabelText("Source URL")).toHaveValue(
+      testRecipeDetail.sourceUrl,
+    );
     expect(screen.getByLabelText("Ingredient 1")).toHaveValue(
       testRecipeDetail.ingredients[0],
     );
@@ -750,6 +856,24 @@ describe("RecipesView", () => {
       user,
       screen.getByLabelText("Title"),
       "Sheet Pan Salmon with Dill",
+    );
+    await user.clear(screen.getByLabelText("Image URL"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Image URL"),
+      "https://example.com/salmon-dill.jpg",
+    );
+    await user.clear(screen.getByLabelText("Note"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Note"),
+      "Add extra dill before serving",
+    );
+    await user.clear(screen.getByLabelText("Source URL"));
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Source URL"),
+      "https://example.com/salmon-dill",
     );
     await user.clear(screen.getByLabelText("Ingredient 3"));
     await typeAndWait(
@@ -790,6 +914,13 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText("Fresh dill")).toBeInTheDocument();
     expect(screen.getByText("Finish with dill")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add extra dill before serving"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View source" })).toHaveAttribute(
+      "href",
+      "https://example.com/salmon-dill",
+    );
     expect(screen.getByText("sheet-pan")).toBeInTheDocument();
   });
 });

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,4 +1,3 @@
-import { ArrowLeft, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useRecipes } from "@/api";
 import {
@@ -46,7 +45,6 @@ export function RecipesView() {
   const [searchValue, setSearchValue] = useState("");
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
-  const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null);
 
   const recipes = data?.data ?? [];
   const searchQuery = normalizeValue(searchValue);
@@ -81,61 +79,14 @@ export function RecipesView() {
     return sortRecipes(visibleRecipes, favoritesOnly);
   }, [favoritesOnly, recipes, searchQuery, selectedTag]);
 
-  const selectedRecipe = useMemo(
-    () => recipes.find((recipe) => recipe.id === selectedRecipeId) ?? null,
-    [recipes, selectedRecipeId],
-  );
-
-  if (selectedRecipeId !== null) {
-    return (
-      <section className="flex-1 overflow-y-auto p-4 sm:p-6">
-        <div className="mx-auto flex max-w-2xl flex-col gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => setSelectedRecipeId(null)}
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back to recipes
-            </Button>
-            <Button type="button" size="sm" disabled>
-              <Plus className="h-4 w-4" />
-              Add recipe
-            </Button>
-          </div>
-
-          <div className="rounded-lg border border-border bg-card p-5 shadow-xs">
-            <p className="text-sm font-medium text-muted-foreground">
-              Selected recipe: {selectedRecipeId}
-            </p>
-            <h1 className="mt-2 text-2xl font-semibold text-foreground">
-              {selectedRecipe?.title ?? "Recipe detail"}
-            </h1>
-            <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Recipe detail is coming in Task 5. This placeholder confirms card
-              navigation and selected-recipe mode.
-            </p>
-          </div>
-        </div>
-      </section>
-    );
-  }
-
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-4">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
-            <p className="text-sm text-muted-foreground">
-              Save family favorites and discover what to cook next.
-            </p>
-          </div>
-          <Button type="button" className="shrink-0" disabled>
-            <Plus className="h-4 w-4" />
-            Add recipe
-          </Button>
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
+          <p className="text-sm text-muted-foreground">
+            Save family favorites and discover what to cook next.
+          </p>
         </div>
 
         {isLoading ? (
@@ -218,10 +169,7 @@ export function RecipesView() {
               <div className="grid gap-3">
                 {filteredRecipes.map((recipe) => (
                   <div key={recipe.id} className={cn("min-w-0")}>
-                    <RecipeLibraryCard
-                      recipe={recipe}
-                      onSelect={setSelectedRecipeId}
-                    />
+                    <RecipeLibraryCard recipe={recipe} />
                   </div>
                 ))}
               </div>

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -266,6 +266,15 @@ export function RecipesView() {
           defaultMode={createSheetMode}
           defaultValues={createSheetDefaultValues}
           isOpen={isCreateSheetOpen}
+          onCancelManual={
+            recipeCreationDraft
+              ? () => {
+                  consumeRecipeCreationDraft();
+                  setIsCreateSheetOpen(false);
+                  setHasOpenedRecipeDraft(false);
+                }
+              : undefined
+          }
           onOpenChange={setIsCreateSheetOpen}
           onCreated={(recipeId) => {
             if (!recipeCreationDraft) {

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -173,6 +173,25 @@ export function RecipesView() {
                   ? selectedRecipe.error.message
                   : "Try again in a moment."}
               </p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setSelectedRecipeId(null)}
+                >
+                  Back to recipes
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={selectedRecipe.isRefetching}
+                  onClick={() => {
+                    void selectedRecipe.refetch();
+                  }}
+                >
+                  Retry
+                </Button>
+              </div>
             </div>
           ) : null
         ) : isLoading ? (

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,7 +1,10 @@
 import { ArrowLeft, Plus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useRecipes } from "@/api";
-import { RecipeFilterBar } from "@/components/recipes/recipe-filter-bar";
+import {
+  RecipeFilterBar,
+  type RecipeTagFilterOption,
+} from "@/components/recipes/recipe-filter-bar";
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
 import { Button } from "@/components/ui/button";
 import type { RecipeSummary } from "@/lib/types";
@@ -9,6 +12,10 @@ import { cn } from "@/lib/utils";
 
 function normalizeValue(value: string) {
   return value.trim().toLowerCase();
+}
+
+function displayTag(value: string) {
+  return normalizeValue(value);
 }
 
 function matchesSearch(recipe: RecipeSummary, query: string) {
@@ -45,16 +52,26 @@ export function RecipesView() {
   const searchQuery = normalizeValue(searchValue);
 
   const availableTags = useMemo(() => {
-    return [...new Set(recipes.flatMap((recipe) => recipe.tags))].sort((a, b) =>
-      a.localeCompare(b),
-    );
+    const tagMap = new Map<string, RecipeTagFilterOption>();
+
+    for (const tag of recipes.flatMap((recipe) => recipe.tags)) {
+      const normalizedTag = normalizeValue(tag);
+      if (!normalizedTag) continue;
+      tagMap.set(normalizedTag, {
+        label: displayTag(tag),
+        value: normalizedTag,
+      });
+    }
+
+    return [...tagMap.values()].sort((a, b) => a.label.localeCompare(b.label));
   }, [recipes]);
 
   const filteredRecipes = useMemo(() => {
     const visibleRecipes = recipes.filter((recipe) => {
       const matchesFavorites = !favoritesOnly || recipe.favorite;
       const matchesTag =
-        selectedTag === null || recipe.tags.includes(selectedTag);
+        selectedTag === null ||
+        recipe.tags.some((tag) => normalizeValue(tag) === selectedTag);
 
       return (
         matchesFavorites && matchesTag && matchesSearch(recipe, searchQuery)
@@ -82,7 +99,7 @@ export function RecipesView() {
               <ArrowLeft className="h-4 w-4" />
               Back to recipes
             </Button>
-            <Button type="button" size="sm">
+            <Button type="button" size="sm" disabled>
               <Plus className="h-4 w-4" />
               Add recipe
             </Button>
@@ -115,7 +132,7 @@ export function RecipesView() {
               Save family favorites and discover what to cook next.
             </p>
           </div>
-          <Button type="button" className="shrink-0">
+          <Button type="button" className="shrink-0" disabled>
             <Plus className="h-4 w-4" />
             Add recipe
           </Button>

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,0 +1,7 @@
+export function RecipesView() {
+  return (
+    <section className="flex-1 overflow-auto p-6">
+      <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
+    </section>
+  );
+}

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
-import { useRecipes } from "@/api";
+import { useRecipe, useRecipes } from "@/api";
+import { RecipeCreateSheet } from "@/components/recipes/recipe-create-sheet";
 import {
   RecipeFilterBar,
   type RecipeTagFilterOption,
@@ -42,12 +43,16 @@ function sortRecipes(recipes: RecipeSummary[], favoritesOnly: boolean) {
 export function RecipesView() {
   const { data, error, isLoading, isError, refetch, isRefetching } =
     useRecipes();
+  const [isCreateSheetOpen, setIsCreateSheetOpen] = useState(false);
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const selectedRecipe = useRecipe(selectedRecipeId);
 
   const recipes = data?.data ?? [];
   const searchQuery = normalizeValue(searchValue);
+  const selectedRecipeData = selectedRecipe.data?.data ?? null;
 
   const availableTags = useMemo(() => {
     const tagMap = new Map<string, RecipeTagFilterOption>();
@@ -82,14 +87,58 @@ export function RecipesView() {
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-4">
-        <div>
-          <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
-          <p className="text-sm text-muted-foreground">
-            Save family favorites and discover what to cook next.
-          </p>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
+            <p className="text-sm text-muted-foreground">
+              Save family favorites and discover what to cook next.
+            </p>
+          </div>
+          {selectedRecipeId === null ? (
+            <Button type="button" onClick={() => setIsCreateSheetOpen(true)}>
+              Add recipe
+            </Button>
+          ) : null}
         </div>
 
-        {isLoading ? (
+        {selectedRecipeId !== null ? (
+          selectedRecipeData ? (
+            <div className="space-y-4 rounded-lg border border-border bg-card p-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setSelectedRecipeId(null)}
+              >
+                Back to recipes
+              </Button>
+              <div className="space-y-1">
+                <h2 className="text-xl font-semibold text-foreground">
+                  {selectedRecipeData.title}
+                </h2>
+                {selectedRecipeData.sourceUrl ? (
+                  <p className="text-sm text-muted-foreground">
+                    {selectedRecipeData.sourceUrl}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          ) : selectedRecipe.isLoading ? (
+            <p className="text-sm font-medium text-muted-foreground">
+              Loading recipe...
+            </p>
+          ) : selectedRecipe.isError ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+              <h2 className="text-base font-semibold text-foreground">
+                Recipe could not be loaded
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {selectedRecipe.error instanceof Error
+                  ? selectedRecipe.error.message
+                  : "Try again in a moment."}
+              </p>
+            </div>
+          ) : null
+        ) : isLoading ? (
           <div className="space-y-3">
             <p className="text-sm font-medium text-muted-foreground">
               Loading recipes...
@@ -109,9 +158,7 @@ export function RecipesView() {
               ))}
             </div>
           </div>
-        ) : null}
-
-        {isError ? (
+        ) : isError ? (
           <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
             <h2 className="text-base font-semibold text-foreground">
               Recipes could not be loaded
@@ -133,9 +180,7 @@ export function RecipesView() {
               Retry
             </Button>
           </div>
-        ) : null}
-
-        {!isLoading && !isError ? (
+        ) : !isLoading && !isError ? (
           <>
             <RecipeFilterBar
               availableTags={availableTags}
@@ -176,6 +221,12 @@ export function RecipesView() {
             )}
           </>
         ) : null}
+
+        <RecipeCreateSheet
+          isOpen={isCreateSheetOpen}
+          onOpenChange={setIsCreateSheetOpen}
+          onCreated={setSelectedRecipeId}
+        />
       </div>
     </section>
   );

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRecipe, useRecipes, useUpdateRecipe } from "@/api";
 import { RecipeCreateSheet } from "@/components/recipes/recipe-create-sheet";
 import { RecipeDetailView } from "@/components/recipes/recipe-detail-view";
@@ -9,8 +9,10 @@ import {
 } from "@/components/recipes/recipe-filter-bar";
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
 import { Button } from "@/components/ui/button";
+import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
 import type { RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { useAppStore } from "@/stores";
 
 function normalizeValue(value: string) {
   return value.trim().toLowerCase();
@@ -45,12 +47,20 @@ function sortRecipes(recipes: RecipeSummary[], favoritesOnly: boolean) {
 export function RecipesView() {
   const { data, error, isLoading, isError, refetch, isRefetching } =
     useRecipes();
+  const recipeCreationDraft = useAppStore((state) => state.recipeCreationDraft);
+  const consumeRecipeCreationDraft = useAppStore(
+    (state) => state.consumeRecipeCreationDraft,
+  );
+  const startMealPlacementFromRecipe = useAppStore(
+    (state) => state.startMealPlacementFromRecipe,
+  );
   const [isCreateSheetOpen, setIsCreateSheetOpen] = useState(false);
   const [isEditSheetOpen, setIsEditSheetOpen] = useState(false);
   const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [hasOpenedRecipeDraft, setHasOpenedRecipeDraft] = useState(false);
   const selectedRecipe = useRecipe(selectedRecipeId);
 
   const recipes = data?.data ?? [];
@@ -88,6 +98,25 @@ export function RecipesView() {
     return sortRecipes(visibleRecipes, favoritesOnly);
   }, [favoritesOnly, recipes, searchQuery, selectedTag]);
 
+  useEffect(() => {
+    if (!recipeCreationDraft) {
+      setHasOpenedRecipeDraft(false);
+      return;
+    }
+
+    if (!hasOpenedRecipeDraft) {
+      setSelectedRecipeId(null);
+      setIsEditSheetOpen(false);
+      setIsCreateSheetOpen(true);
+      setHasOpenedRecipeDraft(true);
+    }
+  }, [hasOpenedRecipeDraft, recipeCreationDraft]);
+
+  const createSheetMode = recipeCreationDraft ? "manual" : "choices";
+  const createSheetDefaultValues = recipeCreationDraft
+    ? { title: recipeCreationDraft.typedTitle }
+    : undefined;
+
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-4">
@@ -110,6 +139,15 @@ export function RecipesView() {
             <RecipeDetailView
               recipe={selectedRecipeData}
               isUpdatingFavorite={updateSelectedRecipe.isPending}
+              onAddToMeals={() => {
+                startMealPlacementFromRecipe({
+                  recipeId: selectedRecipeData.id,
+                  requestedAtWeekStartDate: formatLocalDate(
+                    getWeekStartSunday(new Date()),
+                  ),
+                  source: { kind: "recipes-library" },
+                });
+              }}
               onBack={() => {
                 setIsEditSheetOpen(false);
                 setSelectedRecipeId(null);
@@ -225,9 +263,32 @@ export function RecipesView() {
         ) : null}
 
         <RecipeCreateSheet
+          defaultMode={createSheetMode}
+          defaultValues={createSheetDefaultValues}
           isOpen={isCreateSheetOpen}
           onOpenChange={setIsCreateSheetOpen}
-          onCreated={setSelectedRecipeId}
+          onCreated={(recipeId) => {
+            if (!recipeCreationDraft) {
+              setSelectedRecipeId(recipeId);
+              return;
+            }
+
+            const consumedDraft = consumeRecipeCreationDraft();
+            if (!consumedDraft) {
+              setSelectedRecipeId(recipeId);
+              return;
+            }
+
+            startMealPlacementFromRecipe({
+              recipeId,
+              requestedAtWeekStartDate: consumedDraft.requestedAtWeekStartDate,
+              source: {
+                kind: "meals-slot",
+                dayIndex: consumedDraft.dayIndex,
+                mealType: consumedDraft.mealType,
+              },
+            });
+          }}
         />
         {selectedRecipeData ? (
           <RecipeEditSheet

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/recipes/recipe-filter-bar";
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
 import { Button } from "@/components/ui/button";
+import { formatRecipeTag } from "@/lib/recipe-tags";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
 import type { RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -18,15 +19,11 @@ function normalizeValue(value: string) {
   return value.trim().toLowerCase();
 }
 
-function displayTag(value: string) {
-  return normalizeValue(value);
-}
-
 function matchesSearch(recipe: RecipeSummary, query: string) {
   if (!query) return true;
 
   const normalizedTitle = normalizeValue(recipe.title);
-  const normalizedTags = recipe.tags.map(normalizeValue);
+  const normalizedTags = recipe.tags.map(formatRecipeTag);
 
   return (
     normalizedTitle.includes(query) ||
@@ -34,11 +31,39 @@ function matchesSearch(recipe: RecipeSummary, query: string) {
   );
 }
 
-function sortRecipes(recipes: RecipeSummary[], favoritesOnly: boolean) {
+function compareByRecency(left: RecipeSummary, right: RecipeSummary) {
+  // updatedAt is a zero-padded ISO timestamp, so a lexicographic compare is
+  // chronological; sort descending so most-recently-updated comes first.
+  return right.updatedAt.localeCompare(left.updatedAt);
+}
+
+function compareByFavorite(left: RecipeSummary, right: RecipeSummary) {
+  if (left.favorite === right.favorite) return 0;
+  return left.favorite ? -1 : 1;
+}
+
+/**
+ * Default library browse is ordered by recent activity (spec acceptance
+ * criterion). Favorites are only prioritized when searching, matching the
+ * spec's "favorites surface higher in pickers and search" rule.
+ */
+function sortRecipes(recipes: RecipeSummary[], isSearching: boolean) {
   return [...recipes].sort((left, right) => {
-    if (!favoritesOnly && left.favorite !== right.favorite) {
-      return left.favorite ? -1 : 1;
+    if (isSearching) {
+      const byFavorite = compareByFavorite(left, right);
+      if (byFavorite !== 0) return byFavorite;
+
+      const byRecency = compareByRecency(left, right);
+      if (byRecency !== 0) return byRecency;
+
+      return left.title.localeCompare(right.title);
     }
+
+    const byRecency = compareByRecency(left, right);
+    if (byRecency !== 0) return byRecency;
+
+    const byFavorite = compareByFavorite(left, right);
+    if (byFavorite !== 0) return byFavorite;
 
     return left.title.localeCompare(right.title);
   });
@@ -72,10 +97,10 @@ export function RecipesView() {
     const tagMap = new Map<string, RecipeTagFilterOption>();
 
     for (const tag of recipes.flatMap((recipe) => recipe.tags)) {
-      const normalizedTag = normalizeValue(tag);
+      const normalizedTag = formatRecipeTag(tag);
       if (!normalizedTag) continue;
       tagMap.set(normalizedTag, {
-        label: displayTag(tag),
+        label: normalizedTag,
         value: normalizedTag,
       });
     }
@@ -88,14 +113,14 @@ export function RecipesView() {
       const matchesFavorites = !favoritesOnly || recipe.favorite;
       const matchesTag =
         selectedTag === null ||
-        recipe.tags.some((tag) => normalizeValue(tag) === selectedTag);
+        recipe.tags.some((tag) => formatRecipeTag(tag) === selectedTag);
 
       return (
         matchesFavorites && matchesTag && matchesSearch(recipe, searchQuery)
       );
     });
 
-    return sortRecipes(visibleRecipes, favoritesOnly);
+    return sortRecipes(visibleRecipes, searchQuery.length > 0);
   }, [favoritesOnly, recipes, searchQuery, selectedTag]);
 
   useEffect(() => {

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,7 +1,217 @@
-export function RecipesView() {
+import { ArrowLeft, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useRecipes } from "@/api";
+import { RecipeFilterBar } from "@/components/recipes/recipe-filter-bar";
+import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
+import { Button } from "@/components/ui/button";
+import type { RecipeSummary } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+function normalizeValue(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function matchesSearch(recipe: RecipeSummary, query: string) {
+  if (!query) return true;
+
+  const normalizedTitle = normalizeValue(recipe.title);
+  const normalizedTags = recipe.tags.map(normalizeValue);
+
   return (
-    <section className="flex-1 overflow-auto p-6">
-      <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
+    normalizedTitle.includes(query) ||
+    normalizedTags.some((tag) => tag.includes(query))
+  );
+}
+
+function sortRecipes(recipes: RecipeSummary[], favoritesOnly: boolean) {
+  return [...recipes].sort((left, right) => {
+    if (!favoritesOnly && left.favorite !== right.favorite) {
+      return left.favorite ? -1 : 1;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+}
+
+export function RecipesView() {
+  const { data, error, isLoading, isError, refetch, isRefetching } =
+    useRecipes();
+  const [searchValue, setSearchValue] = useState("");
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null);
+
+  const recipes = data?.data ?? [];
+  const searchQuery = normalizeValue(searchValue);
+
+  const availableTags = useMemo(() => {
+    return [...new Set(recipes.flatMap((recipe) => recipe.tags))].sort((a, b) =>
+      a.localeCompare(b),
+    );
+  }, [recipes]);
+
+  const filteredRecipes = useMemo(() => {
+    const visibleRecipes = recipes.filter((recipe) => {
+      const matchesFavorites = !favoritesOnly || recipe.favorite;
+      const matchesTag =
+        selectedTag === null || recipe.tags.includes(selectedTag);
+
+      return (
+        matchesFavorites && matchesTag && matchesSearch(recipe, searchQuery)
+      );
+    });
+
+    return sortRecipes(visibleRecipes, favoritesOnly);
+  }, [favoritesOnly, recipes, searchQuery, selectedTag]);
+
+  const selectedRecipe = useMemo(
+    () => recipes.find((recipe) => recipe.id === selectedRecipeId) ?? null,
+    [recipes, selectedRecipeId],
+  );
+
+  if (selectedRecipeId !== null) {
+    return (
+      <section className="flex-1 overflow-y-auto p-4 sm:p-6">
+        <div className="mx-auto flex max-w-2xl flex-col gap-4">
+          <div className="flex items-center justify-between gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setSelectedRecipeId(null)}
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to recipes
+            </Button>
+            <Button type="button" size="sm">
+              <Plus className="h-4 w-4" />
+              Add recipe
+            </Button>
+          </div>
+
+          <div className="rounded-lg border border-border bg-card p-5 shadow-xs">
+            <p className="text-sm font-medium text-muted-foreground">
+              Selected recipe: {selectedRecipeId}
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold text-foreground">
+              {selectedRecipe?.title ?? "Recipe detail"}
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Recipe detail is coming in Task 5. This placeholder confirms card
+              navigation and selected-recipe mode.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="flex-1 overflow-y-auto p-4 sm:p-6">
+      <div className="mx-auto flex max-w-3xl flex-col gap-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
+            <p className="text-sm text-muted-foreground">
+              Save family favorites and discover what to cook next.
+            </p>
+          </div>
+          <Button type="button" className="shrink-0">
+            <Plus className="h-4 w-4" />
+            Add recipe
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="space-y-3">
+            <p className="text-sm font-medium text-muted-foreground">
+              Loading recipes...
+            </p>
+            <div className="grid gap-3">
+              {Array.from({ length: 3 }, (_, index) => (
+                <div
+                  key={`recipe-loading-${index}`}
+                  className="overflow-hidden rounded-lg border border-border bg-card"
+                >
+                  <div className="aspect-[4/3] animate-pulse bg-muted" />
+                  <div className="space-y-3 p-4">
+                    <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+                    <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {isError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+            <h2 className="text-base font-semibold text-foreground">
+              Recipes could not be loaded
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {error instanceof Error
+                ? error.message
+                : "Try again in a moment."}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-3"
+              onClick={() => {
+                void refetch();
+              }}
+              disabled={isRefetching}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+
+        {!isLoading && !isError ? (
+          <>
+            <RecipeFilterBar
+              availableTags={availableTags}
+              favoritesOnly={favoritesOnly}
+              onFavoritesOnlyChange={setFavoritesOnly}
+              onSearchChange={setSearchValue}
+              onTagChange={setSelectedTag}
+              searchValue={searchValue}
+              selectedTag={selectedTag}
+            />
+
+            {recipes.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                <h2 className="text-lg font-semibold text-foreground">
+                  No recipes yet
+                </h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Add your first recipe to get started.
+                </p>
+              </div>
+            ) : filteredRecipes.length === 0 ? (
+              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                <h2 className="text-lg font-semibold text-foreground">
+                  No recipes match those filters
+                </h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Try a different search or clear a filter chip.
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-3">
+                {filteredRecipes.map((recipe) => (
+                  <div key={recipe.id} className={cn("min-w-0")}>
+                    <RecipeLibraryCard
+                      recipe={recipe}
+                      onSelect={setSelectedRecipeId}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
-import { useRecipe, useRecipes } from "@/api";
+import { useRecipe, useRecipes, useUpdateRecipe } from "@/api";
 import { RecipeCreateSheet } from "@/components/recipes/recipe-create-sheet";
+import { RecipeDetailView } from "@/components/recipes/recipe-detail-view";
+import { RecipeEditSheet } from "@/components/recipes/recipe-edit-sheet";
 import {
   RecipeFilterBar,
   type RecipeTagFilterOption,
@@ -44,6 +46,7 @@ export function RecipesView() {
   const { data, error, isLoading, isError, refetch, isRefetching } =
     useRecipes();
   const [isCreateSheetOpen, setIsCreateSheetOpen] = useState(false);
+  const [isEditSheetOpen, setIsEditSheetOpen] = useState(false);
   const [selectedRecipeId, setSelectedRecipeId] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const [favoritesOnly, setFavoritesOnly] = useState(false);
@@ -53,6 +56,7 @@ export function RecipesView() {
   const recipes = data?.data ?? [];
   const searchQuery = normalizeValue(searchValue);
   const selectedRecipeData = selectedRecipe.data?.data ?? null;
+  const updateSelectedRecipe = useUpdateRecipe(selectedRecipeId ?? "none");
 
   const availableTags = useMemo(() => {
     const tagMap = new Map<string, RecipeTagFilterOption>();
@@ -103,25 +107,20 @@ export function RecipesView() {
 
         {selectedRecipeId !== null ? (
           selectedRecipeData ? (
-            <div className="space-y-4 rounded-lg border border-border bg-card p-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setSelectedRecipeId(null)}
-              >
-                Back to recipes
-              </Button>
-              <div className="space-y-1">
-                <h2 className="text-xl font-semibold text-foreground">
-                  {selectedRecipeData.title}
-                </h2>
-                {selectedRecipeData.sourceUrl ? (
-                  <p className="text-sm text-muted-foreground">
-                    {selectedRecipeData.sourceUrl}
-                  </p>
-                ) : null}
-              </div>
-            </div>
+            <RecipeDetailView
+              recipe={selectedRecipeData}
+              isUpdatingFavorite={updateSelectedRecipe.isPending}
+              onBack={() => {
+                setIsEditSheetOpen(false);
+                setSelectedRecipeId(null);
+              }}
+              onEdit={() => setIsEditSheetOpen(true)}
+              onToggleFavorite={() => {
+                updateSelectedRecipe.mutate({
+                  favorite: !selectedRecipeData.favorite,
+                });
+              }}
+            />
           ) : selectedRecipe.isLoading ? (
             <p className="text-sm font-medium text-muted-foreground">
               Loading recipe...
@@ -214,7 +213,10 @@ export function RecipesView() {
               <div className="grid gap-3">
                 {filteredRecipes.map((recipe) => (
                   <div key={recipe.id} className={cn("min-w-0")}>
-                    <RecipeLibraryCard recipe={recipe} />
+                    <RecipeLibraryCard
+                      recipe={recipe}
+                      onSelect={(recipeId) => setSelectedRecipeId(recipeId)}
+                    />
                   </div>
                 ))}
               </div>
@@ -227,6 +229,13 @@ export function RecipesView() {
           onOpenChange={setIsCreateSheetOpen}
           onCreated={setSelectedRecipeId}
         />
+        {selectedRecipeData ? (
+          <RecipeEditSheet
+            recipe={selectedRecipeData}
+            isOpen={isEditSheetOpen}
+            onOpenChange={setIsEditSheetOpen}
+          />
+        ) : null}
       </div>
     </section>
   );

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -3,6 +3,7 @@ import { useCreateRecipe, useImportRecipe } from "@/api";
 import { Button } from "@/components/ui/button";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
 import type { RecipeDetailApiResponse } from "@/lib/types";
+import type { RecipeFormData } from "@/lib/validations/recipes";
 import { RecipeForm, toRecipeRequest } from "./recipe-form";
 import { RecipeImportSheet } from "./recipe-import-sheet";
 
@@ -12,22 +13,32 @@ interface RecipeCreateSheetProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated: (recipeId: string) => void;
+  defaultMode?: AddRecipeMode;
+  defaultValues?: Partial<RecipeFormData>;
 }
 
 export function RecipeCreateSheet({
   isOpen,
   onOpenChange,
   onCreated,
+  defaultMode = "choices",
+  defaultValues,
 }: RecipeCreateSheetProps) {
-  const [mode, setMode] = useState<AddRecipeMode>("choices");
+  const [mode, setMode] = useState<AddRecipeMode>(defaultMode);
   const [importError, setImportError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isOpen) {
-      setMode("choices");
+      setMode(defaultMode);
       setImportError(null);
     }
-  }, [isOpen]);
+  }, [defaultMode, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMode(defaultMode);
+    }
+  }, [defaultMode, isOpen]);
 
   const handleSuccess = (response: RecipeDetailApiResponse) => {
     onOpenChange(false);
@@ -62,6 +73,7 @@ export function RecipeCreateSheet({
         title="Create Recipe"
       >
         <RecipeForm
+          defaultValues={defaultValues}
           isPending={createRecipe.isPending}
           errorMessage={createRecipe.isError ? createErrorMessage : null}
           onSubmit={(values) => createRecipe.mutate(toRecipeRequest(values))}

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react";
+import { useCreateRecipe, useImportRecipe } from "@/api";
+import { Button } from "@/components/ui/button";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+import type { RecipeDetailApiResponse } from "@/lib/types";
+import { RecipeForm, toRecipeRequest } from "./recipe-form";
+import { RecipeImportSheet } from "./recipe-import-sheet";
+
+type AddRecipeMode = "choices" | "manual" | "import";
+
+interface RecipeCreateSheetProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (recipeId: string) => void;
+}
+
+export function RecipeCreateSheet({
+  isOpen,
+  onOpenChange,
+  onCreated,
+}: RecipeCreateSheetProps) {
+  const [mode, setMode] = useState<AddRecipeMode>("choices");
+  const [importError, setImportError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setMode("choices");
+      setImportError(null);
+    }
+  }, [isOpen]);
+
+  const handleSuccess = (response: RecipeDetailApiResponse) => {
+    onOpenChange(false);
+    onCreated(response.data.id);
+  };
+
+  const createRecipe = useCreateRecipe({
+    onSuccess: handleSuccess,
+  });
+  const importRecipe = useImportRecipe({
+    onSuccess: (response) => {
+      setImportError(null);
+      handleSuccess(response);
+    },
+  });
+
+  const goBackToChoices = () => {
+    setMode("choices");
+    setImportError(null);
+  };
+
+  if (mode === "manual") {
+    return (
+      <MobileSheet
+        isOpen={isOpen}
+        onClose={goBackToChoices}
+        title="Create Recipe"
+      >
+        <RecipeForm
+          isPending={createRecipe.isPending}
+          onSubmit={(values) => createRecipe.mutate(toRecipeRequest(values))}
+        />
+      </MobileSheet>
+    );
+  }
+
+  if (mode === "import") {
+    return (
+      <RecipeImportSheet
+        isOpen={isOpen}
+        isPending={importRecipe.isPending}
+        errorMessage={importError}
+        onBack={goBackToChoices}
+        onSubmit={(url) => {
+          setImportError(null);
+          importRecipe.mutate(
+            { url },
+            {
+              onError: (error) => {
+                setImportError(
+                  error instanceof Error
+                    ? error.message
+                    : "Could not import recipe",
+                );
+              },
+            },
+          );
+        }}
+      />
+    );
+  }
+
+  return (
+    <MobileSheet
+      isOpen={isOpen}
+      onClose={() => onOpenChange(false)}
+      title="Add Recipe"
+    >
+      <div className="space-y-3">
+        <Button
+          type="button"
+          variant="outline"
+          className="h-auto w-full justify-start px-4 py-4 text-left"
+          onClick={() => setMode("manual")}
+        >
+          Create manually
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          className="h-auto w-full justify-start px-4 py-4 text-left"
+          onClick={() => setMode("import")}
+        >
+          Import from URL
+        </Button>
+      </div>
+    </MobileSheet>
+  );
+}

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -3,7 +3,7 @@ import { useCreateRecipe, useImportRecipe } from "@/api";
 import { Button } from "@/components/ui/button";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
 import type { RecipeDetailApiResponse } from "@/lib/types";
-import type { RecipeFormData } from "@/lib/validations/recipes";
+import type { RecipeFormInput } from "@/lib/validations/recipes";
 import { RecipeForm, toRecipeRequest } from "./recipe-form";
 import { RecipeImportSheet } from "./recipe-import-sheet";
 
@@ -14,7 +14,7 @@ interface RecipeCreateSheetProps {
   onOpenChange: (open: boolean) => void;
   onCreated: (recipeId: string) => void;
   defaultMode?: AddRecipeMode;
-  defaultValues?: Partial<RecipeFormData>;
+  defaultValues?: Partial<RecipeFormInput>;
   onCancelManual?: () => void;
 }
 
@@ -57,9 +57,8 @@ export function RecipeCreateSheet({
     },
   });
 
-  const goBackToChoices = () => {
-    setMode("choices");
-    setImportError(null);
+  const closeAddFlow = () => {
+    onOpenChange(false);
   };
 
   const closeManual = () => {
@@ -68,7 +67,9 @@ export function RecipeCreateSheet({
       return;
     }
 
-    goBackToChoices();
+    // "Cancel" dismisses the whole add flow to match its label, rather than
+    // quietly stepping back to the choices screen.
+    closeAddFlow();
   };
 
   if (mode === "manual") {
@@ -95,7 +96,7 @@ export function RecipeCreateSheet({
         isOpen={isOpen}
         isPending={importRecipe.isPending}
         errorMessage={importError}
-        onBack={goBackToChoices}
+        onClose={closeAddFlow}
         onSubmit={(url) => {
           setImportError(null);
           importRecipe.mutate(

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -50,6 +50,11 @@ export function RecipeCreateSheet({
   };
 
   if (mode === "manual") {
+    const createErrorMessage =
+      createRecipe.error instanceof Error
+        ? createRecipe.error.message
+        : "Could not save recipe";
+
     return (
       <MobileSheet
         isOpen={isOpen}
@@ -58,6 +63,7 @@ export function RecipeCreateSheet({
       >
         <RecipeForm
           isPending={createRecipe.isPending}
+          errorMessage={createRecipe.isError ? createErrorMessage : null}
           onSubmit={(values) => createRecipe.mutate(toRecipeRequest(values))}
         />
       </MobileSheet>

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -15,6 +15,7 @@ interface RecipeCreateSheetProps {
   onCreated: (recipeId: string) => void;
   defaultMode?: AddRecipeMode;
   defaultValues?: Partial<RecipeFormData>;
+  onCancelManual?: () => void;
 }
 
 export function RecipeCreateSheet({
@@ -23,6 +24,7 @@ export function RecipeCreateSheet({
   onCreated,
   defaultMode = "choices",
   defaultValues,
+  onCancelManual,
 }: RecipeCreateSheetProps) {
   const [mode, setMode] = useState<AddRecipeMode>(defaultMode);
   const [importError, setImportError] = useState<string | null>(null);
@@ -60,6 +62,15 @@ export function RecipeCreateSheet({
     setImportError(null);
   };
 
+  const closeManual = () => {
+    if (onCancelManual) {
+      onCancelManual();
+      return;
+    }
+
+    goBackToChoices();
+  };
+
   if (mode === "manual") {
     const createErrorMessage =
       createRecipe.error instanceof Error
@@ -67,11 +78,7 @@ export function RecipeCreateSheet({
         : "Could not save recipe";
 
     return (
-      <MobileSheet
-        isOpen={isOpen}
-        onClose={goBackToChoices}
-        title="Create Recipe"
-      >
+      <MobileSheet isOpen={isOpen} onClose={closeManual} title="Create Recipe">
         <RecipeForm
           defaultValues={defaultValues}
           isPending={createRecipe.isPending}

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -67,8 +67,11 @@ export function RecipeDetailView({
         {recipe.ingredients.length > 0 ? (
           <DetailSection title="Ingredients">
             <ul className="space-y-2 text-sm text-foreground">
-              {recipe.ingredients.map((ingredient) => (
-                <li key={ingredient} className="list-inside list-disc">
+              {recipe.ingredients.map((ingredient, index) => (
+                <li
+                  key={`${index}-${ingredient}`}
+                  className="list-inside list-disc"
+                >
                   {ingredient}
                 </li>
               ))}
@@ -79,8 +82,11 @@ export function RecipeDetailView({
         {recipe.instructions.length > 0 ? (
           <DetailSection title="Instructions">
             <ol className="space-y-2 text-sm text-foreground">
-              {recipe.instructions.map((instruction) => (
-                <li key={instruction} className="list-inside list-decimal">
+              {recipe.instructions.map((instruction, index) => (
+                <li
+                  key={`${index}-${instruction}`}
+                  className="list-inside list-decimal"
+                >
                   {instruction}
                 </li>
               ))}
@@ -90,9 +96,9 @@ export function RecipeDetailView({
 
         {recipe.tags.length > 0 ? (
           <div className="flex flex-wrap gap-2">
-            {recipe.tags.map((tag) => (
+            {recipe.tags.map((tag, index) => (
               <span
-                key={tag}
+                key={`${index}-${tag}`}
                 className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
               >
                 {tag}

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Heart, Pencil } from "lucide-react";
 import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
+import { formatRecipeTag } from "@/lib/recipe-tags";
 import type { RecipeDetail } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -55,12 +56,31 @@ export function RecipeDetailView({
           )}
         </div>
 
-        <div className="space-y-2">
+        <div className="space-y-3">
           <h2 className="text-2xl font-semibold text-foreground">
             {recipe.title}
           </h2>
-          {recipe.note ? (
-            <p className="text-sm text-muted-foreground">{recipe.note}</p>
+          {recipe.tags.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {recipe.tags.map((tag, index) => (
+                <span
+                  key={`${index}-${tag}`}
+                  className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
+                >
+                  {formatRecipeTag(tag)}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {recipe.sourceUrl ? (
+            <a
+              href={recipe.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              View source
+            </a>
           ) : null}
         </div>
 
@@ -94,28 +114,8 @@ export function RecipeDetailView({
           </DetailSection>
         ) : null}
 
-        {recipe.tags.length > 0 ? (
-          <div className="flex flex-wrap gap-2">
-            {recipe.tags.map((tag, index) => (
-              <span
-                key={`${index}-${tag}`}
-                className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        ) : null}
-
-        {recipe.sourceUrl ? (
-          <a
-            href={recipe.sourceUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex text-sm font-medium text-primary underline-offset-4 hover:underline"
-          >
-            View source
-          </a>
+        {recipe.note ? (
+          <p className="text-sm text-muted-foreground">{recipe.note}</p>
         ) : null}
 
         <div className="flex flex-wrap gap-2 border-t border-border pt-4">
@@ -146,7 +146,7 @@ export function RecipeDetailView({
                   : "text-current",
               )}
             />
-            {recipe.favorite ? "Favorite" : "Mark favorite"}
+            {recipe.favorite ? "Favorited" : "Favorite"}
           </Button>
         </div>
       </div>

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -1,0 +1,145 @@
+import { ArrowLeft, Heart, Pencil } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import type { RecipeDetail } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+function DetailSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-lg font-semibold text-foreground">{title}</h3>
+      {children}
+    </section>
+  );
+}
+
+interface RecipeDetailViewProps {
+  recipe: RecipeDetail;
+  isUpdatingFavorite?: boolean;
+  onBack: () => void;
+  onEdit: () => void;
+  onToggleFavorite: () => void;
+}
+
+export function RecipeDetailView({
+  recipe,
+  isUpdatingFavorite = false,
+  onBack,
+  onEdit,
+  onToggleFavorite,
+}: RecipeDetailViewProps) {
+  return (
+    <div className="space-y-4 rounded-lg border border-border bg-card p-4">
+      <Button type="button" variant="outline" onClick={onBack}>
+        <ArrowLeft className="h-4 w-4" />
+        Back to recipes
+      </Button>
+
+      <div className="space-y-5">
+        <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
+          {recipe.imageUrl ? (
+            <img
+              src={recipe.imageUrl}
+              alt={recipe.title}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center">
+              <span className="text-sm font-medium text-muted-foreground">
+                No photo
+              </span>
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold text-foreground">
+            {recipe.title}
+          </h2>
+          {recipe.note ? (
+            <p className="text-sm text-muted-foreground">{recipe.note}</p>
+          ) : null}
+        </div>
+
+        {recipe.ingredients.length > 0 ? (
+          <DetailSection title="Ingredients">
+            <ul className="space-y-2 text-sm text-foreground">
+              {recipe.ingredients.map((ingredient) => (
+                <li key={ingredient} className="list-inside list-disc">
+                  {ingredient}
+                </li>
+              ))}
+            </ul>
+          </DetailSection>
+        ) : null}
+
+        {recipe.instructions.length > 0 ? (
+          <DetailSection title="Instructions">
+            <ol className="space-y-2 text-sm text-foreground">
+              {recipe.instructions.map((instruction) => (
+                <li key={instruction} className="list-inside list-decimal">
+                  {instruction}
+                </li>
+              ))}
+            </ol>
+          </DetailSection>
+        ) : null}
+
+        {recipe.tags.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {recipe.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {recipe.sourceUrl ? (
+          <a
+            href={recipe.sourceUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex text-sm font-medium text-primary underline-offset-4 hover:underline"
+          >
+            View source
+          </a>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2 border-t border-border pt-4">
+          <Button type="button" variant="outline" onClick={onEdit}>
+            <Pencil className="h-4 w-4" />
+            Edit recipe
+          </Button>
+          <Button
+            type="button"
+            variant={recipe.favorite ? "secondary" : "outline"}
+            aria-label={`Favorite recipe: ${recipe.title}`}
+            aria-pressed={recipe.favorite}
+            disabled={isUpdatingFavorite}
+            onClick={onToggleFavorite}
+          >
+            <Heart
+              className={cn(
+                "h-4 w-4",
+                recipe.favorite
+                  ? "fill-rose-500 text-rose-500"
+                  : "text-current",
+              )}
+            />
+            {recipe.favorite ? "Favorite" : "Mark favorite"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -23,6 +23,7 @@ interface RecipeDetailViewProps {
   recipe: RecipeDetail;
   isUpdatingFavorite?: boolean;
   onBack: () => void;
+  onAddToMeals: () => void;
   onEdit: () => void;
   onToggleFavorite: () => void;
 }
@@ -31,6 +32,7 @@ export function RecipeDetailView({
   recipe,
   isUpdatingFavorite = false,
   onBack,
+  onAddToMeals,
   onEdit,
   onToggleFavorite,
 }: RecipeDetailViewProps) {
@@ -118,6 +120,9 @@ export function RecipeDetailView({
           <Button type="button" variant="outline" onClick={onEdit}>
             <Pencil className="h-4 w-4" />
             Edit recipe
+          </Button>
+          <Button type="button" variant="outline" onClick={onAddToMeals}>
+            Add to Meals
           </Button>
           <Button
             type="button"

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -36,11 +36,6 @@ export function RecipeDetailView({
 }: RecipeDetailViewProps) {
   return (
     <div className="space-y-4 rounded-lg border border-border bg-card p-4">
-      <Button type="button" variant="outline" onClick={onBack}>
-        <ArrowLeft className="h-4 w-4" />
-        Back to recipes
-      </Button>
-
       <div className="space-y-5">
         <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
           {recipe.imageUrl ? (
@@ -116,6 +111,10 @@ export function RecipeDetailView({
         ) : null}
 
         <div className="flex flex-wrap gap-2 border-t border-border pt-4">
+          <Button type="button" variant="outline" onClick={onBack}>
+            <ArrowLeft className="h-4 w-4" />
+            Back to recipes
+          </Button>
           <Button type="button" variant="outline" onClick={onEdit}>
             <Pencil className="h-4 w-4" />
             Edit recipe

--- a/src/components/recipes/recipe-edit-sheet.tsx
+++ b/src/components/recipes/recipe-edit-sheet.tsx
@@ -18,6 +18,8 @@ function toUpdateRequest(recipe: RecipeDetail, request: UpdateRecipeRequest) {
     note: request.note,
     sourceUrl: request.sourceUrl,
     tags: request.tags,
+    // The edit form has no favorite control — favorite is toggled from recipe
+    // detail. Persist the saved recipe's favorite so editing never clears it.
     favorite: recipe.favorite,
   };
 }

--- a/src/components/recipes/recipe-edit-sheet.tsx
+++ b/src/components/recipes/recipe-edit-sheet.tsx
@@ -12,11 +12,11 @@ interface RecipeEditSheetProps {
 function toUpdateRequest(recipe: RecipeDetail, request: UpdateRecipeRequest) {
   return {
     title: request.title,
-    imageUrl: recipe.imageUrl,
+    imageUrl: request.imageUrl,
     ingredients: request.ingredients,
     instructions: request.instructions,
-    note: recipe.note,
-    sourceUrl: recipe.sourceUrl,
+    note: request.note,
+    sourceUrl: request.sourceUrl,
     tags: request.tags,
     favorite: recipe.favorite,
   };
@@ -43,6 +43,9 @@ export function RecipeEditSheet({
         key={recipe.id}
         defaultValues={{
           title: recipe.title,
+          imageUrl: recipe.imageUrl,
+          note: recipe.note,
+          sourceUrl: recipe.sourceUrl,
           ingredients: recipe.ingredients,
           instructions: recipe.instructions,
           tags: recipe.tags,

--- a/src/components/recipes/recipe-edit-sheet.tsx
+++ b/src/components/recipes/recipe-edit-sheet.tsx
@@ -1,0 +1,64 @@
+import { useUpdateRecipe } from "@/api";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+import type { RecipeDetail, UpdateRecipeRequest } from "@/lib/types";
+import { RecipeForm, toRecipeRequest } from "./recipe-form";
+
+interface RecipeEditSheetProps {
+  recipe: RecipeDetail;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function toUpdateRequest(recipe: RecipeDetail, request: UpdateRecipeRequest) {
+  return {
+    title: request.title,
+    imageUrl: recipe.imageUrl,
+    ingredients: request.ingredients,
+    instructions: request.instructions,
+    note: recipe.note,
+    sourceUrl: recipe.sourceUrl,
+    tags: request.tags,
+    favorite: recipe.favorite,
+  };
+}
+
+export function RecipeEditSheet({
+  recipe,
+  isOpen,
+  onOpenChange,
+}: RecipeEditSheetProps) {
+  const updateRecipe = useUpdateRecipe(recipe.id);
+  const errorMessage =
+    updateRecipe.error instanceof Error
+      ? updateRecipe.error.message
+      : "Could not save recipe";
+
+  return (
+    <MobileSheet
+      isOpen={isOpen}
+      onClose={() => onOpenChange(false)}
+      title="Edit Recipe"
+    >
+      <RecipeForm
+        key={recipe.id}
+        defaultValues={{
+          title: recipe.title,
+          ingredients: recipe.ingredients,
+          instructions: recipe.instructions,
+          tags: recipe.tags,
+          favorite: recipe.favorite,
+        }}
+        isPending={updateRecipe.isPending}
+        errorMessage={updateRecipe.isError ? errorMessage : null}
+        onSubmit={(values) => {
+          updateRecipe.mutate(
+            toUpdateRequest(recipe, toRecipeRequest(values)),
+            {
+              onSuccess: () => onOpenChange(false),
+            },
+          );
+        }}
+      />
+    </MobileSheet>
+  );
+}

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -3,8 +3,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
+export interface RecipeTagFilterOption {
+  label: string;
+  value: string;
+}
+
 interface RecipeFilterBarProps {
-  availableTags: string[];
+  availableTags: RecipeTagFilterOption[];
   favoritesOnly: boolean;
   onFavoritesOnlyChange: (favoritesOnly: boolean) => void;
   onSearchChange: (value: string) => void;
@@ -60,14 +65,16 @@ export function RecipeFilterBar({
 
         {availableTags.map((tag) => (
           <Button
-            key={tag}
+            key={tag.value}
             type="button"
-            variant={selectedTag === tag ? "secondary" : "outline"}
+            variant={selectedTag === tag.value ? "secondary" : "outline"}
             size="sm"
-            onClick={() => onTagChange(selectedTag === tag ? null : tag)}
+            onClick={() =>
+              onTagChange(selectedTag === tag.value ? null : tag.value)
+            }
             className="shrink-0"
           >
-            {tag}
+            {tag.label}
           </Button>
         ))}
       </div>

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -1,0 +1,76 @@
+import { Heart, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface RecipeFilterBarProps {
+  availableTags: string[];
+  favoritesOnly: boolean;
+  onFavoritesOnlyChange: (favoritesOnly: boolean) => void;
+  onSearchChange: (value: string) => void;
+  onTagChange: (tag: string | null) => void;
+  searchValue: string;
+  selectedTag: string | null;
+}
+
+export function RecipeFilterBar({
+  availableTags,
+  favoritesOnly,
+  onFavoritesOnlyChange,
+  onSearchChange,
+  onTagChange,
+  searchValue,
+  selectedTag,
+}: RecipeFilterBarProps) {
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          aria-label="Search recipes"
+          value={searchValue}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder="Search titles or tags"
+          className="pl-9"
+        />
+      </div>
+
+      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+        <Button
+          type="button"
+          variant={favoritesOnly ? "default" : "outline"}
+          size="sm"
+          onClick={() => onFavoritesOnlyChange(!favoritesOnly)}
+          className="shrink-0"
+        >
+          <Heart className={cn("h-4 w-4", favoritesOnly && "fill-current")} />
+          Favorites only
+        </Button>
+
+        <Button
+          type="button"
+          variant={selectedTag === null ? "secondary" : "outline"}
+          size="sm"
+          onClick={() => onTagChange(null)}
+          className="shrink-0"
+        >
+          All
+        </Button>
+
+        {availableTags.map((tag) => (
+          <Button
+            key={tag}
+            type="button"
+            variant={selectedTag === tag ? "secondary" : "outline"}
+            size="sm"
+            onClick={() => onTagChange(selectedTag === tag ? null : tag)}
+            className="shrink-0"
+          >
+            {tag}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -1,0 +1,183 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Plus } from "lucide-react";
+import { useForm, useWatch } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form-error";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import {
+  type RecipeFormData,
+  recipeFormSchema,
+  toRecipeRequest,
+} from "@/lib/validations/recipes";
+
+const RECIPE_FORM_ID = "recipe-form";
+const DEFAULT_LINE_COUNT = 2;
+
+function ensureMinimumLines(values: string[] | undefined) {
+  const normalized = values && values.length > 0 ? [...values] : [];
+
+  while (normalized.length < DEFAULT_LINE_COUNT) {
+    normalized.push("");
+  }
+
+  return normalized;
+}
+
+function ArrayFieldSection({
+  legend,
+  values,
+  onChange,
+  onAdd,
+}: {
+  legend: string;
+  values: string[];
+  onChange: (index: number, value: string) => void;
+  onAdd: () => void;
+}) {
+  const singular = legend.endsWith("s") ? legend.slice(0, -1) : legend;
+
+  return (
+    <fieldset className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <legend className="text-sm font-semibold text-foreground">
+          {legend}
+        </legend>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onAdd}
+          className="shrink-0"
+        >
+          <Plus className="h-4 w-4" />
+          {`Add ${singular.toLowerCase()}`}
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        {values.map((value, index) => (
+          <Input
+            key={`${singular}-${index}`}
+            aria-label={`${singular} ${index + 1}`}
+            value={value}
+            onChange={(event) => onChange(index, event.target.value)}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+interface RecipeFormProps {
+  onSubmit: (data: RecipeFormData) => void;
+  isPending?: boolean;
+}
+
+export function RecipeForm({ onSubmit, isPending = false }: RecipeFormProps) {
+  const form = useForm<RecipeFormData>({
+    resolver: zodResolver(recipeFormSchema),
+    defaultValues: {
+      title: "",
+      ingredients: ensureMinimumLines(undefined),
+      instructions: ensureMinimumLines(undefined),
+      tags: ensureMinimumLines(undefined),
+      favorite: false,
+    },
+  });
+
+  const ingredients = ensureMinimumLines(
+    useWatch({
+      control: form.control,
+      name: "ingredients",
+    }),
+  );
+  const instructions = ensureMinimumLines(
+    useWatch({
+      control: form.control,
+      name: "instructions",
+    }),
+  );
+  const tags = ensureMinimumLines(
+    useWatch({
+      control: form.control,
+      name: "tags",
+    }),
+  );
+
+  return (
+    <form
+      id={RECIPE_FORM_ID}
+      className="space-y-6"
+      onSubmit={form.handleSubmit((values) => onSubmit(values))}
+    >
+      <button type="submit" className="sr-only" tabIndex={-1} aria-hidden>
+        Save recipe
+      </button>
+
+      <div className="space-y-2">
+        <Label htmlFor="recipe-title">Title</Label>
+        <Input
+          id="recipe-title"
+          autoComplete="off"
+          {...form.register("title")}
+        />
+        <FormError message={form.formState.errors.title?.message} />
+      </div>
+
+      <ArrayFieldSection
+        legend="Ingredients"
+        values={ingredients}
+        onChange={(index, value) => {
+          const next = [...ingredients];
+          next[index] = value;
+          form.setValue("ingredients", next, { shouldDirty: true });
+        }}
+        onAdd={() => {
+          form.setValue("ingredients", [...ingredients, ""], {
+            shouldDirty: true,
+          });
+        }}
+      />
+
+      <ArrayFieldSection
+        legend="Instructions"
+        values={instructions}
+        onChange={(index, value) => {
+          const next = [...instructions];
+          next[index] = value;
+          form.setValue("instructions", next, { shouldDirty: true });
+        }}
+        onAdd={() => {
+          form.setValue("instructions", [...instructions, ""], {
+            shouldDirty: true,
+          });
+        }}
+      />
+
+      <ArrayFieldSection
+        legend="Tags"
+        values={tags}
+        onChange={(index, value) => {
+          const next = [...tags];
+          next[index] = value;
+          form.setValue("tags", next, { shouldDirty: true });
+        }}
+        onAdd={() => {
+          form.setValue("tags", [...tags, ""], {
+            shouldDirty: true,
+          });
+        }}
+      />
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={isPending} className={cn("min-w-28")}>
+          Save recipe
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+export { RECIPE_FORM_ID, toRecipeRequest };

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus } from "lucide-react";
+import type { FieldError } from "react-hook-form";
 import { useForm, useWatch } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/ui/form-error";
@@ -26,14 +27,28 @@ function ensureMinimumLines(values: string[] | undefined) {
   return normalized;
 }
 
+function textInputDefault(value: string | null | undefined) {
+  return value ?? "";
+}
+
+function getArrayErrorMessage(
+  errors: Partial<Record<number, FieldError>> | undefined,
+  index: number,
+) {
+  const message = errors?.[index]?.message;
+  return typeof message === "string" ? message : undefined;
+}
+
 function ArrayFieldSection({
   legend,
   values,
+  errorMessages,
   onChange,
   onAdd,
 }: {
   legend: string;
   values: string[];
+  errorMessages?: Array<string | undefined>;
   onChange: (index: number, value: string) => void;
   onAdd: () => void;
 }) {
@@ -59,12 +74,15 @@ function ArrayFieldSection({
 
       <div className="space-y-2">
         {values.map((value, index) => (
-          <Input
-            key={`${singular}-${index}`}
-            aria-label={`${singular} ${index + 1}`}
-            value={value}
-            onChange={(event) => onChange(index, event.target.value)}
-          />
+          <div key={`${singular}-${index}`} className="space-y-1">
+            <Input
+              aria-label={`${singular} ${index + 1}`}
+              aria-invalid={Boolean(errorMessages?.[index])}
+              value={value}
+              onChange={(event) => onChange(index, event.target.value)}
+            />
+            <FormError message={errorMessages?.[index]} />
+          </div>
         ))}
       </div>
     </fieldset>
@@ -83,9 +101,9 @@ function getDefaultValues(
 ): RecipeFormInput {
   return {
     title: defaultValues?.title ?? "",
-    imageUrl: defaultValues?.imageUrl ?? null,
-    note: defaultValues?.note ?? null,
-    sourceUrl: defaultValues?.sourceUrl ?? null,
+    imageUrl: textInputDefault(defaultValues?.imageUrl),
+    note: textInputDefault(defaultValues?.note),
+    sourceUrl: textInputDefault(defaultValues?.sourceUrl),
     ingredients: ensureMinimumLines(defaultValues?.ingredients),
     instructions: ensureMinimumLines(defaultValues?.instructions),
     tags: ensureMinimumLines(defaultValues?.tags),
@@ -122,6 +140,15 @@ export function RecipeForm({
       name: "tags",
     }),
   );
+  const ingredientErrors = form.formState.errors.ingredients as
+    | Partial<Record<number, FieldError>>
+    | undefined;
+  const instructionErrors = form.formState.errors.instructions as
+    | Partial<Record<number, FieldError>>
+    | undefined;
+  const tagErrors = form.formState.errors.tags as
+    | Partial<Record<number, FieldError>>
+    | undefined;
 
   return (
     <form
@@ -143,9 +170,49 @@ export function RecipeForm({
         <FormError message={form.formState.errors.title?.message} />
       </div>
 
+      <div className="space-y-2">
+        <Label htmlFor="recipe-image-url">Image URL</Label>
+        <Input
+          id="recipe-image-url"
+          type="url"
+          autoComplete="off"
+          placeholder="https://example.com/recipe.jpg"
+          {...form.register("imageUrl")}
+        />
+        <FormError message={form.formState.errors.imageUrl?.message} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="recipe-note">Note</Label>
+        <textarea
+          id="recipe-note"
+          className={cn(
+            "border-input placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 min-h-24 w-full min-w-0 rounded-lg border bg-transparent px-3 py-2 text-[15px] leading-5 shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+            "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+          )}
+          {...form.register("note")}
+        />
+        <FormError message={form.formState.errors.note?.message} />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="recipe-source-url">Source URL</Label>
+        <Input
+          id="recipe-source-url"
+          type="url"
+          autoComplete="off"
+          placeholder="https://example.com/recipe"
+          {...form.register("sourceUrl")}
+        />
+        <FormError message={form.formState.errors.sourceUrl?.message} />
+      </div>
+
       <ArrayFieldSection
         legend="Ingredients"
         values={ingredients}
+        errorMessages={ingredients.map((_, index) =>
+          getArrayErrorMessage(ingredientErrors, index),
+        )}
         onChange={(index, value) => {
           const next = [...ingredients];
           next[index] = value;
@@ -161,6 +228,9 @@ export function RecipeForm({
       <ArrayFieldSection
         legend="Instructions"
         values={instructions}
+        errorMessages={instructions.map((_, index) =>
+          getArrayErrorMessage(instructionErrors, index),
+        )}
         onChange={(index, value) => {
           const next = [...instructions];
           next[index] = value;
@@ -176,6 +246,9 @@ export function RecipeForm({
       <ArrayFieldSection
         legend="Tags"
         values={tags}
+        errorMessages={tags.map((_, index) =>
+          getArrayErrorMessage(tagErrors, index),
+        )}
         onChange={(index, value) => {
           const next = [...tags];
           next[index] = value;

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -74,22 +74,33 @@ interface RecipeFormProps {
   onSubmit: (data: RecipeFormData) => void;
   isPending?: boolean;
   errorMessage?: string | null;
+  defaultValues?: Partial<RecipeFormData>;
+}
+
+function getDefaultValues(
+  defaultValues?: Partial<RecipeFormData>,
+): RecipeFormData {
+  return {
+    title: defaultValues?.title ?? "",
+    imageUrl: defaultValues?.imageUrl ?? null,
+    note: defaultValues?.note ?? null,
+    sourceUrl: defaultValues?.sourceUrl ?? null,
+    ingredients: ensureMinimumLines(defaultValues?.ingredients),
+    instructions: ensureMinimumLines(defaultValues?.instructions),
+    tags: ensureMinimumLines(defaultValues?.tags),
+    favorite: defaultValues?.favorite ?? false,
+  };
 }
 
 export function RecipeForm({
   onSubmit,
   isPending = false,
   errorMessage = null,
+  defaultValues,
 }: RecipeFormProps) {
   const form = useForm<RecipeFormData>({
     resolver: zodResolver(recipeFormSchema),
-    defaultValues: {
-      title: "",
-      ingredients: ensureMinimumLines(undefined),
-      instructions: ensureMinimumLines(undefined),
-      tags: ensureMinimumLines(undefined),
-      favorite: false,
-    },
+    defaultValues: getDefaultValues(defaultValues),
   });
 
   const ingredients = ensureMinimumLines(

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -73,9 +73,14 @@ function ArrayFieldSection({
 interface RecipeFormProps {
   onSubmit: (data: RecipeFormData) => void;
   isPending?: boolean;
+  errorMessage?: string | null;
 }
 
-export function RecipeForm({ onSubmit, isPending = false }: RecipeFormProps) {
+export function RecipeForm({
+  onSubmit,
+  isPending = false,
+  errorMessage = null,
+}: RecipeFormProps) {
   const form = useForm<RecipeFormData>({
     resolver: zodResolver(recipeFormSchema),
     defaultValues: {
@@ -171,10 +176,13 @@ export function RecipeForm({ onSubmit, isPending = false }: RecipeFormProps) {
         }}
       />
 
-      <div className="flex justify-end">
-        <Button type="submit" disabled={isPending} className={cn("min-w-28")}>
-          Save recipe
-        </Button>
+      <div className="space-y-3">
+        <FormError message={errorMessage ?? undefined} />
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isPending} className={cn("min-w-28")}>
+            Save recipe
+          </Button>
+        </div>
       </div>
     </form>
   );

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -154,6 +154,7 @@ export function RecipeForm({
     <form
       id={RECIPE_FORM_ID}
       className="space-y-6"
+      noValidate
       onSubmit={form.handleSubmit((values) => onSubmit(values))}
     >
       <button type="submit" className="sr-only" tabIndex={-1} aria-hidden>
@@ -174,9 +175,11 @@ export function RecipeForm({
         <Label htmlFor="recipe-image-url">Image URL</Label>
         <Input
           id="recipe-image-url"
-          type="url"
+          type="text"
+          inputMode="url"
           autoComplete="off"
           placeholder="https://example.com/recipe.jpg"
+          aria-invalid={Boolean(form.formState.errors.imageUrl)}
           {...form.register("imageUrl")}
         />
         <FormError message={form.formState.errors.imageUrl?.message} />
@@ -199,9 +202,11 @@ export function RecipeForm({
         <Label htmlFor="recipe-source-url">Source URL</Label>
         <Input
           id="recipe-source-url"
-          type="url"
+          type="text"
+          inputMode="url"
           autoComplete="off"
           placeholder="https://example.com/recipe"
+          aria-invalid={Boolean(form.formState.errors.sourceUrl)}
           {...form.register("sourceUrl")}
         />
         <FormError message={form.formState.errors.sourceUrl?.message} />

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import {
   type RecipeFormData,
+  type RecipeFormInput,
   recipeFormSchema,
   toRecipeRequest,
 } from "@/lib/validations/recipes";
@@ -74,12 +75,12 @@ interface RecipeFormProps {
   onSubmit: (data: RecipeFormData) => void;
   isPending?: boolean;
   errorMessage?: string | null;
-  defaultValues?: Partial<RecipeFormData>;
+  defaultValues?: Partial<RecipeFormInput>;
 }
 
 function getDefaultValues(
-  defaultValues?: Partial<RecipeFormData>,
-): RecipeFormData {
+  defaultValues?: Partial<RecipeFormInput>,
+): RecipeFormInput {
   return {
     title: defaultValues?.title ?? "",
     imageUrl: defaultValues?.imageUrl ?? null,
@@ -98,7 +99,7 @@ export function RecipeForm({
   errorMessage = null,
   defaultValues,
 }: RecipeFormProps) {
-  const form = useForm<RecipeFormData>({
+  const form = useForm<RecipeFormInput, undefined, RecipeFormData>({
     resolver: zodResolver(recipeFormSchema),
     defaultValues: getDefaultValues(defaultValues),
   });

--- a/src/components/recipes/recipe-import-sheet.tsx
+++ b/src/components/recipes/recipe-import-sheet.tsx
@@ -7,16 +7,22 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
 
+function isHttpOrHttpsUrl(value: string) {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const recipeImportSchema = z.object({
   url: z
     .string()
     .trim()
     .min(1, "Recipe URL is required")
     .url("Enter a valid URL")
-    .refine((value) => {
-      const protocol = new URL(value).protocol;
-      return protocol === "http:" || protocol === "https:";
-    }, "Enter an http or https URL"),
+    .refine(isHttpOrHttpsUrl, "Enter an http or https URL"),
 });
 
 type RecipeImportFormData = z.infer<typeof recipeImportSchema>;
@@ -45,6 +51,7 @@ export function RecipeImportSheet({
     <MobileSheet isOpen={isOpen} onClose={onBack} title="Import Recipe">
       <form
         className="space-y-6"
+        noValidate
         onSubmit={form.handleSubmit((values) => onSubmit(values.url))}
       >
         <button type="submit" className="sr-only" tabIndex={-1} aria-hidden>
@@ -55,9 +62,11 @@ export function RecipeImportSheet({
           <Label htmlFor="recipe-import-url">Recipe URL</Label>
           <Input
             id="recipe-import-url"
-            type="url"
+            type="text"
+            inputMode="url"
             autoComplete="off"
             placeholder="https://example.com/recipe"
+            aria-invalid={Boolean(form.formState.errors.url)}
             {...form.register("url")}
           />
           <FormError message={form.formState.errors.url?.message} />

--- a/src/components/recipes/recipe-import-sheet.tsx
+++ b/src/components/recipes/recipe-import-sheet.tsx
@@ -1,0 +1,75 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form-error";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+
+const recipeImportSchema = z.object({
+  url: z
+    .string()
+    .trim()
+    .min(1, "Recipe URL is required")
+    .url("Enter a valid URL")
+    .refine((value) => {
+      const protocol = new URL(value).protocol;
+      return protocol === "http:" || protocol === "https:";
+    }, "Enter an http or https URL"),
+});
+
+type RecipeImportFormData = z.infer<typeof recipeImportSchema>;
+
+interface RecipeImportSheetProps {
+  isOpen: boolean;
+  isPending?: boolean;
+  errorMessage?: string | null;
+  onBack: () => void;
+  onSubmit: (url: string) => void;
+}
+
+export function RecipeImportSheet({
+  isOpen,
+  isPending = false,
+  errorMessage = null,
+  onBack,
+  onSubmit,
+}: RecipeImportSheetProps) {
+  const form = useForm<RecipeImportFormData>({
+    resolver: zodResolver(recipeImportSchema),
+    defaultValues: { url: "" },
+  });
+
+  return (
+    <MobileSheet isOpen={isOpen} onClose={onBack} title="Import Recipe">
+      <form
+        className="space-y-6"
+        onSubmit={form.handleSubmit((values) => onSubmit(values.url))}
+      >
+        <button type="submit" className="sr-only" tabIndex={-1} aria-hidden>
+          Import recipe
+        </button>
+
+        <div className="space-y-2">
+          <Label htmlFor="recipe-import-url">Recipe URL</Label>
+          <Input
+            id="recipe-import-url"
+            type="url"
+            autoComplete="off"
+            placeholder="https://example.com/recipe"
+            {...form.register("url")}
+          />
+          <FormError message={form.formState.errors.url?.message} />
+          <FormError message={errorMessage ?? undefined} />
+        </div>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isPending} className="min-w-32">
+            Import recipe
+          </Button>
+        </div>
+      </form>
+    </MobileSheet>
+  );
+}

--- a/src/components/recipes/recipe-import-sheet.tsx
+++ b/src/components/recipes/recipe-import-sheet.tsx
@@ -31,7 +31,7 @@ interface RecipeImportSheetProps {
   isOpen: boolean;
   isPending?: boolean;
   errorMessage?: string | null;
-  onBack: () => void;
+  onClose: () => void;
   onSubmit: (url: string) => void;
 }
 
@@ -39,7 +39,7 @@ export function RecipeImportSheet({
   isOpen,
   isPending = false,
   errorMessage = null,
-  onBack,
+  onClose,
   onSubmit,
 }: RecipeImportSheetProps) {
   const form = useForm<RecipeImportFormData>({
@@ -48,7 +48,7 @@ export function RecipeImportSheet({
   });
 
   return (
-    <MobileSheet isOpen={isOpen} onClose={onBack} title="Import Recipe">
+    <MobileSheet isOpen={isOpen} onClose={onClose} title="Import Recipe">
       <form
         className="space-y-6"
         noValidate

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -59,9 +59,9 @@ export function RecipeLibraryCard({
         </div>
 
         <div className="flex flex-wrap gap-2">
-          {recipe.tags.map((tag) => (
+          {recipe.tags.map((tag, index) => (
             <span
-              key={tag}
+              key={`${index}-${tag}`}
               className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
             >
               {tag}

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -4,21 +4,14 @@ import { cn } from "@/lib/utils";
 
 interface RecipeLibraryCardProps {
   recipe: RecipeSummary;
-  onSelect: (recipeId: string) => void;
 }
 
-export function RecipeLibraryCard({
-  recipe,
-  onSelect,
-}: RecipeLibraryCardProps) {
+export function RecipeLibraryCard({ recipe }: RecipeLibraryCardProps) {
   return (
-    <button
-      type="button"
+    <article
       aria-label={`Recipe card: ${recipe.title}`}
-      onClick={() => onSelect(recipe.id)}
       className={cn(
         "flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-xs transition-colors",
-        "hover:bg-accent/40 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
       )}
     >
       <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
@@ -66,6 +59,6 @@ export function RecipeLibraryCard({
           ))}
         </div>
       </div>
-    </button>
+    </article>
   );
 }

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -4,16 +4,26 @@ import { cn } from "@/lib/utils";
 
 interface RecipeLibraryCardProps {
   recipe: RecipeSummary;
+  onSelect?: (recipeId: string) => void;
 }
 
-export function RecipeLibraryCard({ recipe }: RecipeLibraryCardProps) {
+export function RecipeLibraryCard({
+  recipe,
+  onSelect,
+}: RecipeLibraryCardProps) {
   return (
     <article
       aria-label={`Recipe card: ${recipe.title}`}
       className={cn(
-        "flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-xs transition-colors",
+        "relative flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-xs transition-colors",
       )}
     >
+      <button
+        type="button"
+        aria-label={`Open recipe: ${recipe.title}`}
+        className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={() => onSelect?.(recipe.id)}
+      />
       <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
         {recipe.imageUrl ? (
           <img

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -1,4 +1,5 @@
 import { Heart } from "lucide-react";
+import { formatRecipeTag } from "@/lib/recipe-tags";
 import type { RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -40,7 +41,10 @@ export function RecipeLibraryCard({
         )}
         <div className="absolute right-3 top-3 rounded-full bg-background/90 p-2 shadow-sm">
           <Heart
-            aria-label={`Favorite recipe: ${recipe.title}`}
+            aria-hidden={!recipe.favorite}
+            aria-label={
+              recipe.favorite ? `${recipe.title} is a favorite` : undefined
+            }
             className={cn(
               "h-4 w-4",
               recipe.favorite
@@ -64,7 +68,7 @@ export function RecipeLibraryCard({
               key={`${index}-${tag}`}
               className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
             >
-              {tag}
+              {formatRecipeTag(tag)}
             </span>
           ))}
         </div>

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -1,0 +1,71 @@
+import { Heart } from "lucide-react";
+import type { RecipeSummary } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+interface RecipeLibraryCardProps {
+  recipe: RecipeSummary;
+  onSelect: (recipeId: string) => void;
+}
+
+export function RecipeLibraryCard({
+  recipe,
+  onSelect,
+}: RecipeLibraryCardProps) {
+  return (
+    <button
+      type="button"
+      aria-label={`Recipe card: ${recipe.title}`}
+      onClick={() => onSelect(recipe.id)}
+      className={cn(
+        "flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-xs transition-colors",
+        "hover:bg-accent/40 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:outline-none",
+      )}
+    >
+      <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
+        {recipe.imageUrl ? (
+          <img
+            src={recipe.imageUrl}
+            alt={recipe.title}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <span className="text-sm font-medium text-muted-foreground">
+              No photo
+            </span>
+          </div>
+        )}
+        <div className="absolute right-3 top-3 rounded-full bg-background/90 p-2 shadow-sm">
+          <Heart
+            aria-label={`Favorite recipe: ${recipe.title}`}
+            className={cn(
+              "h-4 w-4",
+              recipe.favorite
+                ? "fill-rose-500 text-rose-500"
+                : "fill-transparent text-muted-foreground",
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <h2 className="text-base leading-6 font-semibold text-foreground">
+            {recipe.title}
+          </h2>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {recipe.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </button>
+  );
+}

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -38,15 +38,20 @@ describe("MobileBottomNav", () => {
     ).toBeInTheDocument();
   });
 
-  it("uses a horizontally flexible layout for seven readable destinations", () => {
+  it("keeps all seven destinations visible without horizontal scrolling", () => {
     render(<MobileBottomNav />);
 
     const navItems = screen.getByRole("navigation", {
       name: /primary/i,
     }).firstElementChild;
+    const buttons = screen.getAllByRole("button");
 
-    expect(navItems).toHaveClass("overflow-x-auto");
-    expect(navItems).not.toHaveClass("grid-cols-7");
+    expect(navItems).toHaveClass("grid", "grid-cols-7");
+    expect(navItems).not.toHaveClass("overflow-x-auto");
+    for (const button of buttons) {
+      expect(button).toHaveClass("min-w-0");
+      expect(button).not.toHaveClass("min-w-16");
+    }
   });
 
   it("switches modules through the app store", async () => {

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -8,7 +8,7 @@ describe("MobileBottomNav", () => {
     useAppStore.setState({ activeModule: null, isSidebarOpen: false });
   });
 
-  it("renders all six tabs and marks Home active when activeModule is null", () => {
+  it("renders all seven destinations and marks Home active when activeModule is null", () => {
     render(<MobileBottomNav />);
 
     const nav = screen.getByRole("navigation", { name: /primary/i });
@@ -31,8 +31,22 @@ describe("MobileBottomNav", () => {
       screen.getByRole("button", { name: /^meals$/i }),
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("button", { name: /^recipes$/i }),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /^photos$/i }),
     ).toBeInTheDocument();
+  });
+
+  it("uses a horizontally flexible layout for seven readable destinations", () => {
+    render(<MobileBottomNav />);
+
+    const navItems = screen.getByRole("navigation", {
+      name: /primary/i,
+    }).firstElementChild;
+
+    expect(navItems).toHaveClass("overflow-x-auto");
+    expect(navItems).not.toHaveClass("grid-cols-7");
   });
 
   it("switches modules through the app store", async () => {

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -38,7 +38,7 @@ describe("MobileBottomNav", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps all seven destinations visible without horizontal scrolling", () => {
+  it("keeps all seven destinations readable in a horizontally scrollable row", () => {
     render(<MobileBottomNav />);
 
     const navItems = screen.getByRole("navigation", {
@@ -46,11 +46,11 @@ describe("MobileBottomNav", () => {
     }).firstElementChild;
     const buttons = screen.getAllByRole("button");
 
-    expect(navItems).toHaveClass("grid", "grid-cols-7");
-    expect(navItems).not.toHaveClass("overflow-x-auto");
+    expect(navItems).toHaveClass("flex", "overflow-x-auto");
+    expect(navItems).not.toHaveClass("grid-cols-7");
     for (const button of buttons) {
-      expect(button).toHaveClass("min-w-0");
-      expect(button).not.toHaveClass("min-w-16");
+      expect(button).toHaveClass("min-w-16");
+      expect(button).not.toHaveClass("min-w-0");
     }
   });
 

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -32,7 +32,7 @@ export function MobileBottomNav() {
       className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
     >
       <div
-        className="flex gap-1 overflow-x-auto px-2 pt-2"
+        className="grid grid-cols-7 gap-0.5 px-1 pt-2"
         style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
       >
         {tabs.map((tab) => {
@@ -47,14 +47,14 @@ export function MobileBottomNav() {
               aria-label={tab.label}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "flex min-h-14 min-w-16 shrink-0 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] leading-none font-semibold transition-colors",
+                "flex min-h-14 min-w-0 flex-col items-center justify-center gap-0.5 rounded-lg px-0.5 py-2 text-[10px] leading-none font-semibold transition-colors",
                 isActive
                   ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground",
               )}
             >
-              <Icon className="h-5 w-5" />
-              <span className="truncate leading-[14px]">{tab.label}</span>
+              <Icon className="h-4 w-4" />
+              <span className="max-w-full truncate leading-3">{tab.label}</span>
             </button>
           );
         })}

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenText,
   Calendar,
   CheckSquare,
   Home,
@@ -17,6 +18,7 @@ const tabs: Array<{ id: ModuleType | null; label: string; icon: LucideIcon }> =
     { id: "lists", label: "Lists", icon: ListTodo },
     { id: "chores", label: "Chores", icon: CheckSquare },
     { id: "meals", label: "Meals", icon: UtensilsCrossed },
+    { id: "recipes", label: "Recipes", icon: BookOpenText },
     { id: "photos", label: "Photos", icon: ImageIcon },
   ];
 
@@ -30,7 +32,7 @@ export function MobileBottomNav() {
       className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
     >
       <div
-        className="grid grid-cols-6 gap-1 px-2 pt-2"
+        className="flex gap-1 overflow-x-auto px-2 pt-2"
         style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
       >
         {tabs.map((tab) => {
@@ -45,7 +47,7 @@ export function MobileBottomNav() {
               aria-label={tab.label}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] leading-none font-semibold transition-colors",
+                "flex min-h-14 min-w-16 shrink-0 flex-col items-center justify-center gap-1 rounded-xl px-1 py-2 text-[11px] leading-none font-semibold transition-colors",
                 isActive
                   ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -32,7 +32,7 @@ export function MobileBottomNav() {
       className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
     >
       <div
-        className="grid grid-cols-7 gap-0.5 px-1 pt-2"
+        className="flex gap-1 overflow-x-auto px-2 pt-2"
         style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
       >
         {tabs.map((tab) => {
@@ -47,14 +47,14 @@ export function MobileBottomNav() {
               aria-label={tab.label}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "flex min-h-14 min-w-0 flex-col items-center justify-center gap-0.5 rounded-lg px-0.5 py-2 text-[10px] leading-none font-semibold transition-colors",
+                "flex min-h-14 min-w-16 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-2 text-[11px] leading-none font-semibold transition-colors",
                 isActive
                   ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
                   : "text-muted-foreground hover:bg-muted hover:text-foreground",
               )}
             >
               <Icon className="h-4 w-4" />
-              <span className="max-w-full truncate leading-3">{tab.label}</span>
+              <span className="whitespace-nowrap leading-3">{tab.label}</span>
             </button>
           );
         })}

--- a/src/components/shared/navigation-tabs.test.tsx
+++ b/src/components/shared/navigation-tabs.test.tsx
@@ -13,4 +13,15 @@ describe("NavigationTabs", () => {
 
     expect(screen.getByRole("navigation")).toHaveClass("flex", "w-20");
   });
+
+  it("renders Meals and Recipes as top-level desktop modules", () => {
+    render(<NavigationTabs />);
+
+    expect(
+      screen.getByRole("button", { name: /^meals$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^recipes$/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/shared/navigation-tabs.tsx
+++ b/src/components/shared/navigation-tabs.tsx
@@ -1,4 +1,5 @@
 import {
+  BookOpenText,
   Calendar,
   CheckSquare,
   ImageIcon,
@@ -16,6 +17,7 @@ const tabs = [
   { id: "lists" as ModuleType, label: "Lists", icon: ListTodo },
   { id: "chores" as ModuleType, label: "Chores", icon: CheckSquare },
   { id: "meals" as ModuleType, label: "Meals", icon: UtensilsCrossed },
+  { id: "recipes" as ModuleType, label: "Recipes", icon: BookOpenText },
   { id: "photos" as ModuleType, label: "Photos", icon: ImageIcon },
 ];
 

--- a/src/lib/recipe-tags.ts
+++ b/src/lib/recipe-tags.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalize a recipe tag for consistent display and comparison.
+ *
+ * Tags are intentionally lightweight, so we trim whitespace and lowercase them
+ * everywhere they surface — library cards, recipe detail, and filter chips — to
+ * avoid the same tag rendering differently in different places.
+ */
+export function formatRecipeTag(tag: string): string {
+  return tag.trim().toLowerCase();
+}

--- a/src/lib/time-utils.test.ts
+++ b/src/lib/time-utils.test.ts
@@ -11,6 +11,7 @@ import {
   getEventKey,
   getSmartDefaultTimes,
   getTimeInMinutes,
+  getWeekStartSunday,
   isEventOnDate,
   parseLocalDate,
   parseTime,
@@ -488,6 +489,20 @@ describe("time-utils", () => {
       expect(leapDay.getFullYear()).toBe(2024);
       expect(leapDay.getMonth()).toBe(1); // February
       expect(leapDay.getDate()).toBe(29);
+    });
+  });
+
+  describe("getWeekStartSunday", () => {
+    it("returns the previous sunday for a weekday using local dates", () => {
+      expect(formatLocalDate(getWeekStartSunday(new Date(2026, 5, 10)))).toBe(
+        "2026-06-07",
+      );
+    });
+
+    it("returns the same local date when given a sunday", () => {
+      expect(
+        formatLocalDate(getWeekStartSunday(new Date(2026, 5, 7, 18, 45, 0))),
+      ).toBe("2026-06-07");
     });
   });
 

--- a/src/lib/time-utils.ts
+++ b/src/lib/time-utils.ts
@@ -110,6 +110,18 @@ export function parseLocalDate(dateStr: string): Date {
 }
 
 /**
+ * Get the local Sunday that starts the week containing the provided date.
+ */
+export function getWeekStartSunday(date: Date): Date {
+  const localDate = startOfDay(date);
+  return new Date(
+    localDate.getFullYear(),
+    localDate.getMonth(),
+    localDate.getDate() - localDate.getDay(),
+  );
+}
+
+/**
  * Check if an event falls on a given date.
  * Handles both single-day events (exact date match) and multi-day events (date range).
  * Normalizes all dates to midnight to avoid time-of-day comparison bugs.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -6,3 +6,4 @@ export * from "./family";
 export * from "./google-calendar";
 export * from "./lists";
 export * from "./meals";
+export * from "./recipes";

--- a/src/lib/types/recipes.ts
+++ b/src/lib/types/recipes.ts
@@ -1,0 +1,46 @@
+import type { ApiResponse } from "./api-response";
+
+export interface RecipeSummary {
+  id: string;
+  title: string;
+  imageUrl: string | null;
+  favorite: boolean;
+  tags: string[];
+  updatedAt: string;
+}
+
+export interface RecipeDetail extends RecipeSummary {
+  ingredients: string[];
+  instructions: string[];
+  note: string | null;
+  sourceUrl: string | null;
+}
+
+export interface CreateRecipeRequest {
+  title: string;
+  imageUrl?: string | null;
+  ingredients?: string[];
+  instructions?: string[];
+  note?: string | null;
+  sourceUrl?: string | null;
+  tags?: string[];
+  favorite?: boolean;
+}
+
+export interface UpdateRecipeRequest {
+  title?: string;
+  imageUrl?: string | null;
+  ingredients?: string[];
+  instructions?: string[];
+  note?: string | null;
+  sourceUrl?: string | null;
+  tags?: string[];
+  favorite?: boolean;
+}
+
+export interface ImportRecipeRequest {
+  url: string;
+}
+
+export type RecipesApiResponse = ApiResponse<RecipeSummary[]>;
+export type RecipeDetailApiResponse = ApiResponse<RecipeDetail>;

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./lists";
 export {
   type RecipeFormData,
+  type RecipeFormInput,
   recipeFormSchema,
   toRecipeRequest,
 } from "./recipes";

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -10,3 +10,8 @@ export {
   listCreateSchema,
   listItemSchema,
 } from "./lists";
+export {
+  type RecipeFormData,
+  recipeFormSchema,
+  toRecipeRequest,
+} from "./recipes";

--- a/src/lib/validations/recipes.test.ts
+++ b/src/lib/validations/recipes.test.ts
@@ -92,4 +92,30 @@ describe("recipeFormSchema", () => {
 
     expect(toRecipeRequest(formData).instructions).toEqual([longInstruction]);
   });
+
+  it("reports an over-length array error on the original field index, even with a blank row before it", () => {
+    const result = recipeFormSchema.safeParse({
+      title: "Big Recipe",
+      ingredients: ["", "a".repeat(501)],
+      tags: ["", "c".repeat(61)],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+
+    const ingredientIssue = result.error.issues.find(
+      (issue) => issue.path[0] === "ingredients",
+    );
+    const tagIssue = result.error.issues.find(
+      (issue) => issue.path[0] === "tags",
+    );
+
+    // Index 1 is the field the user actually typed the too-long value into.
+    expect(ingredientIssue?.path).toEqual(["ingredients", 1]);
+    expect(ingredientIssue?.message).toBe(
+      "Ingredient must be 500 characters or less",
+    );
+    expect(tagIssue?.path).toEqual(["tags", 1]);
+    expect(tagIssue?.message).toBe("Tag must be 60 characters or less");
+  });
 });

--- a/src/lib/validations/recipes.test.ts
+++ b/src/lib/validations/recipes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { recipeFormSchema, toRecipeRequest } from "./recipes";
+
+describe("recipeFormSchema", () => {
+  it("requires a nonblank title", () => {
+    expect(() => recipeFormSchema.parse({ title: "   " })).toThrow(
+      "Recipe title is required",
+    );
+  });
+
+  it("normalizes optional form fields to API-ready values", () => {
+    const formData = recipeFormSchema.parse({
+      title: "  Pasta Night  ",
+      imageUrl: "",
+      note: "   ",
+      sourceUrl: "",
+      ingredients: ["  noodles  ", "", " sauce "],
+      instructions: [" boil ", " ", " toss "],
+      tags: [" dinner ", "", " kid favorite "],
+    });
+
+    expect(toRecipeRequest(formData)).toEqual({
+      title: "Pasta Night",
+      imageUrl: null,
+      note: null,
+      sourceUrl: null,
+      ingredients: ["noodles", "sauce"],
+      instructions: ["boil", "toss"],
+      tags: ["dinner", "kid favorite"],
+      favorite: false,
+    });
+  });
+
+  it("preserves ordered ingredients, instructions, and tags", () => {
+    const formData = recipeFormSchema.parse({
+      title: "Layered Salad",
+      ingredients: [" first ", "second", " third "],
+      instructions: ["prep", "build", "chill"],
+      tags: ["make-ahead", "side", "summer"],
+      favorite: true,
+    });
+
+    expect(toRecipeRequest(formData)).toMatchObject({
+      ingredients: ["first", "second", "third"],
+      instructions: ["prep", "build", "chill"],
+      tags: ["make-ahead", "side", "summer"],
+      favorite: true,
+    });
+  });
+});

--- a/src/lib/validations/recipes.test.ts
+++ b/src/lib/validations/recipes.test.ts
@@ -35,6 +35,13 @@ describe("recipeFormSchema", () => {
     expect(() =>
       recipeFormSchema.parse({
         title: "Pasta Night",
+        imageUrl: "not-a-url",
+      }),
+    ).toThrow("Enter a valid URL");
+
+    expect(() =>
+      recipeFormSchema.parse({
+        title: "Pasta Night",
         imageUrl: "ftp://example.com/photo.jpg",
       }),
     ).toThrow("Enter an http or https URL");
@@ -73,5 +80,16 @@ describe("recipeFormSchema", () => {
       tags: ["make-ahead", "side", "summer"],
       favorite: true,
     });
+  });
+
+  it("allows long instructions because the released backend has no instruction length limit", () => {
+    const longInstruction = "b".repeat(1500);
+
+    const formData = recipeFormSchema.parse({
+      title: "Detailed Prep",
+      instructions: [longInstruction],
+    });
+
+    expect(toRecipeRequest(formData).instructions).toEqual([longInstruction]);
   });
 });

--- a/src/lib/validations/recipes.test.ts
+++ b/src/lib/validations/recipes.test.ts
@@ -31,6 +31,33 @@ describe("recipeFormSchema", () => {
     });
   });
 
+  it("requires recipe URLs to use http or https", () => {
+    expect(() =>
+      recipeFormSchema.parse({
+        title: "Pasta Night",
+        imageUrl: "ftp://example.com/photo.jpg",
+      }),
+    ).toThrow("Enter an http or https URL");
+
+    expect(() =>
+      recipeFormSchema.parse({
+        title: "Pasta Night",
+        sourceUrl: "mailto:cook@example.com",
+      }),
+    ).toThrow("Enter an http or https URL");
+
+    expect(
+      recipeFormSchema.parse({
+        title: "Pasta Night",
+        imageUrl: "https://example.com/photo.jpg",
+        sourceUrl: "http://example.com/recipe",
+      }),
+    ).toMatchObject({
+      imageUrl: "https://example.com/photo.jpg",
+      sourceUrl: "http://example.com/recipe",
+    });
+  });
+
   it("preserves ordered ingredients, instructions, and tags", () => {
     const formData = recipeFormSchema.parse({
       title: "Layered Salad",

--- a/src/lib/validations/recipes.ts
+++ b/src/lib/validations/recipes.ts
@@ -10,9 +10,15 @@ const optionalTextSchema = z
     return trimmed.length > 0 ? trimmed : null;
   });
 
-const optionalUrlSchema = optionalTextSchema.pipe(
-  z.string().url("Enter a valid URL").nullable(),
-);
+const httpUrlSchema = z
+  .string()
+  .url("Enter a valid URL")
+  .refine((value) => {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  }, "Enter an http or https URL");
+
+const optionalUrlSchema = optionalTextSchema.pipe(httpUrlSchema.nullable());
 
 function orderedTextArray(maxLength: number, message: string) {
   return z

--- a/src/lib/validations/recipes.ts
+++ b/src/lib/validations/recipes.ts
@@ -27,17 +27,30 @@ const httpUrlSchema = z
 const optionalUrlSchema = optionalTextSchema.pipe(httpUrlSchema.nullable());
 
 function orderedTextArray(maxLength?: number, message?: string) {
-  const schema = z
-    .array(z.string())
-    .optional()
-    .default([])
-    .transform((values) =>
-      values.map((value) => value.trim()).filter((value) => value.length > 0),
-    );
+  const base = z.array(z.string()).optional().default([]);
 
-  return maxLength === undefined
-    ? schema
-    : schema.pipe(z.array(z.string().max(maxLength, message)));
+  // Validate length on the RAW array so a too-long entry reports its error on
+  // the field the user actually typed into. Trimming/filtering blank rows runs
+  // afterward, which would otherwise re-index errors onto the wrong field when
+  // a blank row precedes an invalid one.
+  const validated =
+    maxLength === undefined
+      ? base
+      : base.superRefine((values, ctx) => {
+          values.forEach((value, index) => {
+            if (value.trim().length > maxLength) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message,
+                path: [index],
+              });
+            }
+          });
+        });
+
+  return validated.transform((values) =>
+    values.map((value) => value.trim()).filter((value) => value.length > 0),
+  );
 }
 
 export const recipeFormSchema = z.object({

--- a/src/lib/validations/recipes.ts
+++ b/src/lib/validations/recipes.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import type { CreateRecipeRequest } from "@/lib/types";
+
+const optionalTextSchema = z
+  .string()
+  .optional()
+  .nullable()
+  .transform((value) => {
+    const trimmed = value?.trim() ?? "";
+    return trimmed.length > 0 ? trimmed : null;
+  });
+
+const optionalUrlSchema = optionalTextSchema.pipe(
+  z.string().url("Enter a valid URL").nullable(),
+);
+
+function orderedTextArray(maxLength: number, message: string) {
+  return z
+    .array(z.string())
+    .optional()
+    .default([])
+    .transform((values) =>
+      values.map((value) => value.trim()).filter((value) => value.length > 0),
+    )
+    .pipe(z.array(z.string().max(maxLength, message)));
+}
+
+export const recipeFormSchema = z.object({
+  title: z
+    .string()
+    .transform((value) => value.trim())
+    .pipe(
+      z
+        .string()
+        .min(1, "Recipe title is required")
+        .max(160, "Recipe title must be 160 characters or less"),
+    ),
+  imageUrl: optionalUrlSchema,
+  note: optionalTextSchema,
+  sourceUrl: optionalUrlSchema,
+  ingredients: orderedTextArray(
+    500,
+    "Ingredient must be 500 characters or less",
+  ),
+  instructions: orderedTextArray(
+    1000,
+    "Instruction must be 1000 characters or less",
+  ),
+  tags: orderedTextArray(60, "Tag must be 60 characters or less"),
+  favorite: z.boolean().optional().default(false),
+});
+
+export type RecipeFormData = z.infer<typeof recipeFormSchema>;
+
+export function toRecipeRequest(formData: RecipeFormData): CreateRecipeRequest {
+  return {
+    title: formData.title,
+    imageUrl: formData.imageUrl,
+    note: formData.note,
+    sourceUrl: formData.sourceUrl,
+    ingredients: formData.ingredients,
+    instructions: formData.instructions,
+    tags: formData.tags,
+    favorite: formData.favorite,
+  };
+}

--- a/src/lib/validations/recipes.ts
+++ b/src/lib/validations/recipes.ts
@@ -57,6 +57,7 @@ export const recipeFormSchema = z.object({
 });
 
 export type RecipeFormData = z.infer<typeof recipeFormSchema>;
+export type RecipeFormInput = z.input<typeof recipeFormSchema>;
 
 export function toRecipeRequest(formData: RecipeFormData): CreateRecipeRequest {
   return {

--- a/src/lib/validations/recipes.ts
+++ b/src/lib/validations/recipes.ts
@@ -10,25 +10,34 @@ const optionalTextSchema = z
     return trimmed.length > 0 ? trimmed : null;
   });
 
+function isHttpOrHttpsUrl(value: string) {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 const httpUrlSchema = z
   .string()
   .url("Enter a valid URL")
-  .refine((value) => {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  }, "Enter an http or https URL");
+  .refine(isHttpOrHttpsUrl, "Enter an http or https URL");
 
 const optionalUrlSchema = optionalTextSchema.pipe(httpUrlSchema.nullable());
 
-function orderedTextArray(maxLength: number, message: string) {
-  return z
+function orderedTextArray(maxLength?: number, message?: string) {
+  const schema = z
     .array(z.string())
     .optional()
     .default([])
     .transform((values) =>
       values.map((value) => value.trim()).filter((value) => value.length > 0),
-    )
-    .pipe(z.array(z.string().max(maxLength, message)));
+    );
+
+  return maxLength === undefined
+    ? schema
+    : schema.pipe(z.array(z.string().max(maxLength, message)));
 }
 
 export const recipeFormSchema = z.object({
@@ -48,10 +57,7 @@ export const recipeFormSchema = z.object({
     500,
     "Ingredient must be 500 characters or less",
   ),
-  instructions: orderedTextArray(
-    1000,
-    "Instruction must be 1000 characters or less",
-  ),
+  instructions: orderedTextArray(),
   tags: orderedTextArray(60, "Tag must be 60 characters or less"),
   favorite: z.boolean().optional().default(false),
 });

--- a/src/stores/app-store.test.ts
+++ b/src/stores/app-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type ModuleType, useAppStore } from "./app-store";
+import { type MealType, type ModuleType, useAppStore } from "./app-store";
 
 describe("AppStore", () => {
   // Store reset handled globally by setup.ts afterEach via resetAllStores()
@@ -11,6 +11,11 @@ describe("AppStore", () => {
 
     it("initializes with isSidebarOpen = false", () => {
       expect(useAppStore.getState().isSidebarOpen).toBe(false);
+    });
+
+    it("initializes handoff drafts as null", () => {
+      expect(useAppStore.getState().mealPlacementDraft).toBe(null);
+      expect(useAppStore.getState().recipeCreationDraft).toBe(null);
     });
   });
 
@@ -125,6 +130,88 @@ describe("AppStore", () => {
 
       expect(useAppStore.getState().activeModule).toBe("chores");
       expect(useAppStore.getState().isSidebarOpen).toBe(true);
+    });
+  });
+
+  describe("recipe and meals handoff drafts", () => {
+    const mealTypes: MealType[] = ["breakfast", "lunch", "dinner"];
+
+    it.each(
+      mealTypes,
+    )("starts meal placement from a recipe with lowercase meal type sample '%s'", (mealType) => {
+      useAppStore.getState().startMealPlacementFromRecipe({
+        recipeId: "recipe-123",
+        requestedAtWeekStartDate: "2026-06-07",
+        source: {
+          kind: "meals-slot",
+          dayIndex: 2,
+          mealType,
+        },
+      });
+
+      expect(useAppStore.getState().activeModule).toBe("meals");
+      expect(useAppStore.getState().mealPlacementDraft).toEqual({
+        recipeId: "recipe-123",
+        requestedAtWeekStartDate: "2026-06-07",
+        source: {
+          kind: "meals-slot",
+          dayIndex: 2,
+          mealType,
+        },
+      });
+    });
+
+    it("consumes the meal placement draft and clears it", () => {
+      useAppStore.getState().startMealPlacementFromRecipe({
+        recipeId: "recipe-123",
+        requestedAtWeekStartDate: "2026-06-07",
+        source: { kind: "recipes-library" },
+      });
+
+      const consumed = useAppStore.getState().consumeMealPlacementDraft();
+
+      expect(consumed).toEqual({
+        recipeId: "recipe-123",
+        requestedAtWeekStartDate: "2026-06-07",
+        source: { kind: "recipes-library" },
+      });
+      expect(useAppStore.getState().mealPlacementDraft).toBe(null);
+    });
+
+    it("starts recipe creation from a meal slot and switches to recipes", () => {
+      useAppStore.getState().startRecipeCreationFromMealSlot({
+        requestedAtWeekStartDate: "2026-06-07",
+        dayIndex: 4,
+        mealType: "dinner",
+        typedTitle: "Taco bowls",
+      });
+
+      expect(useAppStore.getState().activeModule).toBe("recipes");
+      expect(useAppStore.getState().recipeCreationDraft).toEqual({
+        requestedAtWeekStartDate: "2026-06-07",
+        dayIndex: 4,
+        mealType: "dinner",
+        typedTitle: "Taco bowls",
+      });
+    });
+
+    it("consumes the recipe creation draft and clears it", () => {
+      useAppStore.getState().startRecipeCreationFromMealSlot({
+        requestedAtWeekStartDate: "2026-06-07",
+        dayIndex: 1,
+        mealType: "lunch",
+        typedTitle: "Chicken wraps",
+      });
+
+      const consumed = useAppStore.getState().consumeRecipeCreationDraft();
+
+      expect(consumed).toEqual({
+        requestedAtWeekStartDate: "2026-06-07",
+        dayIndex: 1,
+        mealType: "lunch",
+        typedTitle: "Chicken wraps",
+      });
+      expect(useAppStore.getState().recipeCreationDraft).toBe(null);
     });
   });
 });

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -43,7 +43,7 @@ interface AppState {
   toggleSidebar: () => void;
 }
 
-export const useAppStore = create<AppState>((set) => ({
+export const useAppStore = create<AppState>((set, get) => ({
   // Initial state - null shows home dashboard on mobile, desktop redirects to calendar
   activeModule: null,
   isSidebarOpen: false,
@@ -55,14 +55,14 @@ export const useAppStore = create<AppState>((set) => ({
   startMealPlacementFromRecipe: (draft) =>
     set({ mealPlacementDraft: draft, activeModule: "meals" }),
   consumeMealPlacementDraft: () => {
-    const draft = useAppStore.getState().mealPlacementDraft;
+    const draft = get().mealPlacementDraft;
     set({ mealPlacementDraft: null });
     return draft;
   },
   startRecipeCreationFromMealSlot: (draft) =>
     set({ recipeCreationDraft: draft, activeModule: "recipes" }),
   consumeRecipeCreationDraft: () => {
-    const draft = useAppStore.getState().recipeCreationDraft;
+    const draft = get().recipeCreationDraft;
     set({ recipeCreationDraft: null });
     return draft;
   },

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -1,6 +1,12 @@
 import { create } from "zustand";
 
-export type ModuleType = "calendar" | "lists" | "chores" | "meals" | "photos";
+export type ModuleType =
+  | "calendar"
+  | "lists"
+  | "chores"
+  | "meals"
+  | "recipes"
+  | "photos";
 
 interface AppState {
   // State

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -8,13 +8,36 @@ export type ModuleType =
   | "recipes"
   | "photos";
 
+export type MealType = "breakfast" | "lunch" | "dinner";
+
+export type MealPlacementDraft = {
+  recipeId: string;
+  requestedAtWeekStartDate: string;
+  source:
+    | { kind: "recipes-library" }
+    | { kind: "meals-slot"; dayIndex: number; mealType: MealType };
+};
+
+export type RecipeCreationDraft = {
+  requestedAtWeekStartDate: string;
+  dayIndex: number;
+  mealType: MealType;
+  typedTitle: string;
+};
+
 interface AppState {
   // State
   activeModule: ModuleType | null; // null = home dashboard (mobile only)
   isSidebarOpen: boolean;
+  mealPlacementDraft: MealPlacementDraft | null;
+  recipeCreationDraft: RecipeCreationDraft | null;
 
   // Actions
   setActiveModule: (module: ModuleType | null) => void;
+  startMealPlacementFromRecipe: (draft: MealPlacementDraft) => void;
+  consumeMealPlacementDraft: () => MealPlacementDraft | null;
+  startRecipeCreationFromMealSlot: (draft: RecipeCreationDraft) => void;
+  consumeRecipeCreationDraft: () => RecipeCreationDraft | null;
   openSidebar: () => void;
   closeSidebar: () => void;
   toggleSidebar: () => void;
@@ -24,9 +47,25 @@ export const useAppStore = create<AppState>((set) => ({
   // Initial state - null shows home dashboard on mobile, desktop redirects to calendar
   activeModule: null,
   isSidebarOpen: false,
+  mealPlacementDraft: null,
+  recipeCreationDraft: null,
 
   // Actions
   setActiveModule: (module) => set({ activeModule: module }),
+  startMealPlacementFromRecipe: (draft) =>
+    set({ mealPlacementDraft: draft, activeModule: "meals" }),
+  consumeMealPlacementDraft: () => {
+    const draft = useAppStore.getState().mealPlacementDraft;
+    set({ mealPlacementDraft: null });
+    return draft;
+  },
+  startRecipeCreationFromMealSlot: (draft) =>
+    set({ recipeCreationDraft: draft, activeModule: "recipes" }),
+  consumeRecipeCreationDraft: () => {
+    const draft = useAppStore.getState().recipeCreationDraft;
+    set({ recipeCreationDraft: null });
+    return draft;
+  },
   openSidebar: () => set({ isSidebarOpen: true }),
   closeSidebar: () => set({ isSidebarOpen: false }),
   toggleSidebar: () =>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,5 +1,11 @@
 // App Store
-export { type ModuleType, useAppStore } from "./app-store";
+export {
+  type MealPlacementDraft,
+  type MealType,
+  type ModuleType,
+  type RecipeCreationDraft,
+  useAppStore,
+} from "./app-store";
 // Auth Store - Hydration only (auth operations in @/api)
 export {
   useAuthHasHydrated,

--- a/src/test/fixtures/recipes.ts
+++ b/src/test/fixtures/recipes.ts
@@ -1,0 +1,36 @@
+import type { RecipeDetail, RecipeSummary } from "@/lib/types";
+
+export const testRecipeDetail: RecipeDetail = {
+  id: "00000000-0000-4000-8000-000000000501",
+  title: "Sheet Pan Salmon",
+  imageUrl: "https://example.com/salmon.jpg",
+  ingredients: ["Salmon fillets", "Asparagus", "Lemon"],
+  instructions: ["Heat oven to 425F", "Roast everything together"],
+  note: "Weeknight favorite",
+  sourceUrl: "https://example.com/sheet-pan-salmon",
+  tags: ["dinner", "quick"],
+  favorite: true,
+  updatedAt: "2026-06-04T09:00:00",
+};
+
+export const testRecipeSummary: RecipeSummary = {
+  id: testRecipeDetail.id,
+  title: testRecipeDetail.title,
+  imageUrl: testRecipeDetail.imageUrl,
+  favorite: testRecipeDetail.favorite,
+  tags: testRecipeDetail.tags,
+  updatedAt: testRecipeDetail.updatedAt,
+};
+
+export const importedRecipeDetail: RecipeDetail = {
+  id: "00000000-0000-4000-8000-000000000502",
+  title: "Imported Tomato Soup",
+  imageUrl: null,
+  ingredients: ["Tomatoes", "Stock", "Cream"],
+  instructions: ["Simmer tomatoes and stock", "Blend with cream"],
+  note: null,
+  sourceUrl: "https://example.com/imported-tomato-soup",
+  tags: ["lunch"],
+  favorite: false,
+  updatedAt: "2026-06-04T09:00:00",
+};

--- a/src/test/fixtures/recipes.ts
+++ b/src/test/fixtures/recipes.ts
@@ -30,7 +30,26 @@ export const importedRecipeDetail: RecipeDetail = {
   instructions: ["Simmer tomatoes and stock", "Blend with cream"],
   note: null,
   sourceUrl: "https://example.com/imported-tomato-soup",
-  tags: ["lunch"],
+  tags: ["lunch", "quick"],
   favorite: false,
   updatedAt: "2026-06-04T09:00:00",
 };
+
+export const breakfastRecipeDetail: RecipeDetail = {
+  id: "00000000-0000-4000-8000-000000000503",
+  title: "Berry Yogurt Parfaits",
+  imageUrl: "https://example.com/parfaits.jpg",
+  ingredients: ["Greek yogurt", "Berries", "Granola"],
+  instructions: ["Layer yogurt, berries, and granola"],
+  note: null,
+  sourceUrl: null,
+  tags: ["breakfast", "make-ahead"],
+  favorite: true,
+  updatedAt: "2026-06-04T09:30:00",
+};
+
+export const testRecipeDetails: RecipeDetail[] = [
+  importedRecipeDetail,
+  breakfastRecipeDetail,
+  testRecipeDetail,
+];

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -67,7 +67,7 @@ const MOCK_IMPORTED_RECIPE: RecipeDetail = {
   instructions: ["Simmer tomatoes and stock", "Blend with cream"],
   note: null,
   sourceUrl: "https://example.com/imported-tomato-soup",
-  tags: ["lunch"],
+  tags: ["lunch", "quick"],
   favorite: false,
   updatedAt: MOCK_RECIPE_TIMESTAMP,
 };

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -56,6 +56,7 @@ let mockLists: ListDetail[] = [];
 let mockListPreferences: ListPreferences = { showCompletedByDefault: true };
 let mockRecipes: RecipeDetail[] = [];
 let mockIdCounter = 1000;
+let mockRecipeIdCounter = 1000;
 const MOCK_TIMESTAMP = "2026-05-06T09:00:00";
 const MOCK_RECIPE_TIMESTAMP = "2026-06-04T09:00:00";
 const MOCK_IMPORTED_RECIPE: RecipeDetail = {
@@ -260,6 +261,7 @@ export function seedMockListPreferences(preferences: ListPreferences): void {
  */
 export function resetMockRecipes(): void {
   mockRecipes = [];
+  mockRecipeIdCounter = 1000;
 }
 
 /**
@@ -272,6 +274,46 @@ export function seedMockRecipes(recipes: RecipeDetail[]): void {
 function createMockId(): string {
   mockIdCounter += 1;
   return `00000000-0000-4000-8000-${String(mockIdCounter).padStart(12, "0")}`;
+}
+
+function createMockRecipeId(): string {
+  mockRecipeIdCounter += 1;
+  return `00000000-0000-4000-8000-${String(mockRecipeIdCounter).padStart(12, "0")}`;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part))) {
+    return false;
+  }
+
+  const [first, second] = parts;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
+function isBlockedRecipeImportUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const protocolAllowed =
+      url.protocol === "http:" || url.protocol === "https:";
+    if (!protocolAllowed) return true;
+
+    const hostname = url.hostname.toLowerCase();
+    return (
+      hostname === "localhost" ||
+      hostname === "::1" ||
+      hostname.endsWith(".localhost") ||
+      isPrivateIpv4(hostname)
+    );
+  } catch {
+    return true;
+  }
 }
 
 function categoriesForKind(kind: ListKind): ListCategory[] {
@@ -470,7 +512,7 @@ export const handlers = [
   http.post(`${API_BASE}/recipes`, async ({ request }) => {
     const body = (await request.json()) as CreateRecipeRequest;
     const recipe: RecipeDetail = {
-      id: createMockId(),
+      id: createMockRecipeId(),
       title: body.title.trim(),
       imageUrl: body.imageUrl ?? null,
       ingredients: body.ingredients ?? [],
@@ -533,7 +575,10 @@ export const handlers = [
   // POST /recipes/import - Import from URL and persist
   http.post(`${API_BASE}/recipes/import`, async ({ request }) => {
     const body = (await request.json()) as { url: string };
-    if (body.url === "https://example.com/import-error") {
+    if (
+      body.url === "https://example.com/import-error" ||
+      isBlockedRecipeImportUrl(body.url)
+    ) {
       return HttpResponse.json(
         { message: "Could not import recipe" },
         { status: 400 },
@@ -543,7 +588,7 @@ export const handlers = [
     const imported: RecipeDetail = {
       ...MOCK_IMPORTED_RECIPE,
       id: mockRecipes.some((recipe) => recipe.id === MOCK_IMPORTED_RECIPE.id)
-        ? createMockId()
+        ? createMockRecipeId()
         : MOCK_IMPORTED_RECIPE.id,
       sourceUrl: body.url,
     };

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -10,6 +10,7 @@ import type {
   ChoreTemplate,
   CreateChoreTemplateRequest,
   CreateEventRequest,
+  CreateRecipeRequest,
   FamilyData,
   FamilyMember,
   ListCategory,
@@ -19,6 +20,8 @@ import type {
   ListPreferences,
   LoginRequest,
   LoginResponse,
+  RecipeDetail,
+  RecipeSummary,
   RegisterRequest,
   RegisterResponse,
   UpdateChoreTemplateRequest,
@@ -26,6 +29,7 @@ import type {
   UpdateEventRequest,
   UpdateFamilyRequest,
   UpdateMemberRequest,
+  UpdateRecipeRequest,
   UsernameCheckResponse,
 } from "@/lib/types";
 
@@ -50,8 +54,22 @@ let mockUsers: MockUser[] = [];
 // In-memory storage for persisted family lists (reset between tests)
 let mockLists: ListDetail[] = [];
 let mockListPreferences: ListPreferences = { showCompletedByDefault: true };
+let mockRecipes: RecipeDetail[] = [];
 let mockIdCounter = 1000;
 const MOCK_TIMESTAMP = "2026-05-06T09:00:00";
+const MOCK_RECIPE_TIMESTAMP = "2026-06-04T09:00:00";
+const MOCK_IMPORTED_RECIPE: RecipeDetail = {
+  id: "00000000-0000-4000-8000-000000000502",
+  title: "Imported Tomato Soup",
+  imageUrl: null,
+  ingredients: ["Tomatoes", "Stock", "Cream"],
+  instructions: ["Simmer tomatoes and stock", "Blend with cream"],
+  note: null,
+  sourceUrl: "https://example.com/imported-tomato-soup",
+  tags: ["lunch"],
+  favorite: false,
+  updatedAt: MOCK_RECIPE_TIMESTAMP,
+};
 
 function createEmptyChoresBoard(): ChoresBoard {
   return {
@@ -237,6 +255,20 @@ export function seedMockListPreferences(preferences: ListPreferences): void {
   mockListPreferences = preferences;
 }
 
+/**
+ * Reset mock recipe data between tests.
+ */
+export function resetMockRecipes(): void {
+  mockRecipes = [];
+}
+
+/**
+ * Seed mock recipe details for testing.
+ */
+export function seedMockRecipes(recipes: RecipeDetail[]): void {
+  mockRecipes = recipes.map((recipe) => structuredClone(recipe));
+}
+
 function createMockId(): string {
   mockIdCounter += 1;
   return `00000000-0000-4000-8000-${String(mockIdCounter).padStart(12, "0")}`;
@@ -366,6 +398,17 @@ function toListSummary(list: ListDetail) {
   };
 }
 
+function toRecipeSummary(recipe: RecipeDetail): RecipeSummary {
+  return {
+    id: recipe.id,
+    title: recipe.title,
+    imageUrl: recipe.imageUrl,
+    favorite: recipe.favorite,
+    tags: recipe.tags,
+    updatedAt: recipe.updatedAt,
+  };
+}
+
 function createApiResponse<T>(data: T, message?: string): ApiResponse<T> {
   return message ? { data, message } : { data };
 }
@@ -399,6 +442,120 @@ export const API_BASE = "http://localhost:3000/api";
  * ```
  */
 export const handlers = [
+  // ============================================================================
+  // Recipes API Handlers
+  // ============================================================================
+
+  // GET /recipes - Library summaries
+  http.get(`${API_BASE}/recipes`, () => {
+    return HttpResponse.json(
+      createApiResponse(mockRecipes.map(toRecipeSummary)),
+    );
+  }),
+
+  // GET /recipes/:id - Detail payload
+  http.get(`${API_BASE}/recipes/:id`, ({ params }) => {
+    const recipe = mockRecipes.find((candidate) => candidate.id === params.id);
+    if (!recipe) {
+      return HttpResponse.json(
+        { message: `Recipe with id "${params.id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    return HttpResponse.json(createApiResponse(recipe));
+  }),
+
+  // POST /recipes - Create a saved recipe
+  http.post(`${API_BASE}/recipes`, async ({ request }) => {
+    const body = (await request.json()) as CreateRecipeRequest;
+    const recipe: RecipeDetail = {
+      id: createMockId(),
+      title: body.title.trim(),
+      imageUrl: body.imageUrl ?? null,
+      ingredients: body.ingredients ?? [],
+      instructions: body.instructions ?? [],
+      note: body.note ?? null,
+      sourceUrl: body.sourceUrl ?? null,
+      tags: body.tags ?? [],
+      favorite: body.favorite ?? false,
+      updatedAt: MOCK_RECIPE_TIMESTAMP,
+    };
+
+    mockRecipes = [recipe, ...mockRecipes];
+
+    return HttpResponse.json(
+      createApiResponse(recipe, "Recipe created successfully"),
+      { status: 201 },
+    );
+  }),
+
+  // PATCH /recipes/:id - Update a saved recipe
+  http.patch(`${API_BASE}/recipes/:id`, async ({ params, request }) => {
+    const index = mockRecipes.findIndex(
+      (candidate) => candidate.id === params.id,
+    );
+    if (index === -1) {
+      return HttpResponse.json(
+        { message: `Recipe with id "${params.id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    const body = (await request.json()) as UpdateRecipeRequest;
+    const current = mockRecipes[index];
+    const updated: RecipeDetail = {
+      ...current,
+      ...body,
+      title: body.title?.trim() ?? current.title,
+      imageUrl: body.imageUrl === undefined ? current.imageUrl : body.imageUrl,
+      ingredients: body.ingredients ?? current.ingredients,
+      instructions: body.instructions ?? current.instructions,
+      note: body.note === undefined ? current.note : body.note,
+      sourceUrl:
+        body.sourceUrl === undefined ? current.sourceUrl : body.sourceUrl,
+      tags: body.tags ?? current.tags,
+      favorite: body.favorite ?? current.favorite,
+      updatedAt: MOCK_RECIPE_TIMESTAMP,
+    };
+
+    mockRecipes = [
+      ...mockRecipes.slice(0, index),
+      updated,
+      ...mockRecipes.slice(index + 1),
+    ];
+
+    return HttpResponse.json(
+      createApiResponse(updated, "Recipe updated successfully"),
+    );
+  }),
+
+  // POST /recipes/import - Import from URL and persist
+  http.post(`${API_BASE}/recipes/import`, async ({ request }) => {
+    const body = (await request.json()) as { url: string };
+    if (body.url === "https://example.com/import-error") {
+      return HttpResponse.json(
+        { message: "Could not import recipe" },
+        { status: 400 },
+      );
+    }
+
+    const imported: RecipeDetail = {
+      ...MOCK_IMPORTED_RECIPE,
+      id: mockRecipes.some((recipe) => recipe.id === MOCK_IMPORTED_RECIPE.id)
+        ? createMockId()
+        : MOCK_IMPORTED_RECIPE.id,
+      sourceUrl: body.url,
+    };
+
+    mockRecipes = [imported, ...mockRecipes];
+
+    return HttpResponse.json(
+      createApiResponse(imported, "Recipe imported successfully"),
+      { status: 201 },
+    );
+  }),
+
   // ============================================================================
   // Lists API Handlers
   // ============================================================================

--- a/src/test/mocks/server.ts
+++ b/src/test/mocks/server.ts
@@ -9,12 +9,14 @@ import {
   resetMockEvents,
   resetMockFamily,
   resetMockLists,
+  resetMockRecipes,
   resetMockUsers,
   seedMockChoresBoard,
   seedMockEvents,
   seedMockFamily,
   seedMockListPreferences,
   seedMockLists,
+  seedMockRecipes,
 } from "./handlers";
 
 /**
@@ -63,6 +65,7 @@ export function setupMswServer() {
     resetMockEvents();
     resetMockFamily();
     resetMockLists();
+    resetMockRecipes();
     resetMockUsers();
   });
   afterAll(() => server.close());
@@ -78,10 +81,12 @@ export {
   resetMockEvents,
   resetMockFamily,
   resetMockLists,
+  resetMockRecipes,
   resetMockUsers,
   seedMockChoresBoard,
   seedMockEvents,
   seedMockFamily,
   seedMockListPreferences,
   seedMockLists,
+  seedMockRecipes,
 };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -85,6 +85,8 @@ function resetAllStores(): void {
   useAppStore.setState({
     activeModule: "calendar",
     isSidebarOpen: false,
+    mealPlacementDraft: null,
+    recipeCreationDraft: null,
   });
 
   // Reset auth store


### PR DESCRIPTION
## Summary
- Adds Recipes as a standalone top-level frontend module with released `family-hub-api v1.5.0` `/api/recipes` types, services, hooks, validation, fixtures, and MSW handlers.
- Builds the mobile-first recipe library, detail, create, edit, favorite, filter/tag, and URL-import add flow.
- Adds thin shared Recipes <-> Meals handoff draft state with lowercase meal types and a Sunday week-start helper, without implementing Meals board/composer/persistence/snapshot behavior.

Closes #183

## Verification
- `env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run src/api/hooks/use-recipes.test.tsx src/lib/validations/recipes.test.ts src/components/recipes-view.test.tsx src/lib/time-utils.test.ts src/stores/app-store.test.ts src/components/shared/mobile-bottom-nav.test.tsx src/components/shared/navigation-tabs.test.tsx src/App.shell.test.tsx` -> 8 files, 153 tests passed
- `env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run lint` -> exit 0, existing Biome schema-version info only
- `env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm test -- --run` -> 61 files, 769 tests passed
- `env PATH=/Users/joe.bor/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build` -> exit 0, existing chunk-size and Browserslist warnings only
- Backend release check: latest `family-hub-api` release is `v1.5.0`
- Recipe E2E local real-backend run was blocked: Docker daemon unreachable and local Playwright browser binaries missing. Added `e2e/mobile-recipes.spec.ts`; import success remains covered by MSW-backed component/hook tests until local backend/browser E2E can run.

## Issue Contract Checklist
- [x] Work scoped to `frontend` on feature branch `codex/recipes-frontend`.
- [x] Read `frontend/AGENTS.md`, issue body, Story, Spec, Plan, and released backend contract before coding; recorded in `docs/superpowers/work-logs/2026-06-04-recipes-frontend-foundation.md`.
- [x] Recipes is a standalone top-level module: `src/App.tsx`, `src/stores/app-store.ts`, `src/components/shared/*`.
- [x] `/api/recipes` contract implemented against release `family-hub-api v1.5.0`: `src/lib/types/recipes.ts`, `src/api/services/recipes.service.ts`, `src/api/hooks/use-recipes.ts`, `src/lib/validations/recipes.ts`, MSW fixtures/handlers/tests.
- [x] Mobile-first recipe library, detail, create, edit, favorite, search/filter/tag UX: `src/components/recipes-view.tsx`, `src/components/recipes/*`, `src/components/recipes-view.test.tsx`.
- [x] URL import is inside the add flow; successful import auto-saves and lands detail via `RecipeCreateSheet`/`RecipeImportSheet`, covered by `RecipesView` and hook tests.
- [x] Recipe detail is cook-first: image/title/ingredients/instructions precede actions, covered by document-order tests.
- [x] Shared handoff state added only as thin drafts: `mealPlacementDraft`, `recipeCreationDraft`, `startMealPlacementFromRecipe`, `startRecipeCreationFromMealSlot`, with lower-case `breakfast`, `lunch`, `dinner`.
- [x] Sunday week-start helper added in `src/lib/time-utils.ts` with tests.
- [x] Did not implement Meals board, composer, meal persistence, meal snapshots, slot picker, collision UX, grocery/list generation, pantry, backend code, or root production code.
- [x] Atomic commits kept reviewable and tied to plan slices.

## Review Notes
- A `gpt-5.4` code review found issues in metadata editing, mobile nav readability, detail error recovery, and array validation messages; fixed in `d5cb0d1`.
- A second final review attempt was unavailable because the subagent errored with the environment usage-limit message; the errored agent was closed.