### PR TITLE
fix(meals/recipes): consolidated review fixes for Meals + Recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A family dashboard I'm building to organize our household — calendars, chores,
 - **Calendar** — Four views (daily, weekly, monthly, schedule list), color-coded by family member, full CRUD operations
 - **Family Management** — Onboarding flow with member profiles and color assignment
 - **PWA** — Installable on any device, offline support coming soon
-- **More modules** — Chores, Meals, Lists, Photos (UI ready, backend coming)
+- **More modules** — Chores, Lists, Meals, and Recipes are backend-integrated; Photos is UI-only for now
 
 ## Prerequisites
 
@@ -52,17 +52,18 @@ Why I chose what I chose:
 
 ## Current Status
 
-**v0.3.10** — Calendar is feature-complete with mock API. Ready for backend integration. <!-- x-release-please-version -->
+**v0.3.10** — Calendar, Chores, Lists, Meals, and Recipes are integrated with the `family-hub-api` backend (v1.5.0). <!-- x-release-please-version -->
 
 | Module   | Status           |
 | -------- | ---------------- |
 | Calendar | ✅ Complete      |
-| Chores   | 🎨 UI ready      |
-| Meals    | 🎨 UI ready      |
-| Lists    | 🎨 UI ready      |
+| Chores   | ✅ Implemented   |
+| Lists    | ✅ Implemented   |
+| Meals    | ✅ Implemented   |
+| Recipes  | ✅ Implemented   |
 | Photos   | 🎨 UI ready      |
 
-See [ROADMAP.md](docs/ROADMAP.md) for the full journey and what's next.
+Product roadmap and backlog live in the `family-hub` workspace repo (`docs/product/`).
 
 ## Why I Built This
 

--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -68,11 +68,15 @@ test.describe("Mobile Meals", () => {
     });
     await expect(createRecipeSheet).toBeVisible();
     await createRecipeSheet.getByLabel("Title").fill("Sunday Pancakes");
-    await createRecipeSheet.getByLabel("Ingredient 1").fill("1 cup flour");
     await createRecipeSheet
-      .getByLabel("Instruction 1")
+      .getByRole("textbox", { name: "Ingredient 1" })
+      .fill("1 cup flour");
+    await createRecipeSheet
+      .getByRole("textbox", { name: "Instruction 1" })
       .fill("Whisk and griddle");
-    await createRecipeSheet.getByLabel("Tag 1").fill("Breakfast");
+    await createRecipeSheet
+      .getByRole("textbox", { name: "Tag 1" })
+      .fill("Breakfast");
     await createRecipeSheet
       .getByRole("button", { name: "Save recipe" })
       .click();

--- a/e2e/mobile-recipes.spec.ts
+++ b/e2e/mobile-recipes.spec.ts
@@ -48,9 +48,15 @@ test.describe("Mobile Recipes", () => {
     const createDialog = page.getByRole("dialog", { name: "Create Recipe" });
     await expect(createDialog).toBeVisible();
     await createDialog.getByLabel("Title").fill("Sunday Pancakes");
-    await createDialog.getByLabel("Ingredient 1").fill("1 cup flour");
-    await createDialog.getByLabel("Instruction 1").fill("Whisk and griddle");
-    await createDialog.getByLabel("Tag 1").fill("Breakfast");
+    await createDialog
+      .getByRole("textbox", { name: "Ingredient 1" })
+      .fill("1 cup flour");
+    await createDialog
+      .getByRole("textbox", { name: "Instruction 1" })
+      .fill("Whisk and griddle");
+    await createDialog
+      .getByRole("textbox", { name: "Tag 1" })
+      .fill("Breakfast");
     await createDialog.getByRole("button", { name: "Save recipe" }).click();
 
     await expect(createDialog).toBeHidden();

--- a/src/api/hooks/use-meals.test.tsx
+++ b/src/api/hooks/use-meals.test.tsx
@@ -488,17 +488,23 @@ describe("useMeals", () => {
     expect(result.current.data?.data.weekStartDate).toBe("2026-06-14");
   });
 
-  it("keeps optimistic cache assertions alive for meal mutations", async () => {
+  it("board cache reflects server state after upsert (invalidation drives the authoritative refetch)", async () => {
     seedMockMealsBoard(emptyBoard);
-    queryClient.setQueryData(mealsKeys.board("2026-06-07"), {
-      data: emptyBoard,
-    } satisfies ApiResponse<MealBoard>);
 
-    const { result } = renderHook(() => useUpsertMealSlot(), {
-      wrapper: createWrapper(),
+    const { result } = renderHook(
+      () => ({
+        board: useMealsBoard("2026-06-07"),
+        upsert: useUpsertMealSlot(),
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    // Wait for initial board load
+    await waitFor(() => {
+      expect(result.current.board.isSuccess).toBe(true);
     });
 
-    result.current.mutate({
+    result.current.upsert.mutate({
       weekStartDate: "2026-06-07",
       dayIndex: 0,
       mealType: "breakfast",
@@ -514,12 +520,59 @@ describe("useMeals", () => {
       collisionMode: null,
     });
 
+    // The server is the authority: wait for the board observer to reflect
+    // the server-confirmed state (not a hand-merged setQueryData write)
     await waitFor(() => {
       expect(
-        queryClient.getQueryData<ApiResponse<MealBoard>>(
-          mealsKeys.board("2026-06-07"),
-        )?.data.days[0].slots[0].primary?.title,
+        result.current.board.data?.data.days[0].slots[0].primary?.title,
       ).toBe("Toast");
+    });
+
+    expect(
+      queryClient.getQueryState(mealsKeys.board("2026-06-07"))?.isInvalidated,
+    ).toBe(false); // refetch has completed, no longer invalidated
+  });
+
+  it("upsert with collisionMode add_as_extra: server board shows original primary plus new extras after refetch", async () => {
+    const board = boardWithOccupiedDinner();
+    seedMockMealsBoard(board);
+
+    const { result } = renderHook(
+      () => ({
+        board: useMealsBoard("2026-06-07"),
+        upsert: useUpsertMealSlot(),
+      }),
+      { wrapper: createWrapper() },
+    );
+
+    // Wait for initial board load so the observer is active
+    await waitFor(() => {
+      expect(result.current.board.isSuccess).toBe(true);
+    });
+
+    // Monday dinner is occupied by "Pasta"; upsert a new "Toast" with add_as_extra
+    result.current.upsert.mutate({
+      weekStartDate: "2026-06-07",
+      dayIndex: 1,
+      mealType: "dinner",
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title: "Toast",
+        imageUrl: null,
+        note: null,
+      },
+      extras: [],
+      note: null,
+      collisionMode: "add_as_extra",
+    });
+
+    // After the refetch resolves, the board must show the SERVER state:
+    // original primary "Pasta" is preserved, "Toast" is appended to extras
+    await waitFor(() => {
+      const mondayDinner = result.current.board.data?.data.days[1].slots[2];
+      expect(mondayDinner?.primary?.title).toBe("Pasta");
+      expect(mondayDinner?.extras.map((e) => e.title)).toEqual(["Toast"]);
     });
   });
 });

--- a/src/api/hooks/use-meals.ts
+++ b/src/api/hooks/use-meals.ts
@@ -3,7 +3,6 @@ import { mealsService } from "@/api/services";
 import type {
   DuplicateMealSlotRequest,
   MealBoardApiResponse,
-  MealSlot,
   MealSlotApiResponse,
   MoveMealSlotRequest,
   RemoveMealSlotRequest,
@@ -15,30 +14,6 @@ export const mealsKeys = {
   board: (weekStartDate: string) =>
     [...mealsKeys.all, "board", weekStartDate] as const,
 };
-
-function replaceSlotInBoard(
-  previous: MealBoardApiResponse | undefined,
-  updatedSlot: MealSlot,
-): MealBoardApiResponse | undefined {
-  if (!previous) return previous;
-
-  return {
-    ...previous,
-    data: {
-      ...previous.data,
-      days: previous.data.days.map((day) =>
-        day.dayIndex === updatedSlot.dayIndex
-          ? {
-              ...day,
-              slots: day.slots.map((slot) =>
-                slot.mealType === updatedSlot.mealType ? updatedSlot : slot,
-              ),
-            }
-          : day,
-      ),
-    },
-  };
-}
 
 function invalidateBoard(
   queryClient: ReturnType<typeof useQueryClient>,
@@ -74,10 +49,6 @@ export function useUpsertMealSlot(callbacks?: {
     mutationFn: (request: UpsertMealSlotRequest) =>
       mealsService.upsertSlot(request),
     onSuccess: (response, request) => {
-      queryClient.setQueryData<MealBoardApiResponse>(
-        mealsKeys.board(request.weekStartDate),
-        (previous) => replaceSlotInBoard(previous, response.data),
-      );
       invalidateBoard(queryClient, request.weekStartDate);
       callbacks?.onSuccess?.(response);
     },

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mealsKeys } from "@/api";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
-import type { MealBoard } from "@/lib/types";
+import type { ApiResponse, MealBoard } from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealsBoard,
@@ -608,6 +608,76 @@ describe("MealsView", () => {
         "Pasta",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("closes the editor when the selected live slot is removed during a refetch", async () => {
+    seedMockMealsBoard(createOccupiedMealsBoard());
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: /open dinner: pasta/i }),
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Dinner Plan" }),
+    ).toBeInTheDocument();
+
+    const occupiedBoard = createOccupiedMealsBoard();
+    const removedMondayDinner: MealBoard = {
+      ...occupiedBoard,
+      days: occupiedBoard.days.map((day) =>
+        day.dayIndex === 1
+          ? {
+              ...day,
+              slots: day.slots.map((slot) =>
+                slot.mealType === "dinner"
+                  ? {
+                      ...slot,
+                      id: null,
+                      primary: null,
+                      extras: [],
+                      note: null,
+                    }
+                  : slot,
+              ),
+            }
+          : day,
+      ),
+    };
+    seedMockMealsBoard(removedMondayDinner);
+    await queryClient.invalidateQueries({
+      queryKey: mealsKeys.board(testWeekStartDate),
+    });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ApiResponse<MealBoard>>(
+        mealsKeys.board(testWeekStartDate),
+      );
+      expect(cached?.data.days[1].slots[2].primary).toBeNull();
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Dinner Plan" }),
+    ).not.toBeInTheDocument();
+
+    seedMockMealsBoard(createOccupiedMealsBoard());
+    await queryClient.invalidateQueries({
+      queryKey: mealsKeys.board(testWeekStartDate),
+    });
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ApiResponse<MealBoard>>(
+        mealsKeys.board(testWeekStartDate),
+      );
+      expect(cached?.data.days[1].slots[2].primary?.title).toBe("Pasta");
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Dinner Plan" }),
+    ).not.toBeInTheDocument();
   });
 
   it("re-checks collision against the live board", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -498,6 +498,54 @@ describe("MealsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows no Edit/Add-to-Meals/Favorite buttons in the meal-context recipe detail", async () => {
+    const board = createRecipeBackedMealsBoard();
+    seedMockMealsBoard(board);
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(
+      <MealEditorSheet
+        isOpen
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
+        board={board}
+        readOnly={false}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "View recipe" }));
+
+    // Back is always present
+    expect(
+      await screen.findByRole("button", { name: "Back to recipes" }),
+    ).toBeInTheDocument();
+    // Recipe content present
+    expect(
+      screen.getByRole("heading", { name: testRecipeDetail.title }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Ingredients" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Instructions" }),
+    ).toBeInTheDocument();
+    // Dead-end action buttons must NOT appear
+    expect(
+      screen.queryByRole("button", { name: "Edit recipe" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to Meals" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: `Favorite recipe: ${testRecipeDetail.title}`,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("reflects a saved meal note in the editor without reopening", async () => {
     seedMockMealsBoard(createOccupiedMealsBoard());
     const queryClient = new QueryClient({

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -1,5 +1,8 @@
+import { QueryClient } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mealsKeys } from "@/api";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
+import type { MealBoard } from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealsBoard,
@@ -14,7 +17,7 @@ import {
   seedMockRecipes,
   setupMswServer,
 } from "@/test/mocks/server";
-import { renderWithUser, screen, waitFor } from "@/test/test-utils";
+import { renderWithUser, screen, waitFor, within } from "@/test/test-utils";
 import { MealEditorSheet } from "./meals/meal-editor-sheet";
 import { MealsView } from "./meals-view";
 
@@ -262,7 +265,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -297,7 +304,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -328,7 +339,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -350,7 +365,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -374,7 +393,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -403,7 +426,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onReplace={onReplace}
@@ -446,7 +473,11 @@ describe("MealsView", () => {
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}
@@ -467,13 +498,135 @@ describe("MealsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("reflects a saved meal note in the editor without reopening", async () => {
+    seedMockMealsBoard(createOccupiedMealsBoard());
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: /open dinner: pasta/i }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add meal note" }));
+    await user.type(screen.getByLabelText("Meal note"), "Family favorite");
+    await user.click(screen.getByRole("button", { name: "Save note" }));
+
+    // The sheet stays open and its read view shows the freshly saved note.
+    const sheet = screen.getByRole("dialog", { name: "Dinner Plan" });
+    expect(
+      await within(sheet).findByText("Family favorite"),
+    ).toBeInTheDocument();
+    expect(
+      within(sheet).getByRole("button", { name: "Edit meal note" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not lose the editor when the board revalidates", async () => {
+    seedMockMealsBoard(createOccupiedMealsBoard());
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: /open dinner: pasta/i }),
+    );
+    const sheet = screen.getByRole("dialog", { name: "Dinner Plan" });
+    expect(within(sheet).getByText("Pasta")).toBeInTheDocument();
+
+    await queryClient.invalidateQueries({
+      queryKey: mealsKeys.board(testWeekStartDate),
+    });
+
+    // The editor and its primary title survive a background board refetch.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Dinner Plan" }),
+      ).toBeInTheDocument();
+    });
+    expect(
+      within(screen.getByRole("dialog", { name: "Dinner Plan" })).getByText(
+        "Pasta",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("re-checks collision against the live board", async () => {
+    // Monday dinner occupied; Tuesday dinner (the default move target) empty.
+    const board = createOccupiedMealsBoard();
+    const emptyTuesdayDinner: MealBoard = {
+      ...board,
+      days: board.days.map((day) =>
+        day.dayIndex === 2
+          ? {
+              ...day,
+              slots: day.slots.map((slot) =>
+                slot.mealType === "dinner"
+                  ? {
+                      ...slot,
+                      id: null,
+                      primary: null,
+                      extras: [],
+                      note: null,
+                    }
+                  : slot,
+              ),
+            }
+          : day,
+      ),
+    };
+    seedMockMealsBoard(emptyTuesdayDinner);
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: /open dinner: pasta/i }),
+    );
+
+    // Tuesday dinner becomes occupied after the editor opened.
+    const occupiedTuesdayDinner = createOccupiedMealsBoard();
+    seedMockMealsBoard(occupiedTuesdayDinner);
+    await queryClient.invalidateQueries({
+      queryKey: mealsKeys.board(testWeekStartDate),
+    });
+    await waitFor(() => {
+      expect(
+        getMockMealsBoard(testWeekStartDate).days[2].slots[2].primary?.title,
+      ).toBe("Soup");
+    });
+
+    await user.click(screen.getByRole("button", { name: "Move meal" }));
+    await user.click(screen.getByRole("button", { name: "Move here" }));
+
+    expect(
+      await screen.findByText("That slot already has a meal"),
+    ).toBeInTheDocument();
+  });
+
   it("moves a planned meal to a chosen day and meal type", async () => {
     const board = createOccupiedMealsBoard(); // Monday dinner: Pasta + Salad
     seedMockMealsBoard(board);
     const { user } = renderWithUser(
       <MealEditorSheet
         isOpen
-        slot={board.days[1].slots[2]}
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
         board={board}
         readOnly={false}
         onOpenChange={vi.fn()}

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -616,6 +616,121 @@ describe("MealsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("past occupied slot is enabled and opens the editor in read-only mode", async () => {
+    const pastWeekStartDate = "2026-05-31";
+    const pastBoard = createOccupiedMealsBoard();
+    // Override weekStartDate so the board and slots belong to the past week
+    const pastOccupied = {
+      ...pastBoard,
+      weekStartDate: pastWeekStartDate,
+      days: pastBoard.days.map((day) => ({
+        ...day,
+        slots: day.slots.map((slot) => ({
+          ...slot,
+          weekStartDate: pastWeekStartDate,
+        })),
+      })),
+    };
+    seedMockMealsBoard(pastOccupied);
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Previous week" }),
+    );
+
+    // The week banner and review-only label must be visible
+    expect(await screen.findByText("Review only")).toBeInTheDocument();
+
+    // The occupied dinner card must be present and NOT disabled
+    const occupiedCard = await screen.findByRole("button", {
+      name: /open dinner: pasta/i,
+    });
+    expect(occupiedCard).not.toBeDisabled();
+
+    // Clicking the occupied card opens the editor
+    await user.click(occupiedCard);
+    const editorDialog = await screen.findByRole("dialog", {
+      name: "Dinner Plan",
+    });
+    expect(editorDialog).toBeInTheDocument();
+
+    // Mutation buttons must be disabled on a read-only past week
+    expect(
+      within(editorDialog).getByRole("button", { name: "Replace meal" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Add extra or side" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Move meal" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Duplicate meal" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Remove meal" }),
+    ).toBeDisabled();
+
+    // Extra-remove ✕ must NOT be rendered on a read-only week
+    expect(
+      within(editorDialog).queryByRole("button", {
+        name: /remove extra:/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("past recipe-backed occupied slot opens editor with View recipe available", async () => {
+    const pastWeekStartDate = "2026-05-31";
+    const pastBoard = createRecipeBackedMealsBoard();
+    const pastRecipeBacked = {
+      ...pastBoard,
+      weekStartDate: pastWeekStartDate,
+      days: pastBoard.days.map((day) => ({
+        ...day,
+        slots: day.slots.map((slot) => ({
+          ...slot,
+          weekStartDate: pastWeekStartDate,
+        })),
+      })),
+    };
+    seedMockMealsBoard(pastRecipeBacked);
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Previous week" }),
+    );
+
+    expect(await screen.findByText("Review only")).toBeInTheDocument();
+
+    // Open the recipe-backed occupied slot
+    const occupiedCard = await screen.findByRole("button", {
+      name: /open dinner: snapshot salmon/i,
+    });
+    expect(occupiedCard).not.toBeDisabled();
+    await user.click(occupiedCard);
+
+    const editorDialog = await screen.findByRole("dialog", {
+      name: "Dinner Plan",
+    });
+
+    // "View recipe" must be present and clickable (no disabled gate)
+    const viewRecipeBtn = within(editorDialog).getByRole("button", {
+      name: "View recipe",
+    });
+    expect(viewRecipeBtn).not.toBeDisabled();
+
+    await user.click(viewRecipeBtn);
+
+    // Recipe detail view is shown
+    expect(
+      await screen.findByRole("heading", { name: testRecipeDetail.title }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Ingredients" }),
+    ).toBeInTheDocument();
+  });
+
   it("moves a planned meal to a chosen day and meal type", async () => {
     const board = createOccupiedMealsBoard(); // Monday dinner: Pasta + Salad
     seedMockMealsBoard(board);

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -1,4 +1,5 @@
 import { QueryClient } from "@tanstack/react-query";
+import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mealsKeys } from "@/api";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
@@ -12,9 +13,11 @@ import {
 } from "@/test/fixtures/meals";
 import { testRecipeDetail } from "@/test/fixtures/recipes";
 import {
+  API_BASE,
   getMockMealsBoard,
   seedMockMealsBoard,
   seedMockRecipes,
+  server,
   setupMswServer,
 } from "@/test/mocks/server";
 import { renderWithUser, screen, waitFor, within } from "@/test/test-utils";
@@ -777,6 +780,38 @@ describe("MealsView", () => {
     expect(
       screen.getByRole("heading", { name: "Ingredients" }),
     ).toBeInTheDocument();
+  });
+
+  it("shows a Retry button in the board error state and retries successfully", async () => {
+    // Force the board GET to return a 500 so the error block renders.
+    server.use(
+      http.get(
+        `${API_BASE}/meals/board`,
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Meals could not be loaded" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeEnabled();
+
+    // Remove the error override and seed a real board so retry succeeds.
+    server.resetHandlers();
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    // After a successful refetch the board's add affordances should be visible.
+    expect(
+      await screen.findAllByRole("button", { name: /add .*meal/i }),
+    ).not.toHaveLength(0);
+    expect(
+      screen.queryByRole("heading", { name: "Meals could not be loaded" }),
+    ).not.toBeInTheDocument();
   });
 
   it("moves a planned meal to a chosen day and meal type", async () => {

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/meals/meal-editor-sheet";
 import { MealGrid } from "@/components/meals/meal-grid";
 import { WeekHeader } from "@/components/meals/week-header";
+import { Button } from "@/components/ui/button";
 import { useMediaQuery } from "@/hooks";
 import {
   formatLocalDate,
@@ -147,6 +148,17 @@ export function MealsView() {
                 ? board.error.message
                 : "Try again in a moment."}
             </p>
+            <Button
+              type="button"
+              variant="outline"
+              className="mt-3"
+              onClick={() => {
+                void board.refetch();
+              }}
+              disabled={board.isRefetching}
+            >
+              Retry
+            </Button>
           </div>
         ) : null}
 

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -5,7 +5,10 @@ import {
   type MealSlotSelection,
 } from "@/components/meals/meal-composer-sheet";
 import { MealDayCard } from "@/components/meals/meal-day-card";
-import { MealEditorSheet } from "@/components/meals/meal-editor-sheet";
+import {
+  MealEditorSheet,
+  type MealSlotId,
+} from "@/components/meals/meal-editor-sheet";
 import { MealGrid } from "@/components/meals/meal-grid";
 import { WeekHeader } from "@/components/meals/week-header";
 import { useMediaQuery } from "@/hooks";
@@ -14,7 +17,6 @@ import {
   getWeekStartSunday,
   isPastWeek,
 } from "@/lib/time-utils";
-import type { MealBoard } from "@/lib/types";
 import type { MealPlacementDraft } from "@/stores";
 import { useAppStore } from "@/stores";
 
@@ -25,10 +27,7 @@ export function MealsView() {
   const [selectedSlot, setSelectedSlot] = useState<MealSlotSelection | null>(
     null,
   );
-  const [editingSlot, setEditingSlot] = useState<MealSlotSelection | null>(
-    null,
-  );
-  const [editingBoard, setEditingBoard] = useState<MealBoard | null>(null);
+  const [editingSlotId, setEditingSlotId] = useState<MealSlotId | null>(null);
   const [placementDraft, setPlacementDraft] =
     useState<MealPlacementDraft | null>(null);
   const board = useMealsBoard(visibleWeekStartDate);
@@ -82,8 +81,11 @@ export function MealsView() {
 
   function selectSlot(slot: MealSlotSelection) {
     if (slot.primary && !pendingRecipeId) {
-      setEditingSlot(slot);
-      setEditingBoard(board.data?.data ?? null);
+      setEditingSlotId({
+        weekStartDate: slot.weekStartDate,
+        dayIndex: slot.dayIndex,
+        mealType: slot.mealType,
+      });
       return;
     }
 
@@ -101,14 +103,12 @@ export function MealsView() {
   }
 
   function replaceFromEditor(slot: MealSlotSelection) {
-    setEditingSlot(null);
-    setEditingBoard(null);
+    setEditingSlotId(null);
     setSelectedSlot({ ...slot, intent: "primary" });
   }
 
   function addExtraFromEditor(slot: MealSlotSelection) {
-    setEditingSlot(null);
-    setEditingBoard(null);
+    setEditingSlotId(null);
     setSelectedSlot({ ...slot, intent: "extra" });
   }
 
@@ -121,8 +121,7 @@ export function MealsView() {
           onWeekChange={(weekStartDate) => {
             setVisibleWeekStartDate(weekStartDate);
             setSelectedSlot(null);
-            setEditingSlot(null);
-            setEditingBoard(null);
+            setEditingSlotId(null);
           }}
         />
 
@@ -187,16 +186,15 @@ export function MealsView() {
       />
 
       <MealEditorSheet
-        isOpen={editingSlot !== null}
-        slot={editingSlot}
-        board={editingBoard}
+        isOpen={editingSlotId !== null}
+        slotId={editingSlotId}
+        board={board.data?.data ?? null}
         readOnly={readOnly}
         onReplace={replaceFromEditor}
         onAddExtra={addExtraFromEditor}
         onOpenChange={(open) => {
           if (!open) {
-            setEditingSlot(null);
-            setEditingBoard(null);
+            setEditingSlotId(null);
           }
         }}
       />

--- a/src/components/meals/meal-composer-sheet.test.tsx
+++ b/src/components/meals/meal-composer-sheet.test.tsx
@@ -3,6 +3,7 @@ import type { MealSlot, RecipeDetail } from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealSlot,
+  createEmptyMealsBoard,
   createOccupiedMealsBoard,
   testWeekStartDate,
 } from "@/test/fixtures/meals";
@@ -12,6 +13,7 @@ import {
   testRecipeDetail,
 } from "@/test/fixtures/recipes";
 import {
+  getMockMealsBoard,
   seedMockMealsBoard,
   seedMockRecipes,
   setupMswServer,
@@ -179,15 +181,80 @@ describe("MealComposerSheet", () => {
     });
   });
 
-  it("offers entry into the full recipe library", async () => {
-    const lunchSlot = createEmptyMealSlot(testWeekStartDate, 3, "lunch");
-    const { user } = renderComposer(lunchSlot);
+  it("shows all recipes in-composer without switching module or closing", async () => {
+    // Seed 9 non-favorite recipes; default "Recent recipes" shows only 4, so the
+    // oldest 5 are hidden until "Show all recipes" is clicked.
+    const nineRecipes: RecipeDetail[] = Array.from({ length: 9 }, (_, i) => ({
+      ...importedRecipeDetail,
+      id: `00000000-0000-4000-8000-0000000006${String(i + 1).padStart(2, "0")}`,
+      title: `Library Recipe ${i + 1}`,
+      // Newer recipes have higher numbers (recipe 9 is newest, recipe 1 is oldest)
+      updatedAt: `2026-01-${String(i + 1).padStart(2, "0")}T09:00:00`,
+      favorite: false,
+    }));
+    // recipe 1 has updatedAt 2026-01-01 → oldest → NOT shown in the default top-4
+    const hiddenRecipe = nineRecipes[0]; // "Library Recipe 1" — oldest
 
+    const emptyBoard = createEmptyMealsBoard();
+    seedMockMealsBoard(emptyBoard);
+    seedMockRecipes(nineRecipes);
+
+    // dayIndex 2 = Wednesday, mealType breakfast → slotIndex 0
+    const breakfastSlot = createEmptyMealSlot(
+      testWeekStartDate,
+      2,
+      "breakfast",
+    );
+    const onOpenChange = vi.fn();
+    const { user } = renderComposer(breakfastSlot, onOpenChange);
+
+    // Wait for recipes to load
+    await screen.findByText("Recent recipes");
+
+    // The hidden recipe (oldest) should NOT be visible in the default view
+    expect(
+      screen.queryByRole("button", {
+        name: /select recipe: library recipe 1/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // The visible recipe (newest) should be in the default view
+    expect(
+      screen.getByRole("button", {
+        name: /select recipe: library recipe 9/i,
+      }),
+    ).toBeInTheDocument();
+
+    // Click "Show all recipes"
+    await user.click(screen.getByRole("button", { name: "Show all recipes" }));
+
+    // All 9 recipes should now be present
+    for (let i = 1; i <= 9; i++) {
+      expect(
+        screen.getByRole("button", {
+          name: new RegExp(`select recipe: library recipe ${i}`, "i"),
+        }),
+      ).toBeInTheDocument();
+    }
+
+    // Select the previously-hidden recipe
     await user.click(
-      screen.getByRole("button", { name: "Browse recipe library" }),
+      screen.getByRole("button", {
+        name: /select recipe: library recipe 1/i,
+      }),
     );
 
-    expect(useAppStore.getState().activeModule).toBe("recipes");
+    // The correct slot should have received the recipe
+    await waitFor(() => {
+      const board = getMockMealsBoard(testWeekStartDate);
+      // dayIndex 2, breakfast = slotIndex 0
+      expect(board.days[2].slots[0].primary?.recipeId).toBe(hiddenRecipe.id);
+    });
+
+    // The module should NOT have changed — still "calendar" (the test-reset default, NOT "recipes")
+    expect(useAppStore.getState().activeModule).toBe("calendar");
+    // The composer should have closed (upsert success fires onOpenChange(false))
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("shows recent recipes sorted newest-first when there is no query", async () => {

--- a/src/components/meals/meal-composer-sheet.test.tsx
+++ b/src/components/meals/meal-composer-sheet.test.tsx
@@ -257,6 +257,86 @@ describe("MealComposerSheet", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("rejects an invalid image URL with an inline error and no mutation", async () => {
+    const emptyBoard = createEmptyMealsBoard();
+    seedMockMealsBoard(emptyBoard);
+
+    // dayIndex 4, dinner = slotIndex 2
+    const dinnerSlot = createEmptyMealSlot(testWeekStartDate, 4, "dinner");
+    const onOpenChange = vi.fn();
+    const { user } = renderComposer(dinnerSlot, onOpenChange);
+
+    await user.type(screen.getByLabelText("Meal name"), "Mystery Meal");
+    await user.type(screen.getByLabelText("Image URL"), "not a url");
+    await user.click(screen.getByRole("button", { name: "Create quick meal" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("valid URL");
+
+    // No mutation: the slot stays empty and the composer stays open.
+    const board = getMockMealsBoard(testWeekStartDate);
+    expect(board.days[4].slots[2].primary).toBeNull();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("saves a valid quick meal to the board", async () => {
+    const emptyBoard = createEmptyMealsBoard();
+    seedMockMealsBoard(emptyBoard);
+
+    // dayIndex 5, lunch = slotIndex 1
+    const lunchSlot = createEmptyMealSlot(testWeekStartDate, 5, "lunch");
+    const onOpenChange = vi.fn();
+    const { user } = renderComposer(lunchSlot, onOpenChange);
+
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.type(
+      screen.getByLabelText("Image URL"),
+      "https://example.com/tacos.jpg",
+    );
+    await user.type(screen.getByLabelText("Note"), "Extra cilantro");
+    await user.click(screen.getByRole("button", { name: "Create quick meal" }));
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    const board = getMockMealsBoard(testWeekStartDate);
+    const slot = board.days[5].slots[1];
+    expect(slot.primary?.sourceType).toBe("quick");
+    expect(slot.primary?.title).toBe("Tacos");
+    // Quick-meal note lives on the entry, not the slot.
+    expect(slot.primary?.note).toBe("Extra cilantro");
+    expect(slot.note).toBeNull();
+  });
+
+  it("carries a typed note onto the slot when placing a recipe", async () => {
+    const emptyBoard = createEmptyMealsBoard();
+    seedMockMealsBoard(emptyBoard);
+
+    // dayIndex 6, dinner = slotIndex 2
+    const dinnerSlot = createEmptyMealSlot(testWeekStartDate, 6, "dinner");
+    const onOpenChange = vi.fn();
+    const { user } = renderComposer(dinnerSlot, onOpenChange);
+
+    await user.type(screen.getByLabelText("Note"), "Double the sauce");
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: /select recipe: imported tomato soup/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    const board = getMockMealsBoard(testWeekStartDate);
+    const slot = board.days[6].slots[2];
+    // The user's meal-planning note belongs to the slot, not the recipe entry.
+    expect(slot.note).toBe("Double the sauce");
+    expect(slot.primary?.sourceType).toBe("recipe");
+    expect(slot.primary?.recipeId).toBe(importedRecipeDetail.id);
+  });
+
   it("shows recent recipes sorted newest-first when there is no query", async () => {
     const olderRecipe: RecipeDetail = {
       ...importedRecipeDetail,

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -16,6 +16,10 @@ import type {
   RecipeSummary,
   UpsertMealSlotRequest,
 } from "@/lib/types";
+import {
+  toMealEntryRequest,
+  upsertMealSlotSchema,
+} from "@/lib/validations/meals";
 import { useAppStore } from "@/stores";
 import { formatMealType } from "./meal-type-utils";
 import { RecipeMatchList } from "./recipe-match-list";
@@ -64,6 +68,7 @@ export function MealComposerSheet({
   const [imageUrl, setImageUrl] = useState("");
   const [note, setNote] = useState("");
   const [showAll, setShowAll] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const [collisionRequest, setCollisionRequest] =
     useState<UpsertMealSlotRequest | null>(null);
   const recipes = useRecipes();
@@ -80,6 +85,7 @@ export function MealComposerSheet({
       setImageUrl("");
       setNote("");
       setShowAll(false);
+      setValidationError(null);
       setCollisionRequest(null);
     }
   }, [isOpen]);
@@ -140,54 +146,82 @@ export function MealComposerSheet({
     upsertSlot.mutate(request);
   }
 
-  function buildRecipeRequest(
-    recipeId: string,
-    collisionMode: MealCollisionMode | null = null,
-  ): UpsertMealSlotRequest {
+  function buildValidatedRequest(
+    input: unknown,
+  ):
+    | { ok: true; request: UpsertMealSlotRequest }
+    | { ok: false; message: string } {
+    const parsed = upsertMealSlotSchema.safeParse(input);
+    if (!parsed.success) {
+      return {
+        ok: false,
+        message:
+          parsed.error.issues[0]?.message ??
+          "Check the meal details and try again.",
+      };
+    }
     return {
-      weekStartDate: activeSlot.weekStartDate,
-      dayIndex: activeSlot.dayIndex,
-      mealType: activeSlot.mealType,
-      primary: {
-        sourceType: "recipe",
-        recipeId,
-        title: null,
-        imageUrl: null,
-        note: null,
+      ok: true,
+      request: {
+        weekStartDate: parsed.data.weekStartDate,
+        dayIndex: parsed.data.dayIndex,
+        mealType: parsed.data.mealType,
+        primary: toMealEntryRequest(parsed.data.primary),
+        extras: parsed.data.extras.map(toMealEntryRequest),
+        note: parsed.data.note,
+        collisionMode: parsed.data.collisionMode,
       },
-      extras: [],
-      note: null,
-      collisionMode,
     };
   }
 
+  function placeRecipe(recipeId: string) {
+    const result = buildValidatedRequest({
+      weekStartDate: activeSlot.weekStartDate,
+      dayIndex: activeSlot.dayIndex,
+      mealType: activeSlot.mealType,
+      // The user's meal-planning note belongs to the slot; the recipe entry
+      // snapshot is sourced from the saved recipe (entry note forced to null).
+      primary: { sourceType: "recipe", recipeId },
+      extras: [],
+      note,
+      collisionMode: null,
+    });
+    if (!result.ok) {
+      setValidationError(result.message);
+      return;
+    }
+    setValidationError(null);
+    submitRequest(result.request);
+  }
+
   function handleSelectRecipe(recipe: RecipeSummary) {
-    submitRequest(buildRecipeRequest(recipe.id));
+    placeRecipe(recipe.id);
   }
 
   function handleSeededRecipe() {
     if (!seededRecipeId) return;
-    submitRequest(buildRecipeRequest(seededRecipeId));
+    placeRecipe(seededRecipeId);
   }
 
   function handleCreateQuickMeal() {
     if (!trimmedMealName) return;
 
-    submitRequest({
+    const result = buildValidatedRequest({
       weekStartDate: activeSlot.weekStartDate,
       dayIndex: activeSlot.dayIndex,
       mealType: activeSlot.mealType,
-      primary: {
-        sourceType: "quick",
-        recipeId: null,
-        title: trimmedMealName,
-        imageUrl: imageUrl.trim() || null,
-        note: note.trim() || null,
-      },
+      // Quick-meal note belongs to the entry, not the slot (unchanged behavior).
+      primary: { sourceType: "quick", title: mealName, imageUrl, note },
       extras: [],
       note: null,
       collisionMode: null,
     });
+    if (!result.ok) {
+      setValidationError(result.message);
+      return;
+    }
+    setValidationError(null);
+    submitRequest(result.request);
   }
 
   function handleCreateRecipeFromThis() {
@@ -284,7 +318,11 @@ export function MealComposerSheet({
               </Button>
             </div>
 
-            {upsertSlot.isError ? (
+            {validationError ? (
+              <p className="text-sm text-destructive" role="alert">
+                {validationError}
+              </p>
+            ) : upsertSlot.isError ? (
               <p className="text-sm text-destructive" role="alert">
                 {upsertSlot.error instanceof Error
                   ? upsertSlot.error.message

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -238,6 +238,7 @@ export function MealComposerSheet({
 
   function resolveCollision(collisionMode: MealCollisionMode) {
     if (!collisionRequest) return;
+    setValidationError(null);
     upsertSlot.mutate({ ...collisionRequest, collisionMode });
     setCollisionRequest(null);
   }

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -63,6 +63,7 @@ export function MealComposerSheet({
   const [mealName, setMealName] = useState("");
   const [imageUrl, setImageUrl] = useState("");
   const [note, setNote] = useState("");
+  const [showAll, setShowAll] = useState(false);
   const [collisionRequest, setCollisionRequest] =
     useState<UpsertMealSlotRequest | null>(null);
   const recipes = useRecipes();
@@ -72,13 +73,13 @@ export function MealComposerSheet({
   const startRecipeCreationFromMealSlot = useAppStore(
     (state) => state.startRecipeCreationFromMealSlot,
   );
-  const setActiveModule = useAppStore((state) => state.setActiveModule);
 
   useEffect(() => {
     if (isOpen) {
       setMealName("");
       setImageUrl("");
       setNote("");
+      setShowAll(false);
       setCollisionRequest(null);
     }
   }, [isOpen]);
@@ -106,6 +107,13 @@ export function MealComposerSheet({
       sortedByFavoriteThenRecent(
         allRecipes.filter((recipe) => recipeMatchesQuery(recipe, query)),
       ).slice(0, 6),
+    [allRecipes, query],
+  );
+  const allSortedRecipes = useMemo(
+    () =>
+      sortedByFavoriteThenRecent(
+        allRecipes.filter((recipe) => recipeMatchesQuery(recipe, query)),
+      ),
     [allRecipes, query],
   );
 
@@ -284,36 +292,43 @@ export function MealComposerSheet({
               </p>
             ) : null}
 
-            <Button
-              type="button"
-              variant="ghost"
-              className="w-full justify-start"
-              onClick={() => {
-                setActiveModule("recipes");
-                onOpenChange(false);
-              }}
-            >
-              Browse recipe library
-            </Button>
-
-            {query ? (
+            {showAll ? (
               <RecipeMatchList
-                title="Matching recipes"
-                recipes={matchingRecipes}
+                title="All recipes"
+                recipes={allSortedRecipes}
                 onSelectRecipe={handleSelectRecipe}
               />
             ) : (
               <>
-                <RecipeMatchList
-                  title="Favorite recipes"
-                  recipes={favoriteRecipes}
-                  onSelectRecipe={handleSelectRecipe}
-                />
-                <RecipeMatchList
-                  title="Recent recipes"
-                  recipes={recentRecipes}
-                  onSelectRecipe={handleSelectRecipe}
-                />
+                {query ? (
+                  <RecipeMatchList
+                    title="Matching recipes"
+                    recipes={matchingRecipes}
+                    onSelectRecipe={handleSelectRecipe}
+                  />
+                ) : (
+                  <>
+                    <RecipeMatchList
+                      title="Favorite recipes"
+                      recipes={favoriteRecipes}
+                      onSelectRecipe={handleSelectRecipe}
+                    />
+                    <RecipeMatchList
+                      title="Recent recipes"
+                      recipes={recentRecipes}
+                      onSelectRecipe={handleSelectRecipe}
+                    />
+                  </>
+                )}
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-start"
+                  onClick={() => setShowAll(true)}
+                >
+                  Show all recipes
+                </Button>
               </>
             )}
           </div>

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -25,6 +25,7 @@ import type {
   MealEntryRequest,
   MealSlot,
   MealSlotEntry,
+  MealType,
   MoveMealSlotRequest,
   UpsertMealSlotRequest,
 } from "@/lib/types";
@@ -56,9 +57,15 @@ type PendingCollision =
   | { kind: "move"; request: MoveMealSlotRequest }
   | { kind: "duplicate"; request: DuplicateMealSlotRequest };
 
+export interface MealSlotId {
+  weekStartDate: string;
+  dayIndex: number;
+  mealType: MealType;
+}
+
 interface MealEditorSheetProps {
   isOpen: boolean;
-  slot: MealSlot | null;
+  slotId: MealSlotId | null;
   board: MealBoard | null;
   readOnly: boolean;
   onReplace?: (slot: MealSlot) => void;
@@ -66,9 +73,15 @@ interface MealEditorSheetProps {
   onOpenChange: (open: boolean) => void;
 }
 
+function findSlot(board: MealBoard, slotId: MealSlotId): MealSlot | undefined {
+  return board.days[slotId.dayIndex]?.slots.find(
+    (candidate) => candidate.mealType === slotId.mealType,
+  );
+}
+
 export function MealEditorSheet({
   isOpen,
-  slot,
+  slotId,
   board,
   readOnly,
   onReplace,
@@ -81,7 +94,10 @@ export function MealEditorSheet({
     null,
   );
   const [showRecipe, setShowRecipe] = useState(false);
-  const recipeId = slot?.primary?.recipeId ?? null;
+  // The slot is always read from the live board so saves and collisions stay
+  // accurate; local state only ever holds in-progress drafts.
+  const liveSlot = board && slotId ? findSlot(board, slotId) : undefined;
+  const recipeId = liveSlot?.primary?.recipeId ?? null;
   const recipe = useRecipe(showRecipe ? recipeId : null);
   const moveSlot = useMoveMealSlot({
     onSuccess: () => onOpenChange(false),
@@ -92,25 +108,27 @@ export function MealEditorSheet({
   const removeSlot = useRemoveMealSlot({
     onSuccess: () => onOpenChange(false),
   });
-  const [workingExtras, setWorkingExtras] = useState<MealSlotEntry[]>(
-    slot?.extras ?? [],
-  );
   const [isEditingNote, setIsEditingNote] = useState(false);
-  const [noteDraft, setNoteDraft] = useState(slot?.note ?? "");
+  const [noteDraft, setNoteDraft] = useState(liveSlot?.note ?? "");
+  // Reset the note draft only when the identified slot changes, not on every
+  // background board refetch (which would clobber an in-progress edit).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset keys off the slot identity, not the live slot snapshot.
   useEffect(() => {
-    setWorkingExtras(slot?.extras ?? []);
-    setNoteDraft(slot?.note ?? "");
+    setNoteDraft(liveSlot?.note ?? "");
     setIsEditingNote(false);
-  }, [slot]);
+  }, [slotId?.weekStartDate, slotId?.dayIndex, slotId?.mealType]);
   const upsertSlot = useUpsertMealSlot({
-    onError: () => setWorkingExtras(slot?.extras ?? []),
+    onError: () => {
+      setNoteDraft(liveSlot?.note ?? "");
+      setIsEditingNote(false);
+    },
   });
 
-  if (!slot || !board || !slot.primary) return null;
+  if (!board || !slotId || !liveSlot?.primary) return null;
 
-  const activeSlot = slot;
+  const activeSlot = liveSlot;
   const activeBoard = board;
-  const activePrimary = slot.primary;
+  const activePrimary = liveSlot.primary;
   const actionDisabled =
     readOnly ||
     moveSlot.isPending ||
@@ -141,15 +159,16 @@ export function MealEditorSheet({
   }
 
   function handleRemoveExtra(extraId: string) {
-    const nextExtras = workingExtras.filter((extra) => extra.id !== extraId);
-    setWorkingExtras(nextExtras);
+    const nextExtras = activeSlot.extras.filter(
+      (extra) => extra.id !== extraId,
+    );
     saveComposition(nextExtras, activeSlot.note);
   }
 
   function handleSaveNote() {
     const nextNote = noteDraft.trim() || null;
     setIsEditingNote(false);
-    saveComposition(workingExtras, nextNote);
+    saveComposition(activeSlot.extras, nextNote);
   }
 
   function confirmMoveTarget(target: {
@@ -234,9 +253,9 @@ export function MealEditorSheet({
                   {activePrimary.note}
                 </p>
               ) : null}
-              {workingExtras.length > 0 ? (
+              {activeSlot.extras.length > 0 ? (
                 <div className="mt-3 flex flex-wrap gap-1">
-                  {workingExtras.map((extra) => (
+                  {activeSlot.extras.map((extra) => (
                     <span
                       key={extra.id}
                       className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-1 text-xs font-medium text-secondary-foreground"

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -97,6 +97,8 @@ export function MealEditorSheet({
   // The slot is always read from the live board so saves and collisions stay
   // accurate; local state only ever holds in-progress drafts.
   const liveSlot = board && slotId ? findSlot(board, slotId) : undefined;
+  const selectedSlotMissing =
+    isOpen && Boolean(board && slotId && !liveSlot?.primary);
   const recipeId = liveSlot?.primary?.recipeId ?? null;
   const recipe = useRecipe(showRecipe ? recipeId : null);
   const moveSlot = useMoveMealSlot({
@@ -117,6 +119,11 @@ export function MealEditorSheet({
     setNoteDraft(liveSlot?.note ?? "");
     setIsEditingNote(false);
   }, [slotId?.weekStartDate, slotId?.dayIndex, slotId?.mealType]);
+  useEffect(() => {
+    if (selectedSlotMissing) {
+      onOpenChange(false);
+    }
+  }, [onOpenChange, selectedSlotMissing]);
   const upsertSlot = useUpsertMealSlot({
     onError: () => {
       setNoteDraft(liveSlot?.note ?? "");

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -228,9 +228,6 @@ export function MealEditorSheet({
             <RecipeDetailView
               recipe={recipe.data.data}
               onBack={() => setShowRecipe(false)}
-              onAddToMeals={() => undefined}
-              onEdit={() => undefined}
-              onToggleFavorite={() => undefined}
             />
           ) : recipe.isLoading ? (
             <p className="text-sm text-muted-foreground">Loading recipe...</p>

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -29,7 +29,6 @@ export function MealSlotCard({
           readOnly ? "cursor-default" : "hover:bg-muted/50",
         )}
         aria-label={`Open ${slot.mealType}: ${slot.primary.title}`}
-        disabled={readOnly}
         onClick={() => onSelectSlot(slot)}
       >
         <div className="flex items-start gap-3">

--- a/src/components/meals/recipe-match-list.test.tsx
+++ b/src/components/meals/recipe-match-list.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { testRecipeSummary } from "@/test/fixtures/recipes";
+import { fireEvent, render, screen } from "@/test/test-utils";
+import { RecipeMatchList } from "./recipe-match-list";
+
+describe("RecipeMatchList", () => {
+  it("returns null when recipes array is empty", () => {
+    const { container } = render(
+      <RecipeMatchList title="Matches" recipes={[]} onSelectRecipe={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders recipe rows with the recipe title", () => {
+    render(
+      <RecipeMatchList
+        title="Matches"
+        recipes={[testRecipeSummary]}
+        onSelectRecipe={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: `Select recipe: ${testRecipeSummary.title}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the image when imageUrl is present and load succeeds", () => {
+    const { container } = render(
+      <RecipeMatchList
+        title="Matches"
+        recipes={[testRecipeSummary]}
+        onSelectRecipe={vi.fn()}
+      />,
+    );
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute("src", testRecipeSummary.imageUrl);
+  });
+
+  it("shows no image element when imageUrl is absent", () => {
+    const recipe = { ...testRecipeSummary, imageUrl: null };
+    const { container } = render(
+      <RecipeMatchList
+        title="Matches"
+        recipes={[recipe]}
+        onSelectRecipe={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("falls back to the placeholder div when the image fails to load", () => {
+    const { container } = render(
+      <RecipeMatchList
+        title="Matches"
+        recipes={[testRecipeSummary]}
+        onSelectRecipe={vi.fn()}
+      />,
+    );
+
+    const img = container.querySelector("img") as HTMLImageElement | null;
+    expect(img).not.toBeNull();
+
+    fireEvent.error(img as HTMLImageElement);
+
+    // Image should be replaced by the fallback div — no img element in DOM
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("calls onSelectRecipe when a recipe button is clicked", async () => {
+    const onSelectRecipe = vi.fn();
+    render(
+      <RecipeMatchList
+        title="Matches"
+        recipes={[testRecipeSummary]}
+        onSelectRecipe={onSelectRecipe}
+      />,
+    );
+
+    screen
+      .getByRole("button", {
+        name: `Select recipe: ${testRecipeSummary.title}`,
+      })
+      .click();
+
+    expect(onSelectRecipe).toHaveBeenCalledWith(testRecipeSummary);
+  });
+});

--- a/src/components/meals/recipe-match-list.tsx
+++ b/src/components/meals/recipe-match-list.tsx
@@ -1,5 +1,21 @@
 import { Heart } from "lucide-react";
+import { useState } from "react";
 import type { RecipeSummary } from "@/lib/types";
+
+function RecipeMatchThumbnail({ recipe }: { recipe: RecipeSummary }) {
+  const [imgFailed, setImgFailed] = useState(false);
+  if (!recipe.imageUrl || imgFailed) {
+    return <div className="h-12 w-12 rounded-md bg-muted" />;
+  }
+  return (
+    <img
+      src={recipe.imageUrl}
+      alt=""
+      className="h-12 w-12 rounded-md object-cover"
+      onError={() => setImgFailed(true)}
+    />
+  );
+}
 
 interface RecipeMatchListProps {
   title: string;
@@ -26,15 +42,7 @@ export function RecipeMatchList({
             aria-label={`Select recipe: ${recipe.title}`}
             onClick={() => onSelectRecipe(recipe)}
           >
-            {recipe.imageUrl ? (
-              <img
-                src={recipe.imageUrl}
-                alt=""
-                className="h-12 w-12 rounded-md object-cover"
-              />
-            ) : (
-              <div className="h-12 w-12 rounded-md bg-muted" />
-            )}
+            <RecipeMatchThumbnail recipe={recipe} />
             <span className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
               {recipe.title}
             </span>

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -524,7 +524,32 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("opens manual create from a meals draft and returns to meals with a slot handoff after save", async () => {
+  it("opens the chooser from a meals draft so URL import is reachable", async () => {
+    seedMockRecipes([]);
+    useAppStore.getState().startRecipeCreationFromMealSlot({
+      requestedAtWeekStartDate: "2026-06-07",
+      dayIndex: 3,
+      mealType: "dinner",
+      typedTitle: "Skillet Eggs",
+    });
+
+    renderWithUser(<RecipesView />);
+
+    // The chooser (Add Recipe) must open — not jump straight to manual mode.
+    expect(
+      await screen.findByRole("dialog", { name: "Add Recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create manually" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Import from URL" }),
+    ).toBeVisible();
+    // The manual form must NOT be visible yet.
+    expect(screen.queryByLabelText("Title")).not.toBeInTheDocument();
+  });
+
+  it("picking Create manually from the meals-draft chooser prefills the title and returns to meals after save", async () => {
     seedMockRecipes([]);
     useAppStore.getState().startRecipeCreationFromMealSlot({
       requestedAtWeekStartDate: "2026-06-07",
@@ -535,6 +560,11 @@ describe("RecipesView", () => {
 
     const { user } = renderWithUser(<RecipesView />);
 
+    // Wait for the chooser to open.
+    await screen.findByRole("dialog", { name: "Add Recipe" });
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+
+    // Switching to manual mode should prefill the title from the draft.
     expect(
       await screen.findByRole("dialog", { name: "Create Recipe" }),
     ).toBeInTheDocument();
@@ -555,7 +585,7 @@ describe("RecipesView", () => {
     });
   });
 
-  it("cancels a meals draft create without leaving stale handoff state", async () => {
+  it("importing from URL via the meals-draft chooser returns to meals with a slot handoff", async () => {
     seedMockRecipes([]);
     useAppStore.getState().startRecipeCreationFromMealSlot({
       requestedAtWeekStartDate: "2026-06-07",
@@ -566,10 +596,52 @@ describe("RecipesView", () => {
 
     const { user } = renderWithUser(<RecipesView />);
 
+    // Chooser opens.
+    await screen.findByRole("dialog", { name: "Add Recipe" });
+    await user.click(screen.getByRole("button", { name: "Import from URL" }));
+
+    // Import sheet appears.
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Recipe URL"),
+      "https://example.com/imported-soup",
+    );
+    await user.click(screen.getByRole("button", { name: "Import recipe" }));
+
+    // After a successful import the app returns to Meals with the placement draft.
+    expect(useAppStore.getState().activeModule).toBe("meals");
+    expect(useAppStore.getState().recipeCreationDraft).toBe(null);
+    expect(useAppStore.getState().mealPlacementDraft).toEqual({
+      recipeId: "00000000-0000-4000-8000-000000000502",
+      requestedAtWeekStartDate: "2026-06-07",
+      source: {
+        kind: "meals-slot",
+        dayIndex: 2,
+        mealType: "lunch",
+      },
+    });
+  });
+
+  it("dismissing the meals-draft chooser clears the draft without leaving stale handoff state", async () => {
+    seedMockRecipes([]);
+    useAppStore.getState().startRecipeCreationFromMealSlot({
+      requestedAtWeekStartDate: "2026-06-07",
+      dayIndex: 2,
+      mealType: "lunch",
+      typedTitle: "Soup idea",
+    });
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    // Chooser opens (not manual mode).
     expect(
-      await screen.findByRole("dialog", { name: "Create Recipe" }),
+      await screen.findByRole("dialog", { name: "Add Recipe" }),
     ).toBeInTheDocument();
 
+    // Navigate into manual mode then cancel — onCancelManual fires and clears
+    // the draft.
+    await user.click(screen.getByRole("button", { name: "Create manually" }));
+    await screen.findByRole("dialog", { name: "Create Recipe" });
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(useAppStore.getState().recipeCreationDraft).toBe(null);

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -476,6 +476,31 @@ describe("RecipesView", () => {
     expect(screen.getByText("Imported Tomato Soup")).toBeInTheDocument();
   });
 
+  it("shows an 'Add your first recipe' button in the empty card that opens the chooser", async () => {
+    seedMockRecipes([]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await screen.findByText("No recipes yet");
+
+    const emptyCardButton = screen.getByRole("button", {
+      name: "Add your first recipe",
+    });
+    expect(emptyCardButton).toBeVisible();
+
+    await user.click(emptyCardButton);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Add Recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create manually" }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Import from URL" }),
+    ).toBeVisible();
+  });
+
   it("opens the add flow with manual and import choices", async () => {
     seedMockRecipes(testRecipeDetails);
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -647,6 +647,33 @@ describe("RecipesView", () => {
     });
   });
 
+  it("dismissing the chooser directly (without entering manual) clears the meals draft", async () => {
+    seedMockRecipes([]);
+    useAppStore.getState().startRecipeCreationFromMealSlot({
+      requestedAtWeekStartDate: "2026-06-07",
+      dayIndex: 3,
+      mealType: "dinner",
+      typedTitle: "Skillet Eggs",
+    });
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    // Chooser opens (not manual mode).
+    expect(
+      await screen.findByRole("dialog", { name: "Add Recipe" }),
+    ).toBeInTheDocument();
+
+    // Cancel directly on the chooser — without drilling into "Create manually".
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // The draft must be consumed so it cannot stale-prefill a future create.
+    expect(useAppStore.getState().recipeCreationDraft).toBe(null);
+    // The dialog must be gone.
+    expect(
+      screen.queryByRole("dialog", { name: "Add Recipe" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("dismissing the meals-draft chooser clears the draft without leaving stale handoff state", async () => {
     seedMockRecipes([]);
     useAppStore.getState().startRecipeCreationFromMealSlot({
@@ -663,7 +690,7 @@ describe("RecipesView", () => {
       await screen.findByRole("dialog", { name: "Add Recipe" }),
     ).toBeInTheDocument();
 
-    // Navigate into manual mode then cancel — onCancelManual fires and clears
+    // Navigate into manual mode then cancel — onCancel fires and clears
     // the draft.
     await user.click(screen.getByRole("button", { name: "Create manually" }));
     await screen.findByRole("dialog", { name: "Create Recipe" });

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -318,7 +318,7 @@ export function RecipesView() {
           defaultMode={createSheetMode}
           defaultValues={createSheetDefaultValues}
           isOpen={isCreateSheetOpen}
-          onCancelManual={
+          onCancel={
             recipeCreationDraft
               ? () => {
                   consumeRecipeCreationDraft();

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -281,6 +281,14 @@ export function RecipesView() {
                 <p className="mt-2 text-sm text-muted-foreground">
                   Add your first recipe to get started.
                 </p>
+                <div className="mt-4">
+                  <Button
+                    type="button"
+                    onClick={() => setIsCreateSheetOpen(true)}
+                  >
+                    Add your first recipe
+                  </Button>
+                </div>
               </div>
             ) : filteredRecipes.length === 0 ? (
               <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -137,7 +137,7 @@ export function RecipesView() {
     }
   }, [hasOpenedRecipeDraft, recipeCreationDraft]);
 
-  const createSheetMode = recipeCreationDraft ? "manual" : "choices";
+  const createSheetMode = "choices";
   const createSheetDefaultValues = recipeCreationDraft
     ? { title: recipeCreationDraft.typedTitle }
     : undefined;

--- a/src/components/recipes/recipe-create-sheet.tsx
+++ b/src/components/recipes/recipe-create-sheet.tsx
@@ -15,7 +15,7 @@ interface RecipeCreateSheetProps {
   onCreated: (recipeId: string) => void;
   defaultMode?: AddRecipeMode;
   defaultValues?: Partial<RecipeFormInput>;
-  onCancelManual?: () => void;
+  onCancel?: () => void;
 }
 
 export function RecipeCreateSheet({
@@ -24,7 +24,7 @@ export function RecipeCreateSheet({
   onCreated,
   defaultMode = "choices",
   defaultValues,
-  onCancelManual,
+  onCancel,
 }: RecipeCreateSheetProps) {
   const [mode, setMode] = useState<AddRecipeMode>(defaultMode);
   const [importError, setImportError] = useState<string | null>(null);
@@ -57,19 +57,16 @@ export function RecipeCreateSheet({
     },
   });
 
-  const closeAddFlow = () => {
-    onOpenChange(false);
-  };
-
-  const closeManual = () => {
-    if (onCancelManual) {
-      onCancelManual();
+  // Unified dismissal: if the caller provided onCancel (e.g. a meals draft
+  // flow), delegate so it can consume the draft and reset state. Otherwise
+  // just close the sheet. Must NOT be used from handleSuccess — the success
+  // path keeps onCreated responsible for consuming the draft.
+  const dismissFlow = () => {
+    if (onCancel) {
+      onCancel();
       return;
     }
-
-    // "Cancel" dismisses the whole add flow to match its label, rather than
-    // quietly stepping back to the choices screen.
-    closeAddFlow();
+    onOpenChange(false);
   };
 
   if (mode === "manual") {
@@ -79,7 +76,7 @@ export function RecipeCreateSheet({
         : "Could not save recipe";
 
     return (
-      <MobileSheet isOpen={isOpen} onClose={closeManual} title="Create Recipe">
+      <MobileSheet isOpen={isOpen} onClose={dismissFlow} title="Create Recipe">
         <RecipeForm
           defaultValues={defaultValues}
           isPending={createRecipe.isPending}
@@ -96,7 +93,7 @@ export function RecipeCreateSheet({
         isOpen={isOpen}
         isPending={importRecipe.isPending}
         errorMessage={importError}
-        onClose={closeAddFlow}
+        onClose={dismissFlow}
         onSubmit={(url) => {
           setImportError(null);
           importRecipe.mutate(
@@ -117,11 +114,7 @@ export function RecipeCreateSheet({
   }
 
   return (
-    <MobileSheet
-      isOpen={isOpen}
-      onClose={() => onOpenChange(false)}
-      title="Add Recipe"
-    >
+    <MobileSheet isOpen={isOpen} onClose={dismissFlow} title="Add Recipe">
       <div className="space-y-3">
         <Button
           type="button"

--- a/src/components/recipes/recipe-detail-view.test.tsx
+++ b/src/components/recipes/recipe-detail-view.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { testRecipeDetail } from "@/test/fixtures/recipes";
-import { render, screen } from "@/test/test-utils";
+import { fireEvent, render, screen } from "@/test/test-utils";
 import { RecipeDetailView } from "./recipe-detail-view";
 
 describe("RecipeDetailView", () => {
@@ -104,5 +104,20 @@ describe("RecipeDetailView", () => {
         name: `Favorite recipe: ${testRecipeDetail.title}`,
       }),
     ).toBeInTheDocument();
+  });
+
+  it("falls back to No photo placeholder when the recipe image fails to load", () => {
+    // testRecipeDetail has imageUrl set, so the img is rendered initially
+    render(<RecipeDetailView recipe={testRecipeDetail} onBack={vi.fn()} />);
+
+    const img = screen.getByRole("img", { name: testRecipeDetail.title });
+    expect(img).toBeInTheDocument();
+
+    fireEvent.error(img);
+
+    expect(
+      screen.queryByRole("img", { name: testRecipeDetail.title }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("No photo")).toBeInTheDocument();
   });
 });

--- a/src/components/recipes/recipe-detail-view.test.tsx
+++ b/src/components/recipes/recipe-detail-view.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { testRecipeDetail } from "@/test/fixtures/recipes";
+import { render, screen } from "@/test/test-utils";
+import { RecipeDetailView } from "./recipe-detail-view";
+
+describe("RecipeDetailView", () => {
+  it("renders recipe content and Back button when no action handlers are provided", () => {
+    render(<RecipeDetailView recipe={testRecipeDetail} onBack={vi.fn()} />);
+
+    // Content always present
+    expect(
+      screen.getByRole("heading", { name: testRecipeDetail.title }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Ingredients" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Instructions" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeInTheDocument();
+
+    // Action buttons absent when handlers not provided
+    expect(
+      screen.queryByRole("button", { name: "Edit recipe" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to Meals" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: `Favorite recipe: ${testRecipeDetail.title}`,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders all action buttons when all handlers are provided", () => {
+    render(
+      <RecipeDetailView
+        recipe={testRecipeDetail}
+        onBack={vi.fn()}
+        onEdit={vi.fn()}
+        onAddToMeals={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Back to recipes" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to Meals" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: `Favorite recipe: ${testRecipeDetail.title}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders only the Edit button when only onEdit is provided", () => {
+    render(
+      <RecipeDetailView
+        recipe={testRecipeDetail}
+        onBack={vi.fn()}
+        onEdit={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Edit recipe" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to Meals" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: `Favorite recipe: ${testRecipeDetail.title}`,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders only the Favorite button when only onToggleFavorite is provided", () => {
+    render(
+      <RecipeDetailView
+        recipe={testRecipeDetail}
+        onBack={vi.fn()}
+        onToggleFavorite={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Edit recipe" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add to Meals" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: `Favorite recipe: ${testRecipeDetail.title}`,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, Heart, Pencil } from "lucide-react";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { formatRecipeTag } from "@/lib/recipe-tags";
 import type { RecipeDetail } from "@/lib/types";
@@ -37,15 +38,17 @@ export function RecipeDetailView({
   onEdit,
   onToggleFavorite,
 }: RecipeDetailViewProps) {
+  const [imgFailed, setImgFailed] = useState(false);
   return (
     <div className="space-y-4 rounded-lg border border-border bg-card p-4">
       <div className="space-y-5">
         <div className="relative aspect-[4/3] overflow-hidden rounded-lg bg-muted">
-          {recipe.imageUrl ? (
+          {recipe.imageUrl && !imgFailed ? (
             <img
               src={recipe.imageUrl}
               alt={recipe.title}
               className="h-full w-full object-cover"
+              onError={() => setImgFailed(true)}
             />
           ) : (
             <div className="flex h-full items-center justify-center">

--- a/src/components/recipes/recipe-detail-view.tsx
+++ b/src/components/recipes/recipe-detail-view.tsx
@@ -24,9 +24,9 @@ interface RecipeDetailViewProps {
   recipe: RecipeDetail;
   isUpdatingFavorite?: boolean;
   onBack: () => void;
-  onAddToMeals: () => void;
-  onEdit: () => void;
-  onToggleFavorite: () => void;
+  onAddToMeals?: () => void;
+  onEdit?: () => void;
+  onToggleFavorite?: () => void;
 }
 
 export function RecipeDetailView({
@@ -123,31 +123,37 @@ export function RecipeDetailView({
             <ArrowLeft className="h-4 w-4" />
             Back to recipes
           </Button>
-          <Button type="button" variant="outline" onClick={onEdit}>
-            <Pencil className="h-4 w-4" />
-            Edit recipe
-          </Button>
-          <Button type="button" variant="outline" onClick={onAddToMeals}>
-            Add to Meals
-          </Button>
-          <Button
-            type="button"
-            variant={recipe.favorite ? "secondary" : "outline"}
-            aria-label={`Favorite recipe: ${recipe.title}`}
-            aria-pressed={recipe.favorite}
-            disabled={isUpdatingFavorite}
-            onClick={onToggleFavorite}
-          >
-            <Heart
-              className={cn(
-                "h-4 w-4",
-                recipe.favorite
-                  ? "fill-rose-500 text-rose-500"
-                  : "text-current",
-              )}
-            />
-            {recipe.favorite ? "Favorited" : "Favorite"}
-          </Button>
+          {onEdit ? (
+            <Button type="button" variant="outline" onClick={onEdit}>
+              <Pencil className="h-4 w-4" />
+              Edit recipe
+            </Button>
+          ) : null}
+          {onAddToMeals ? (
+            <Button type="button" variant="outline" onClick={onAddToMeals}>
+              Add to Meals
+            </Button>
+          ) : null}
+          {onToggleFavorite ? (
+            <Button
+              type="button"
+              variant={recipe.favorite ? "secondary" : "outline"}
+              aria-label={`Favorite recipe: ${recipe.title}`}
+              aria-pressed={recipe.favorite}
+              disabled={isUpdatingFavorite}
+              onClick={onToggleFavorite}
+            >
+              <Heart
+                className={cn(
+                  "h-4 w-4",
+                  recipe.favorite
+                    ? "fill-rose-500 text-rose-500"
+                    : "text-current",
+                )}
+              />
+              {recipe.favorite ? "Favorited" : "Favorite"}
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/recipes/recipe-form.test.tsx
+++ b/src/components/recipes/recipe-form.test.tsx
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  renderWithUser,
+  screen,
+  typeAndWait,
+  waitFor,
+} from "@/test/test-utils";
+import { RecipeForm } from "./recipe-form";
+
+describe("RecipeForm — per-row remove controls", () => {
+  it("renders a Remove button for each ingredient row", async () => {
+    renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    // Default is 2 rows, so expect 2 remove buttons
+    expect(
+      screen.getByRole("button", { name: "Remove ingredient 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove ingredient 2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Remove button for each instruction row", async () => {
+    renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Remove instruction 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove instruction 2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a Remove button for each tag row", async () => {
+    renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: "Remove tag 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove tag 2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("removes the middle ingredient row and shifts remaining values correctly", async () => {
+    const { user } = renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    // Fill the default 2 rows
+    await typeAndWait(user, screen.getByLabelText("Ingredient 1"), "apple");
+    await typeAndWait(user, screen.getByLabelText("Ingredient 2"), "banana");
+
+    // Add a third row
+    await user.click(screen.getByRole("button", { name: "Add ingredient" }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Ingredient 3")).toBeInTheDocument();
+    });
+    await typeAndWait(user, screen.getByLabelText("Ingredient 3"), "cherry");
+
+    // Remove the middle row (Ingredient 2 = "banana")
+    await user.click(
+      screen.getByRole("button", { name: "Remove ingredient 2" }),
+    );
+
+    // After removal: "apple" stays in row 1, "cherry" moves to row 2
+    await waitFor(() => {
+      expect(screen.getByLabelText("Ingredient 1")).toHaveValue("apple");
+      expect(screen.getByLabelText("Ingredient 2")).toHaveValue("cherry");
+    });
+
+    // "banana" should be gone
+    const allInputs = screen
+      .getAllByRole("textbox")
+      .filter((input) =>
+        input.getAttribute("aria-label")?.startsWith("Ingredient"),
+      );
+    expect(allInputs).toHaveLength(2);
+    expect(
+      allInputs.every(
+        (input) => (input as HTMLInputElement).value !== "banana",
+      ),
+    ).toBe(true);
+  });
+
+  it("removes the middle instruction row and shifts remaining values correctly", async () => {
+    const { user } = renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    await typeAndWait(user, screen.getByLabelText("Instruction 1"), "step one");
+    await typeAndWait(user, screen.getByLabelText("Instruction 2"), "step two");
+
+    await user.click(screen.getByRole("button", { name: "Add instruction" }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Instruction 3")).toBeInTheDocument();
+    });
+    await typeAndWait(
+      user,
+      screen.getByLabelText("Instruction 3"),
+      "step three",
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove instruction 2" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Instruction 1")).toHaveValue("step one");
+      expect(screen.getByLabelText("Instruction 2")).toHaveValue("step three");
+    });
+
+    const allInputs = screen
+      .getAllByRole("textbox")
+      .filter((input) =>
+        input.getAttribute("aria-label")?.startsWith("Instruction"),
+      );
+    expect(allInputs).toHaveLength(2);
+    expect(
+      allInputs.every(
+        (input) => (input as HTMLInputElement).value !== "step two",
+      ),
+    ).toBe(true);
+  });
+
+  it("removes the middle tag row and shifts remaining values correctly", async () => {
+    const { user } = renderWithUser(<RecipeForm onSubmit={vi.fn()} />);
+
+    await typeAndWait(user, screen.getByLabelText("Tag 1"), "vegan");
+    await typeAndWait(user, screen.getByLabelText("Tag 2"), "quick");
+
+    await user.click(screen.getByRole("button", { name: "Add tag" }));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Tag 3")).toBeInTheDocument();
+    });
+    await typeAndWait(user, screen.getByLabelText("Tag 3"), "dinner");
+
+    await user.click(screen.getByRole("button", { name: "Remove tag 2" }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Tag 1")).toHaveValue("vegan");
+      expect(screen.getByLabelText("Tag 2")).toHaveValue("dinner");
+    });
+
+    const allInputs = screen
+      .getAllByRole("textbox")
+      .filter((input) => input.getAttribute("aria-label")?.startsWith("Tag"));
+    expect(allInputs).toHaveLength(2);
+    expect(
+      allInputs.every((input) => (input as HTMLInputElement).value !== "quick"),
+    ).toBe(true);
+  });
+
+  it("keeps at least two blank rows after removing all ingredients, and can submit a name-only recipe", async () => {
+    const onSubmit = vi.fn();
+    const { user } = renderWithUser(<RecipeForm onSubmit={onSubmit} />);
+
+    // Default state: 2 blank rows. Remove row 1 → re-pads back to 2 blank rows.
+    await user.click(
+      screen.getByRole("button", { name: "Remove ingredient 1" }),
+    );
+
+    // Still 2 blank ingredient rows
+    await waitFor(() => {
+      const ingredientInputs = screen
+        .getAllByRole("textbox")
+        .filter((input) =>
+          input.getAttribute("aria-label")?.startsWith("Ingredient"),
+        );
+      expect(ingredientInputs).toHaveLength(2);
+      expect(ingredientInputs[0]).toHaveValue("");
+      expect(ingredientInputs[1]).toHaveValue("");
+    });
+
+    // Remove the second of the re-padded rows → still 2 blank rows
+    await user.click(
+      screen.getByRole("button", { name: "Remove ingredient 2" }),
+    );
+
+    await waitFor(() => {
+      const ingredientInputs = screen
+        .getAllByRole("textbox")
+        .filter((input) =>
+          input.getAttribute("aria-label")?.startsWith("Ingredient"),
+        );
+      expect(ingredientInputs).toHaveLength(2);
+      ingredientInputs.forEach((input) => {
+        expect(input).toHaveValue("");
+      });
+    });
+
+    // Fill in a title and submit — onSubmit should receive empty arrays (blank strings stripped)
+    await typeAndWait(user, screen.getByLabelText("Title"), "Simple Recipe");
+    await user.click(screen.getByRole("button", { name: "Save recipe" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    const submitted = onSubmit.mock.calls[0][0];
+    expect(submitted.ingredients).toEqual([]);
+    expect(submitted.instructions).toEqual([]);
+    expect(submitted.tags).toEqual([]);
+    expect(submitted.title).toBe("Simple Recipe");
+  });
+});

--- a/src/components/recipes/recipe-form.tsx
+++ b/src/components/recipes/recipe-form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Plus } from "lucide-react";
+import { Plus, X } from "lucide-react";
 import type { FieldError } from "react-hook-form";
 import { useForm, useWatch } from "react-hook-form";
 import { Button } from "@/components/ui/button";
@@ -45,12 +45,14 @@ function ArrayFieldSection({
   errorMessages,
   onChange,
   onAdd,
+  onRemove,
 }: {
   legend: string;
   values: string[];
   errorMessages?: Array<string | undefined>;
   onChange: (index: number, value: string) => void;
   onAdd: () => void;
+  onRemove: (index: number) => void;
 }) {
   const singular = legend.endsWith("s") ? legend.slice(0, -1) : legend;
 
@@ -75,12 +77,25 @@ function ArrayFieldSection({
       <div className="space-y-2">
         {values.map((value, index) => (
           <div key={`${singular}-${index}`} className="space-y-1">
-            <Input
-              aria-label={`${singular} ${index + 1}`}
-              aria-invalid={Boolean(errorMessages?.[index])}
-              value={value}
-              onChange={(event) => onChange(index, event.target.value)}
-            />
+            <div className="flex items-center gap-2">
+              <Input
+                aria-label={`${singular} ${index + 1}`}
+                aria-invalid={Boolean(errorMessages?.[index])}
+                value={value}
+                onChange={(event) => onChange(index, event.target.value)}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                aria-label={`Remove ${singular.toLowerCase()} ${index + 1}`}
+                onClick={() => onRemove(index)}
+                className="shrink-0"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
             <FormError message={errorMessages?.[index]} />
           </div>
         ))}
@@ -228,6 +243,13 @@ export function RecipeForm({
             shouldDirty: true,
           });
         }}
+        onRemove={(index) => {
+          form.setValue(
+            "ingredients",
+            ingredients.filter((_, i) => i !== index),
+            { shouldDirty: true },
+          );
+        }}
       />
 
       <ArrayFieldSection
@@ -246,6 +268,13 @@ export function RecipeForm({
             shouldDirty: true,
           });
         }}
+        onRemove={(index) => {
+          form.setValue(
+            "instructions",
+            instructions.filter((_, i) => i !== index),
+            { shouldDirty: true },
+          );
+        }}
       />
 
       <ArrayFieldSection
@@ -263,6 +292,13 @@ export function RecipeForm({
           form.setValue("tags", [...tags, ""], {
             shouldDirty: true,
           });
+        }}
+        onRemove={(index) => {
+          form.setValue(
+            "tags",
+            tags.filter((_, i) => i !== index),
+            { shouldDirty: true },
+          );
         }}
       />
 

--- a/src/components/recipes/recipe-library-card.test.tsx
+++ b/src/components/recipes/recipe-library-card.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { testRecipeSummary } from "@/test/fixtures/recipes";
+import { fireEvent, render, screen } from "@/test/test-utils";
+import { RecipeLibraryCard } from "./recipe-library-card";
+
+describe("RecipeLibraryCard", () => {
+  it("shows the recipe image when imageUrl is present and load succeeds", () => {
+    render(<RecipeLibraryCard recipe={testRecipeSummary} />);
+
+    const img = screen.getByRole("img", { name: testRecipeSummary.title });
+    expect(img).toBeInTheDocument();
+    expect(screen.queryByText("No photo")).not.toBeInTheDocument();
+  });
+
+  it("shows the No photo placeholder when imageUrl is absent", () => {
+    const recipe = { ...testRecipeSummary, imageUrl: null };
+    render(<RecipeLibraryCard recipe={recipe} />);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("No photo")).toBeInTheDocument();
+  });
+
+  it("falls back to No photo placeholder when the image fails to load", () => {
+    render(<RecipeLibraryCard recipe={testRecipeSummary} />);
+
+    const img = screen.getByRole("img", { name: testRecipeSummary.title });
+    expect(img).toBeInTheDocument();
+
+    fireEvent.error(img);
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    expect(screen.getByText("No photo")).toBeInTheDocument();
+  });
+
+  it("calls onSelect with the recipe id when the open button is clicked", async () => {
+    const onSelect = vi.fn();
+    render(
+      <RecipeLibraryCard recipe={testRecipeSummary} onSelect={onSelect} />,
+    );
+
+    const btn = screen.getByRole("button", {
+      name: `Open recipe: ${testRecipeSummary.title}`,
+    });
+    btn.click();
+
+    expect(onSelect).toHaveBeenCalledWith(testRecipeSummary.id);
+  });
+});

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -1,4 +1,5 @@
 import { Heart } from "lucide-react";
+import { useState } from "react";
 import { formatRecipeTag } from "@/lib/recipe-tags";
 import type { RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -12,6 +13,7 @@ export function RecipeLibraryCard({
   recipe,
   onSelect,
 }: RecipeLibraryCardProps) {
+  const [imgFailed, setImgFailed] = useState(false);
   return (
     <article
       aria-label={`Recipe card: ${recipe.title}`}
@@ -26,11 +28,12 @@ export function RecipeLibraryCard({
         onClick={() => onSelect?.(recipe.id)}
       />
       <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
-        {recipe.imageUrl ? (
+        {recipe.imageUrl && !imgFailed ? (
           <img
             src={recipe.imageUrl}
             alt={recipe.title}
             className="h-full w-full object-cover"
+            onError={() => setImgFailed(true)}
           />
         ) : (
           <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
## Summary

Resolves all valid findings from two independent feature reviews (Claude + Codex) of the **Recipes + Meals** modules so behavior matches the Meals & Recipes foundation design. Frontend-only — the released backend (`family-hub-api v1.5.0`) already supports every write path used here.

Themes:
1. **Data integrity** — the meal editor reads **live** board/slot data instead of a frozen snapshot, so saves are reflected immediately and move/duplicate collision checks are correct; board refetch is the single source of truth after an upsert.
2. **Reviewability** — past weeks are genuinely browsable: tapping a past occupied meal opens the editor read-only (mutations disabled, "View recipe" available).
3. **Cross-module flow** — removed dead/no-op affordances and restored the meals↔recipes handoffs (in-context full-library pick, URL import from the meals-origin create flow).
4. **Validation** — the composer now routes payloads through the previously-dead, tested Zod schemas; a typed note becomes the slot-level meal note on recipe placement.
5. **Polish** — image `onError` fallbacks, board retry, recipe-row removal, empty-state CTA, README refresh.

**Locked product decision (preserved):** tapping a recipe-backed planned meal keeps the **editor-first** flow — the editor opens first and "View recipe" reaches live recipe detail.

Plan: `docs/superpowers/plans/2026-06-07-meals-recipes-review-consolidated-fixes.md`

## Requirement → coverage

| ID | Finding | Commit | Tests |
|----|---------|--------|-------|
| C1 | Meal editor read frozen snapshot (stale note, wrong collisions) | `6689726` | meals-view: live-note save, survives revalidation, live-board collision |
| C11 | `useUpsertMealSlot` partial hand-merge could mask server state | `f531729` | use-meals: invalidation/refetch is authority; `add_as_extra` merge |
| C2 | Past occupied meals not openable for review | `5aecd67` | meals-view: past slot opens read-only; mutations disabled; View recipe works |
| C3 | In-editor recipe detail showed dead Edit/Favorite/Add buttons | `00001f5` | recipe-detail-view: optional actions; meals-view: review-only detail |
| C4 | "Browse recipe library" dropped the slot/week being planned | `4b2deb2` | composer: in-context "Show all recipes", no module switch |
| C5 | URL import unreachable from meals-origin recipe creation | `1b63516` | recipes-view: chooser shown; manual prefill + meals return; import → meals return |
| C6 | Composer bypassed tested Zod schemas; typed note dropped on recipe placement | `dbbaed9`, `ed358c8` | composer: invalid image URL blocked (no mutation); slot-level note carry |
| C7 | Broken images showed the browser glyph (no fallback) | `40dc68f` | library-card / detail-view / match-list: `onError` → placeholder |
| C8 | Meals board error state had no Retry | `0517445` | meals-view: retry refetches the board |
| C9 | Recipe form rows had Add but no per-row Remove | `05f4840` | recipe-form: remove ingredient/instruction/tag; name-only submit |
| C10 | Recipes empty state had no add CTA | `d3155e4` | recipes-view: "Add your first recipe" opens chooser |
| C12 | README module-status table + version line stale; dead ROADMAP link | `bb6528d` | docs only |

**Review follow-up:** `c044b7c` — fixes a regression surfaced in code review where dismissing the create chooser from a meals draft left `recipeCreationDraft` orphaned (stale prefill / wrong meals-return). All dismissal paths now consume the draft; the success path is unchanged.

## Deferred / no action (documented in plan)

- **D1** Multi-column recipe grid on large screens — spec is permissive ("can"); left single-column.
- **D2** Cross-week move/duplicate not reachable from UI — intentional (explicit within-week picker); hook-level tests kept.
- **D3** Recipe array visual floor — removing all rows re-pads to two blank rows (name-only recipes are valid); submitted arrays may be empty.

## Test evidence

```
npm run lint            → exit 0 (only the pre-existing biome.json schema-version info note)
npm test -- --run       → exit 0 — 856 passed (856), 69 files
npm run build           → exit 0 (tsc + Vite + PWA)
```

Baseline before this branch: 819 tests / 65 files → now 856 / 69 (+37 tests, +4 files).

Editor-first flow and review-only detail are covered by `meals-view.test.tsx` ("opens the live recipe detail from a recipe-backed planned meal", "shows no Edit/Add-to-Meals/Favorite buttons in the meal-context recipe detail") and the past-week review test.

**E2E note:** `e2e/mobile-meals.spec.ts` / `mobile-recipes.spec.ts` require a live backend (`registerFamily` hits `127.0.0.1:8080/api`), which CI provisions from the latest published BE release; they were not run in this local worktree (no backend container). The flows are covered by the full `MealsView`/`RecipesView` + MSW integration tests.
