### PR TITLE
fix(lists): preserve items when a list-setting PATCH races an item mutation

### DIFF
--- a/e2e/mobile-lists.spec.ts
+++ b/e2e/mobile-lists.spec.ts
@@ -41,33 +41,16 @@ test.describe("Mobile Lists", () => {
     await page
       .getByRole("combobox", { name: "Category" })
       .selectOption({ label: "Produce" });
-    // Wait for the create to be confirmed server-side before triggering the
-    // next list mutation; otherwise the category-mode update below can refetch
-    // an item-less list and clobber the just-added item.
-    const createItemResponse = page.waitForResponse(
-      (response) =>
-        /\/lists\/[^/]+\/items$/.test(new URL(response.url()).pathname) &&
-        response.request().method() === "POST",
-    );
     await page.getByRole("button", { name: "Save item" }).click();
-    await createItemResponse;
 
     await expect(page.getByRole("heading", { name: "Produce" })).toBeVisible();
     await expect(page.getByText("Bananas")).toBeVisible();
 
-    // Wait for the list-level update to settle so its response cannot overwrite
-    // the subsequent item-completion toggle.
-    const updateListResponse = page.waitForResponse((response) => {
-      const { pathname } = new URL(response.url());
-      return (
-        /\/lists\/[^/]+$/.test(pathname) &&
-        !pathname.endsWith("/preferences") &&
-        response.request().method() === "PATCH"
-      );
-    });
+    // Switch the category mode immediately — the item create may still be in
+    // flight, so the list-level PATCH response must not clobber the new item.
     await page.getByLabel("Categories").selectOption("flat");
-    await updateListResponse;
     await expect(page.getByRole("heading", { name: "Produce" })).toBeHidden();
+    await expect(page.getByText("Bananas")).toBeVisible();
 
     await page.getByRole("button", { name: /^Bananas$/ }).click();
     await expect(page.getByText("Bananas")).toHaveCSS(

--- a/src/api/hooks/use-lists.test.tsx
+++ b/src/api/hooks/use-lists.test.tsx
@@ -379,6 +379,101 @@ describe("useLists", () => {
     });
   });
 
+  it("preserves a created item when a concurrent list-setting PATCH resolves last", async () => {
+    seedMockLists([groceryList]);
+    queryClient.setQueryData(listsKeys.detail(groceryList.id), {
+      data: groceryList,
+    } satisfies ApiResponse<ListDetail>);
+
+    const createCanFinish = createDeferred();
+    const patchCanFinish = createDeferred();
+    const serverItem: ListItem = {
+      id: "00000000-0000-4000-8000-000000009002",
+      text: "Milk",
+      completed: false,
+      completedAt: null,
+      categoryId: null,
+      createdAt: "2026-05-06T09:30:00",
+      updatedAt: "2026-05-06T09:30:00",
+    };
+
+    server.use(
+      // Hold the create response open so it is in flight when the PATCH fires.
+      http.post(`${API_BASE}/lists/:id/items`, async () => {
+        await createCanFinish.promise;
+        return HttpResponse.json(
+          { data: serverItem, message: "List item created successfully" },
+          { status: 201 },
+        );
+      }),
+      // The list-level PATCH returns a STALE detail (no items) — simulating the
+      // server handling the setting change before the in-flight create landed.
+      http.patch(`${API_BASE}/lists/:id`, async () => {
+        await patchCanFinish.promise;
+        return HttpResponse.json({
+          data: {
+            ...groceryList,
+            categoryDisplayMode: "flat",
+            showCompletedOverride: null,
+            items: [],
+          },
+          message: "List updated successfully",
+        } satisfies ApiResponse<ListDetail>);
+      }),
+    );
+
+    const { result: createItem } = renderHook(
+      () => useCreateListItem(groceryList.id),
+      { wrapper: createWrapper() },
+    );
+    const { result: updateList } = renderHook(
+      () => useUpdateList(groceryList.id),
+      { wrapper: createWrapper() },
+    );
+
+    // 1) Start creating an item — the optimistic item enters the cache.
+    createItem.current.mutate({ text: "Milk", categoryId: null });
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<ApiResponse<ListDetail>>(
+          listsKeys.detail(groceryList.id),
+        )?.data.items,
+      ).toHaveLength(1);
+    });
+
+    // 2) While the create is still in flight, change a list-level setting.
+    updateList.current.mutate({
+      categoryDisplayMode: "flat",
+      showCompletedOverride: null,
+    });
+
+    // 3) Let the create finish first: the real server item replaces the optimistic one.
+    createCanFinish.resolve();
+    await waitFor(() => {
+      expect(createItem.current.isSuccess).toBe(true);
+      expect(
+        queryClient
+          .getQueryData<ApiResponse<ListDetail>>(
+            listsKeys.detail(groceryList.id),
+          )
+          ?.data.items.map((item) => item.id),
+      ).toEqual([serverItem.id]);
+    });
+
+    // 4) Now the list-setting PATCH resolves last with its stale, item-less body.
+    patchCanFinish.resolve();
+    await waitFor(() => {
+      expect(updateList.current.isSuccess).toBe(true);
+    });
+
+    // The PATCH only changes list-level settings; it must not drop the item.
+    const detail = queryClient.getQueryData<ApiResponse<ListDetail>>(
+      listsKeys.detail(groceryList.id),
+    );
+    expect(detail?.data.categoryDisplayMode).toBe("flat");
+    expect(detail?.data.items.map((item) => item.id)).toEqual([serverItem.id]);
+  });
+
   it("rolls back an optimistic created item when the server rejects it", async () => {
     seedMockLists([groceryList]);
     queryClient.setQueryData(listsKeys.detail(groceryList.id), {

--- a/src/api/hooks/use-lists.ts
+++ b/src/api/hooks/use-lists.ts
@@ -128,7 +128,21 @@ export function useUpdateList(id: string) {
       }
     },
     onSuccess: (response) => {
-      queryClient.setQueryData(listsKeys.detail(id), response);
+      // The list-level PATCH never changes items, but its response carries the
+      // server's item set at handling time — which can be stale if an item
+      // mutation (create/update) was still in flight. Keep the cache's current
+      // items and take the rest of the list fields from the response so a
+      // concurrent item mutation is not clobbered.
+      queryClient.setQueryData<ListDetailApiResponse>(
+        listsKeys.detail(id),
+        (current) =>
+          current
+            ? {
+                ...response,
+                data: { ...response.data, items: current.data.items },
+              }
+            : response,
+      );
       queryClient.invalidateQueries({ queryKey: listsKeys.hub() });
     },
   });


### PR DESCRIPTION
## Problem

`useUpdateList` handles **list-level** changes only — `PATCH /lists/:id` for `categoryDisplayMode` and `showCompletedOverride`. It never changes items. But its `onSuccess` blindly overwrote the entire detail cache with the server's PATCH response:

```ts
queryClient.setQueryData(listsKeys.detail(id), response); // clobbers items
```

That response reflects the server's item set **at the time the PATCH was handled**. If a concurrent item mutation (`POST /lists/:id/items` or `PATCH /lists/:id/items/:itemId`) was still in flight, the PATCH response carried a **stale** item set and clobbered the just-added/just-toggled item out of the cache.

**User-facing symptom:** add a grocery item, then immediately change a list setting (e.g. switch "Categories" → "Hide categories"). The new item vanishes from the UI until reload. Reproduced ~67% in E2E before this fix.

## Fix

In `useUpdateList.onSuccess`, keep the cache's **current** items and take the remaining list fields (name, `categoryDisplayMode`, `showCompletedOverride`, categories, timestamps) from the response. The list-level PATCH never changes items, so trusting the live cache for items is correct and order-independent — whether the create/update-item `onSuccess` lands before or after the update-list `onSuccess`, the item survives (`replaceCreatedItem` swaps the temp id for the real one; update-item merges by id).

## Sibling audit

Confirmed the other hooks in `use-lists.ts` don't have the same blind-overwrite pattern:

- `useCreateList` — writes `detail(response.data.id)` for a brand-new list id; no concurrent items possible.
- `useCreateListItem` / `useUpdateListItem` / `useDeleteListItem` / `useClearCompleted` — all merge into the current cache via the `updateDetailItems(...)` helper.
- `useUpdateListPreferences` — writes the separate `preferences()` key.

Only `useUpdateList` did a blind overwrite.

## Tests

**Unit regression** (`use-lists.test.tsx`, `gcTime: Infinity` client per the repo's optimistic-update gotcha): a created item is held in flight while a list-setting PATCH fires; the PATCH returns a stale, item-less body and resolves **last**; the test asserts the created item survives in the cache. Fails before the fix (item clobbered to `[]`), passes after.

> Note: the clobbering `useUpdateList.onSuccess` must be the last cache write to expose the bug — that's the real-world order (add item → then change a setting). When create resolves last, `replaceCreatedItem`'s fallback re-adds the item and masks the defect.

**E2E** (`e2e/mobile-lists.spec.ts`): the two `waitForResponse(...)` guards added in #187 masked this race by waiting out the in-flight mutations. They're removed here so the spec switches the category mode immediately after adding an item and asserts the item survives — exercising the real race instead of working around it.

## Verification

- `npm test -- --run src/api/hooks/use-lists.test.tsx` — 10/10 pass
- `npm test -- --run` — full unit suite, 819/819 pass
- `npm run lint` — clean (only the pre-existing Biome schema-version info line)
- `npx tsc -b` — clean
- Real-backend E2E (BE `v1.5.0`, same setup CI uses): `e2e/mobile-lists.spec.ts --project="Mobile Chrome" --repeat-each=5` — **5/5 pass** (was 4/5 FAIL before the fix)

Frontend-only change; no backend changes.
