### PR TITLE
Mobile pass: sidebar/menu, settings modals, and onboarding/login

### DIFF
--- a/e2e/family-management.spec.ts
+++ b/e2e/family-management.spec.ts
@@ -33,8 +33,8 @@ test.describe("Family Member Management", () => {
     const menuButton = page.getByRole("button", { name: "Menu" });
     await menuButton.click();
 
-    // Wait for sidebar to appear
-    const sidebar = page.locator("aside");
+    // Wait for sidebar (now an accessible side-sheet dialog) to appear
+    const sidebar = page.getByRole("dialog", { name: "Menu" });
     await expect(sidebar).toBeVisible();
 
     // Verify family members are shown in sidebar
@@ -47,8 +47,9 @@ test.describe("Family Member Management", () => {
     // Click Family Settings button
     await page.getByRole("button", { name: "Family Settings" }).click();
 
-    // Wait for Family Settings modal
-    const dialog = page.getByRole("dialog");
+    // Wait for Family Settings modal. Scope by accessible name — the menu
+    // side-sheet is also a dialog (aria-hidden behind this modal).
+    const dialog = page.getByRole("dialog", { name: "Family Settings" });
     await expect(dialog).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Family Settings" }),
@@ -153,8 +154,12 @@ test.describe("Family Member Management", () => {
     // Close the settings modal using Escape (more reliable than clicking Close button
     // which can be unstable due to layout shift after member removal)
     await page.keyboard.press("Escape");
+    await expect(
+      page.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeHidden();
 
-    // Wait for dialog to close
+    // The menu side-sheet is still open behind the modal — close it too.
+    await page.keyboard.press("Escape");
     await waitForDialogClosed(page);
 
     // Verify we're back to the main app

--- a/e2e/google-calendar.spec.ts
+++ b/e2e/google-calendar.spec.ts
@@ -25,7 +25,7 @@ test.describe("Google Calendar Integration", () => {
   test("member profile shows Google Calendar section", async ({ page }) => {
     // Open sidebar
     await page.getByRole("button", { name: "Menu" }).click();
-    const sidebar = page.locator("aside");
+    const sidebar = page.getByRole("dialog", { name: "Menu" });
     await expect(sidebar).toBeVisible();
 
     // Click on member name to open profile
@@ -42,7 +42,7 @@ test.describe("Google Calendar Integration", () => {
 
   test("connect button is disabled without email", async ({ page }) => {
     await page.getByRole("button", { name: "Menu" }).click();
-    const sidebar = page.locator("aside");
+    const sidebar = page.getByRole("dialog", { name: "Menu" });
     await expect(sidebar).toBeVisible();
     await sidebar.getByText("Alice").click();
 

--- a/e2e/mobile-bottom-nav.spec.ts
+++ b/e2e/mobile-bottom-nav.spec.ts
@@ -35,17 +35,12 @@ test.describe("Mobile Bottom Navigation", () => {
     const nav = page.getByRole("navigation", { name: /primary/i });
     await expect(nav).toBeVisible();
 
-    const expectedTabs = [
-      "Home",
-      "Calendar",
-      "Lists",
-      "Chores",
-      "Meals",
-      "Photos",
-    ];
+    const expectedTabs = ["Home", "Calendar", "Lists", "Chores", "More"];
     for (const tab of expectedTabs) {
       await expect(nav.getByRole("button", { name: tab })).toBeVisible();
     }
+    await expect(nav.getByRole("button", { name: "Meals" })).toHaveCount(0);
+    await expect(nav.getByRole("button", { name: "Photos" })).toHaveCount(0);
 
     await nav.getByRole("button", { name: "Calendar" }).click();
     await expect(page.getByRole("button", { name: "Add event" })).toBeVisible();
@@ -64,14 +59,13 @@ test.describe("Mobile Bottom Navigation", () => {
       page.getByRole("heading", { name: "Chores", level: 1 }),
     ).toBeVisible();
 
-    await nav.getByRole("button", { name: "Meals" }).click();
+    await nav.getByRole("button", { name: "More" }).click();
+    const moreSheet = page.getByRole("dialog", { name: "More" });
+    await expect(moreSheet).toBeVisible();
+    await moreSheet.getByRole("button", { name: "Meals" }).click();
+    await expect(moreSheet).toBeHidden();
     await expect(
       page.getByRole("heading", { name: "Meals", level: 1 }),
-    ).toBeVisible();
-
-    await nav.getByRole("button", { name: "Photos" }).click();
-    await expect(
-      page.getByRole("heading", { name: "Family Photos" }),
     ).toBeVisible();
 
     await expect(nav).toBeVisible();

--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -30,7 +30,11 @@ test.describe("Mobile Meals", () => {
     await waitForHydration(page);
 
     const nav = page.getByRole("navigation", { name: /primary/i });
-    await safeClick(nav.getByRole("button", { name: "Meals" }));
+    await safeClick(nav.getByRole("button", { name: "More" }));
+    const mealsMoreSheet = page.getByRole("dialog", { name: "More" });
+    await expect(mealsMoreSheet).toBeVisible();
+    await safeClick(mealsMoreSheet.getByRole("button", { name: "Meals" }));
+    await expect(mealsMoreSheet).toBeHidden();
 
     await expect(
       page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
@@ -51,7 +55,11 @@ test.describe("Mobile Meals", () => {
       page.getByRole("button", { name: /open dinner: leftovers/i }),
     ).toBeVisible();
 
-    await safeClick(nav.getByRole("button", { name: "Recipes" }));
+    await safeClick(nav.getByRole("button", { name: "More" }));
+    const recipesMoreSheet = page.getByRole("dialog", { name: "More" });
+    await expect(recipesMoreSheet).toBeVisible();
+    await safeClick(recipesMoreSheet.getByRole("button", { name: "Recipes" }));
+    await expect(recipesMoreSheet).toBeHidden();
     await expect(
       page.getByRole("heading", { name: "Recipes", level: 1, exact: true }),
     ).toBeVisible();

--- a/e2e/mobile-recipes.spec.ts
+++ b/e2e/mobile-recipes.spec.ts
@@ -33,7 +33,11 @@ test.describe("Mobile Recipes", () => {
     await waitForHydration(page);
 
     const nav = page.getByRole("navigation", { name: /primary/i });
-    await safeClick(nav.getByRole("button", { name: "Recipes" }));
+    await safeClick(nav.getByRole("button", { name: "More" }));
+    const moreSheet = page.getByRole("dialog", { name: "More" });
+    await expect(moreSheet).toBeVisible();
+    await safeClick(moreSheet.getByRole("button", { name: "Recipes" }));
+    await expect(moreSheet).toBeHidden();
 
     await expect(
       page.getByRole("heading", { name: "Recipes", level: 1 }),

--- a/e2e/mobile-settings-sidebar.spec.ts
+++ b/e2e/mobile-settings-sidebar.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+test.describe("Mobile menu + More overflow", () => {
+  test.beforeEach(async ({ page, request, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+    const reg = await registerFamily(request, {
+      familyName: "Menu Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+    await page.reload();
+    await waitForHydration(page);
+  });
+
+  test("More overflow reaches Recipes and closes the sheet", async ({
+    page,
+  }) => {
+    const nav = page.getByRole("navigation", { name: /primary/i });
+    // Recipes is an overflow module — not present in the bar.
+    await expect(nav.getByRole("button", { name: /^recipes$/i })).toHaveCount(
+      0,
+    );
+
+    await safeClick(nav.getByRole("button", { name: /^more$/i }));
+
+    const moreSheet = page.getByRole("dialog", { name: /more/i });
+    await expect(moreSheet).toBeVisible();
+
+    await safeClick(moreSheet.getByRole("button", { name: /^recipes$/i }));
+
+    // Selecting an overflow module switches the module and closes the sheet.
+    await expect(moreSheet).toHaveCount(0);
+    await expect(
+      page.getByRole("heading", { name: "Recipes", level: 1 }),
+    ).toBeVisible();
+  });
+
+  test("menu opens from the header and closes via Escape", async ({ page }) => {
+    await safeClick(page.getByRole("button", { name: /^menu$/i }));
+
+    // Scope to the side sheet dialog — the family name also appears in the
+    // header, so an unscoped text query would match two elements.
+    const menu = page.getByRole("dialog", { name: "Menu" });
+    await expect(menu).toBeVisible();
+    await expect(menu.getByText("Menu Test Family")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(menu).toHaveCount(0);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,7 @@ function renderModule(activeModule: ModuleType | null) {
 
 function LoadingScreen() {
   return (
-    <div className="h-screen flex items-center justify-center bg-background">
+    <div className="h-dvh flex items-center justify-center bg-background">
       <div className="animate-pulse text-muted-foreground">Loading...</div>
     </div>
   );
@@ -166,7 +166,7 @@ export default function FamilyHub() {
 
   return (
     <>
-      <div className="h-screen flex flex-col bg-background">
+      <div className="h-dvh flex flex-col bg-background">
         {!(isMobile && activeModule === "calendar") && <AppHeader />}
 
         <div className="flex-1 flex min-h-0 overflow-hidden">

--- a/src/api/hooks/use-auth.test.tsx
+++ b/src/api/hooks/use-auth.test.tsx
@@ -1,0 +1,57 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLogout } from "./use-auth";
+
+let queryClient: QueryClient;
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const originalLocation = window.location;
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+describe("useLogout", () => {
+  it("still clears the query cache and reloads when storage removal throws", () => {
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+    // Simulate a storage-disabled webview where removeItem throws.
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+    const clearSpy = vi.spyOn(queryClient, "clear");
+
+    const { result } = renderHook(() => useLogout(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(() => result.current()).not.toThrow();
+    expect(clearSpy).toHaveBeenCalled();
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -65,6 +65,19 @@ export function clearStoredToken(): void {
 }
 
 /**
+ * Remove persisted family data from localStorage.
+ */
+export function clearStoredFamily(): void {
+  try {
+    localStorage.removeItem(FAMILY_STORAGE_KEY);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to clear family from localStorage:", error);
+    }
+  }
+}
+
+/**
  * Write family data to localStorage (Zustand persist format).
  */
 function writeFamilyToStorage(family: FamilyData): void {
@@ -189,8 +202,8 @@ export function useLogout() {
     // Clear token from storage
     clearStoredToken();
 
-    // Clear family data from localStorage
-    localStorage.removeItem(FAMILY_STORAGE_KEY);
+    // Clear family data from localStorage (storage may be disabled in some webviews)
+    clearStoredFamily();
 
     // Clear all query cache
     queryClient.clear();

--- a/src/components/auth/login-form.test.tsx
+++ b/src/components/auth/login-form.test.tsx
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { LoginForm } from "./login-form";
+
+let mockIsMobile = true;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => mockIsMobile };
+});
+
+describe("LoginForm", () => {
+  beforeEach(() => {
+    mockIsMobile = true;
+  });
+
+  it("does not autofocus the username field on mobile", () => {
+    render(<LoginForm onSwitchToOnboarding={vi.fn()} />);
+    expect(screen.getByLabelText(/username/i)).not.toBe(document.activeElement);
+  });
+
+  it("autofocuses the username field on desktop", () => {
+    mockIsMobile = false;
+    render(<LoginForm onSwitchToOnboarding={vi.fn()} />);
+    expect(screen.getByLabelText(/username/i)).toBe(document.activeElement);
+  });
+});

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/ui/form-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useIsMobile } from "@/hooks";
+import { cn } from "@/lib/utils";
 import { type LoginFormData, loginFormSchema } from "@/lib/validations/auth";
 import { useAuthStore } from "@/stores";
 
@@ -15,6 +17,7 @@ interface LoginFormProps {
 export function LoginForm({ onSwitchToOnboarding }: LoginFormProps) {
   const login = useLogin();
   const setAuthenticated = useAuthStore((state) => state.setAuthenticated);
+  const isMobile = useIsMobile();
 
   const {
     register,
@@ -42,8 +45,13 @@ export function LoginForm({ onSwitchToOnboarding }: LoginFormProps) {
   };
 
   return (
-    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
-      <div className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full">
+    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background overflow-y-auto [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
+      <div
+        className={cn(
+          "flex-1 flex flex-col max-w-md mx-auto w-full",
+          !isMobile && "justify-center",
+        )}
+      >
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           <div className="space-y-3 text-center">
             <h1 className="text-2xl font-bold text-foreground">
@@ -69,7 +77,7 @@ export function LoginForm({ onSwitchToOnboarding }: LoginFormProps) {
                 id="login-username"
                 placeholder="your_username"
                 autoComplete="username"
-                autoFocus
+                autoFocus={!isMobile}
                 {...register("username")}
               />
               <FormError message={errors.username?.message} />

--- a/src/components/onboarding/onboarding-credentials.tsx
+++ b/src/components/onboarding/onboarding-credentials.tsx
@@ -7,7 +7,8 @@ import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/ui/form-error";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useDebounce } from "@/hooks";
+import { useDebounce, useIsMobile } from "@/hooks";
+import { cn } from "@/lib/utils";
 import {
   type CredentialsFormData,
   credentialsFormSchema,
@@ -36,6 +37,8 @@ export function OnboardingCredentials({
   } = useForm<CredentialsFormData>({
     resolver: zodResolver(credentialsFormSchema),
   });
+
+  const isMobile = useIsMobile();
 
   const username = watch("username");
   const debouncedUsername = useDebounce(username || "", 500);
@@ -66,7 +69,7 @@ export function OnboardingCredentials({
   const showUsernameStatus = debouncedUsername.length >= 3;
 
   return (
-    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
+    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background overflow-y-auto [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
         <Button
@@ -82,7 +85,12 @@ export function OnboardingCredentials({
       </div>
 
       {/* Content */}
-      <div className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full">
+      <div
+        className={cn(
+          "flex-1 flex flex-col max-w-md mx-auto w-full",
+          !isMobile && "justify-center",
+        )}
+      >
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           <div className="space-y-3 text-center">
             <h1 className="text-2xl font-bold text-foreground">
@@ -107,7 +115,7 @@ export function OnboardingCredentials({
                   id="credentials-username"
                   placeholder="your_family_username"
                   autoComplete="username"
-                  autoFocus
+                  autoFocus={!isMobile}
                   className="pr-10"
                   {...register("username")}
                 />

--- a/src/components/onboarding/onboarding-credentials.tsx
+++ b/src/components/onboarding/onboarding-credentials.tsx
@@ -74,7 +74,7 @@ export function OnboardingCredentials({
       <div className="flex items-center gap-2 mb-8">
         <Button
           variant="ghost"
-          size="icon"
+          size="icon-lg"
           onClick={onBack}
           disabled={isSubmitting}
           aria-label="Go back"

--- a/src/components/onboarding/onboarding-family-name.test.tsx
+++ b/src/components/onboarding/onboarding-family-name.test.tsx
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { OnboardingFamilyName } from "./onboarding-family-name";
+
+let mockIsMobile = true;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => mockIsMobile };
+});
+
+describe("OnboardingFamilyName", () => {
+  beforeEach(() => {
+    mockIsMobile = true;
+  });
+
+  it("does not autofocus the family-name field on mobile", () => {
+    render(
+      <OnboardingFamilyName initialName="" onNext={vi.fn()} onBack={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/family name/i)).not.toBe(
+      document.activeElement,
+    );
+  });
+
+  it("autofocuses the family-name field on desktop", () => {
+    mockIsMobile = false;
+    render(
+      <OnboardingFamilyName initialName="" onNext={vi.fn()} onBack={vi.fn()} />,
+    );
+    expect(screen.getByLabelText(/family name/i)).toBe(document.activeElement);
+  });
+});

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -38,7 +38,7 @@ export function OnboardingFamilyName({
   };
 
   return (
-    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
+    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background overflow-y-auto [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
         <Button
@@ -78,7 +78,7 @@ export function OnboardingFamilyName({
               placeholder="The Smiths"
               className="text-center text-lg h-14"
               autoComplete="off"
-              autoFocus
+              autoFocus={!isMobile}
               aria-describedby={
                 errors.name ? "onboarding-family-name-error" : undefined
               }

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -5,6 +5,8 @@ import type { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useIsMobile } from "@/hooks";
+import { cn } from "@/lib/utils";
 import { familyNameSchema } from "@/lib/validations/family";
 
 type FamilyNameFormData = z.infer<typeof familyNameSchema>;
@@ -20,6 +22,8 @@ export function OnboardingFamilyName({
   onNext,
   onBack,
 }: OnboardingFamilyNameProps) {
+  const isMobile = useIsMobile();
+
   const {
     register,
     handleSubmit,
@@ -49,7 +53,12 @@ export function OnboardingFamilyName({
       </div>
 
       {/* Content */}
-      <div className="flex-1 flex flex-col justify-center max-w-md mx-auto w-full">
+      <div
+        className={cn(
+          "flex-1 flex flex-col max-w-md mx-auto w-full",
+          !isMobile && "justify-center",
+        )}
+      >
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-8">
           <div className="space-y-3 text-center">
             <h1 className="text-2xl font-bold text-foreground">

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -34,7 +34,7 @@ export function OnboardingFamilyName({
   };
 
   return (
-    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
+    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
         <Button

--- a/src/components/onboarding/onboarding-family-name.tsx
+++ b/src/components/onboarding/onboarding-family-name.tsx
@@ -43,7 +43,7 @@ export function OnboardingFamilyName({
       <div className="flex items-center gap-2 mb-8">
         <Button
           variant="ghost"
-          size="icon"
+          size="icon-lg"
           onClick={onBack}
           aria-label="Go back"
         >

--- a/src/components/onboarding/onboarding-members.tsx
+++ b/src/components/onboarding/onboarding-members.tsx
@@ -58,7 +58,7 @@ export function OnboardingMembers({
   const canComplete = members.length >= 1;
 
   return (
-    <div className="flex flex-col min-h-screen p-4 md:p-6 bg-background">
+    <div className="flex flex-col min-h-dvh p-4 md:p-6 bg-background [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
       {/* Header with back button */}
       <div className="flex items-center gap-2 mb-8">
         <Button

--- a/src/components/onboarding/onboarding-members.tsx
+++ b/src/components/onboarding/onboarding-members.tsx
@@ -63,7 +63,7 @@ export function OnboardingMembers({
       <div className="flex items-center gap-2 mb-8">
         <Button
           variant="ghost"
-          size="icon"
+          size="icon-lg"
           onClick={onBack}
           aria-label="Go back"
         >

--- a/src/components/onboarding/onboarding-welcome.tsx
+++ b/src/components/onboarding/onboarding-welcome.tsx
@@ -7,7 +7,7 @@ interface OnboardingWelcomeProps {
 
 export function OnboardingWelcome({ onNext }: OnboardingWelcomeProps) {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen p-4 md:p-6 bg-gradient-to-b from-primary/10 to-background">
+    <div className="flex flex-col items-center justify-center min-h-dvh p-4 md:p-6 bg-gradient-to-b from-primary/10 to-background [padding-top:max(1rem,env(safe-area-inset-top))] [padding-bottom:max(1rem,env(safe-area-inset-bottom))]">
       <div className="max-w-md w-full text-center space-y-8">
         {/* Logo / Icon */}
         <div className="flex justify-center">

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -112,7 +112,7 @@ export function FamilySettingsModal({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogContent className="max-w-lg max-h-[90dvh] overflow-y-auto">
           <DialogHeader>
             <div className="flex items-center justify-between">
               <DialogTitle className="text-xl">Family Settings</DialogTitle>

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -138,15 +138,15 @@ export function MemberProfileModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-sm max-h-[90dvh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center justify-between">
             <DialogTitle className="text-xl">Member Profile</DialogTitle>
             <Button
               variant="ghost"
-              size="icon"
+              size="icon-lg"
               onClick={() => onOpenChange(false)}
-              className="h-8 w-8"
+              aria-label="Close"
             >
               <X className="h-4 w-4" />
             </Button>
@@ -176,7 +176,7 @@ export function MemberProfileModal({
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
-                className="absolute bottom-0 right-0 w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-md hover:bg-primary/90 transition-colors"
+                className="absolute bottom-0 right-0 w-11 h-11 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-md hover:bg-primary/90 transition-colors"
                 aria-label="Upload avatar"
               >
                 <Camera className="h-4 w-4" />

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -138,7 +138,7 @@ export function MemberProfileModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm">
+      <DialogContent className="max-w-sm max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center justify-between">
             <DialogTitle className="text-xl">Member Profile</DialogTitle>

--- a/src/components/shared/app-header.test.tsx
+++ b/src/components/shared/app-header.test.tsx
@@ -1,0 +1,23 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, seedFamilyStore } from "@/test/test-utils";
+import { AppHeader } from "./app-header";
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => true };
+});
+
+describe("AppHeader (mobile)", () => {
+  beforeEach(() => {
+    seedFamilyStore({
+      name: "Test Family",
+      members: [{ id: "m1", name: "Alice", color: "coral" }],
+    });
+  });
+
+  it("exposes exactly one header control: Menu", () => {
+    render(<AppHeader />);
+    expect(screen.getByRole("button", { name: /menu/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+});

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,4 +1,4 @@
-import { Cloud, Menu, Settings, Sun } from "lucide-react";
+import { Cloud, Menu, Sun } from "lucide-react";
 import { useFamilyMembers, useFamilyName } from "@/api";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks";
@@ -93,15 +93,6 @@ export function AppHeader() {
             ))}
           </div>
         )}
-
-        {/* Settings */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground hover:text-foreground"
-        >
-          <Settings className="h-5 w-5" />
-        </Button>
       </div>
     </header>
   );

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -5,62 +5,48 @@ import { MobileBottomNav } from "./mobile-bottom-nav";
 
 describe("MobileBottomNav", () => {
   beforeEach(() => {
-    useAppStore.setState({ activeModule: null, isSidebarOpen: false });
+    useAppStore.setState({ activeModule: null });
   });
 
-  it("renders all seven destinations and marks Home active when activeModule is null", () => {
+  it("shows four primary tabs plus More, and no Photos", () => {
     render(<MobileBottomNav />);
-
     const nav = screen.getByRole("navigation", { name: /primary/i });
-
     expect(nav).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /^home$/i })).toHaveAttribute(
+
+    for (const label of ["Home", "Calendar", "Lists", "Chores", "More"]) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`^${label}$`, "i") }),
+      ).toBeInTheDocument();
+    }
+    // Overflow + deferred modules are not in the bar.
+    expect(
+      screen.queryByRole("button", { name: /^meals$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^photos$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens the More sheet and switches to an overflow module", async () => {
+    const { user } = renderWithUser(<MobileBottomNav />);
+    await user.click(screen.getByRole("button", { name: /^more$/i }));
+
+    const meals = await screen.findByRole("button", { name: /^meals$/i });
+    await user.click(meals);
+
+    expect(useAppStore.getState().activeModule).toBe("meals");
+    // sheet closes
+    expect(
+      screen.queryByRole("button", { name: /^recipes$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks More active when an overflow module is active", () => {
+    useAppStore.setState({ activeModule: "recipes" });
+    render(<MobileBottomNav />);
+    expect(screen.getByRole("button", { name: /^more$/i })).toHaveAttribute(
       "aria-current",
       "page",
     );
-    expect(
-      screen.getByRole("button", { name: /^calendar$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^lists$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^chores$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^meals$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^recipes$/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^photos$/i }),
-    ).toBeInTheDocument();
-  });
-
-  it("keeps all seven destinations readable in a horizontally scrollable row", () => {
-    render(<MobileBottomNav />);
-
-    const navItems = screen.getByRole("navigation", {
-      name: /primary/i,
-    }).firstElementChild;
-    const buttons = screen.getAllByRole("button");
-
-    expect(navItems).toHaveClass("flex", "overflow-x-auto");
-    expect(navItems).not.toHaveClass("grid-cols-7");
-    for (const button of buttons) {
-      expect(button).toHaveClass("min-w-16");
-      expect(button).not.toHaveClass("min-w-0");
-    }
-  });
-
-  it("switches modules through the app store", async () => {
-    const { user } = renderWithUser(<MobileBottomNav />);
-
-    await user.click(screen.getByRole("button", { name: /^photos$/i }));
-    expect(useAppStore.getState().activeModule).toBe("photos");
-
-    await user.click(screen.getByRole("button", { name: /^home$/i }));
-    expect(useAppStore.getState().activeModule).toBeNull();
   });
 });

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -3,62 +3,123 @@ import {
   Calendar,
   CheckSquare,
   Home,
-  ImageIcon,
   ListTodo,
   type LucideIcon,
+  MoreHorizontal,
   UtensilsCrossed,
 } from "lucide-react";
+import { useState } from "react";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
 import { cn } from "@/lib/utils";
 import { type ModuleType, useAppStore } from "@/stores";
 
-const tabs: Array<{ id: ModuleType | null; label: string; icon: LucideIcon }> =
-  [
-    { id: null, label: "Home", icon: Home },
-    { id: "calendar", label: "Calendar", icon: Calendar },
-    { id: "lists", label: "Lists", icon: ListTodo },
-    { id: "chores", label: "Chores", icon: CheckSquare },
-    { id: "meals", label: "Meals", icon: UtensilsCrossed },
-    { id: "recipes", label: "Recipes", icon: BookOpenText },
-    { id: "photos", label: "Photos", icon: ImageIcon },
-  ];
+type NavModule = { id: ModuleType | null; label: string; icon: LucideIcon };
+
+// Ordered navigable modules. First PRIMARY_COUNT render in the bar; the rest
+// overflow into the "More" sheet. Photos is intentionally omitted (deferred).
+// Appending a future module here makes it overflow automatically.
+const MODULES: NavModule[] = [
+  { id: null, label: "Home", icon: Home },
+  { id: "calendar", label: "Calendar", icon: Calendar },
+  { id: "lists", label: "Lists", icon: ListTodo },
+  { id: "chores", label: "Chores", icon: CheckSquare },
+  { id: "meals", label: "Meals", icon: UtensilsCrossed },
+  { id: "recipes", label: "Recipes", icon: BookOpenText },
+];
+const PRIMARY_COUNT = 4;
+const primaryModules = MODULES.slice(0, PRIMARY_COUNT);
+const overflowModules = MODULES.slice(PRIMARY_COUNT);
+
+const tabBase =
+  "flex min-h-14 min-w-16 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-2 text-[11px] leading-none font-semibold transition-colors";
+const tabActive =
+  "bg-primary text-primary-foreground shadow-sm shadow-primary/20";
+const tabIdle = "text-muted-foreground hover:bg-muted hover:text-foreground";
 
 export function MobileBottomNav() {
   const activeModule = useAppStore((state) => state.activeModule);
   const setActiveModule = useAppStore((state) => state.setActiveModule);
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const overflowActive = overflowModules.some((m) => m.id === activeModule);
+
+  const selectOverflow = (id: ModuleType | null) => {
+    setActiveModule(id);
+    setMoreOpen(false);
+  };
 
   return (
-    <nav
-      aria-label="Primary"
-      className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
-    >
-      <div
-        className="flex gap-1 overflow-x-auto px-2 pt-2"
-        style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+    <>
+      <nav
+        aria-label="Primary"
+        className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
       >
-        {tabs.map((tab) => {
-          const Icon = tab.icon;
-          const isActive = activeModule === tab.id;
+        <div
+          className="flex gap-1 px-2 pt-2"
+          style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}
+        >
+          {primaryModules.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeModule === tab.id;
+            return (
+              <button
+                key={tab.label}
+                type="button"
+                onClick={() => setActiveModule(tab.id)}
+                aria-label={tab.label}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(tabBase, isActive ? tabActive : tabIdle)}
+              >
+                <Icon className="h-4 w-4" />
+                <span className="whitespace-nowrap leading-3">{tab.label}</span>
+              </button>
+            );
+          })}
 
-          return (
+          {overflowModules.length > 0 && (
             <button
-              key={tab.label}
               type="button"
-              onClick={() => setActiveModule(tab.id)}
-              aria-label={tab.label}
-              aria-current={isActive ? "page" : undefined}
-              className={cn(
-                "flex min-h-14 min-w-16 flex-1 flex-col items-center justify-center gap-0.5 rounded-lg px-2 py-2 text-[11px] leading-none font-semibold transition-colors",
-                isActive
-                  ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
-                  : "text-muted-foreground hover:bg-muted hover:text-foreground",
-              )}
+              onClick={() => setMoreOpen(true)}
+              aria-label="More"
+              aria-current={overflowActive ? "page" : undefined}
+              className={cn(tabBase, overflowActive ? tabActive : tabIdle)}
             >
-              <Icon className="h-4 w-4" />
-              <span className="whitespace-nowrap leading-3">{tab.label}</span>
+              <MoreHorizontal className="h-4 w-4" />
+              <span className="whitespace-nowrap leading-3">More</span>
             </button>
-          );
-        })}
-      </div>
-    </nav>
+          )}
+        </div>
+      </nav>
+
+      <MobileSheet
+        isOpen={moreOpen}
+        onClose={() => setMoreOpen(false)}
+        title="More"
+      >
+        <div className="space-y-1">
+          {overflowModules.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeModule === tab.id;
+            return (
+              <button
+                key={tab.label}
+                type="button"
+                onClick={() => selectOverflow(tab.id)}
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "flex w-full min-h-11 items-center gap-3 rounded-lg px-3 py-3 text-base font-medium transition-colors",
+                  isActive
+                    ? "bg-primary/10 text-primary"
+                    : "text-foreground hover:bg-muted",
+                )}
+              >
+                <Icon className="h-5 w-5" />
+                <span>{tab.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </MobileSheet>
+    </>
   );
 }

--- a/src/components/shared/sidebar-menu.test.tsx
+++ b/src/components/shared/sidebar-menu.test.tsx
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAppStore } from "@/stores";
+import { renderWithUser, screen, seedFamilyStore } from "@/test/test-utils";
+import { SidebarMenu } from "./sidebar-menu";
+
+const logoutSpy = vi.fn();
+vi.mock("@/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api")>();
+  return { ...actual, useLogout: () => logoutSpy };
+});
+
+describe("SidebarMenu", () => {
+  beforeEach(() => {
+    logoutSpy.mockClear();
+    seedFamilyStore({
+      name: "Test Family",
+      members: [{ id: "m1", name: "Alice", color: "coral" }],
+    });
+    useAppStore.setState({ isSidebarOpen: true });
+  });
+
+  it("closes on Escape", async () => {
+    const { user } = renderWithUser(<SidebarMenu />);
+    expect(screen.getByText("Test Family")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(useAppStore.getState().isSidebarOpen).toBe(false);
+  });
+
+  it("requires confirmation before signing out", async () => {
+    const { user } = renderWithUser(<SidebarMenu />);
+    await user.click(screen.getByRole("button", { name: /sign out/i }));
+    expect(logoutSpy).not.toHaveBeenCalled();
+
+    // confirmation dialog appears
+    await user.click(
+      screen.getByRole("button", { name: /^sign out$/i, hidden: false }),
+    );
+    expect(logoutSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -3,6 +3,14 @@ import { useEffect, useState } from "react";
 import { useFamilyMembers, useFamilyName, useLogout } from "@/api";
 import { FamilySettingsModal, MemberProfileModal } from "@/components/settings";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SideSheet } from "@/components/ui/side-sheet";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores";
@@ -11,16 +19,13 @@ export function SidebarMenu() {
   const isOpen = useAppStore((state) => state.isSidebarOpen);
   const closeSidebar = useAppStore((state) => state.closeSidebar);
 
-  // From family-store
   const familyName = useFamilyName();
   const familyMembers = useFamilyMembers();
-
-  // Auth
   const logout = useLogout();
 
-  // Modal state
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
@@ -32,40 +37,41 @@ export function SidebarMenu() {
     }
   }, [isOpen]);
 
-  if (!isOpen) return null;
-
-  const handleOpenMemberProfile = (memberId: string) => {
-    setSelectedMemberId(memberId);
-  };
-
-  const handleOpenSettings = () => {
-    setIsSettingsOpen(true);
-  };
-
   const menuItems = [
-    { icon: Users, label: "Family Settings", action: handleOpenSettings },
-    { icon: LogOut, label: "Sign Out", action: logout },
+    {
+      icon: Users,
+      label: "Family Settings",
+      action: () => setIsSettingsOpen(true),
+    },
+    {
+      icon: LogOut,
+      label: "Sign Out",
+      action: () => setShowSignOutConfirm(true),
+    },
   ];
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm"
-        onClick={closeSidebar}
-      />
-
-      {/* Sidebar */}
-      <aside className="fixed left-0 top-0 bottom-0 z-50 w-72 bg-card shadow-2xl flex flex-col">
+      <SideSheet
+        open={isOpen}
+        onOpenChange={(open) => !open && closeSidebar()}
+        title="Menu"
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-border">
           <div>
             <h2 className="text-lg font-bold text-foreground">
               {familyName || "Family Hub"}
             </h2>
-            <p className="text-sm text-muted-foreground">Calendar Settings</p>
+            <p className="text-sm text-muted-foreground">Menu</p>
           </div>
-          <Button variant="ghost" size="icon" onClick={closeSidebar}>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Close menu"
+            onClick={closeSidebar}
+            className="h-11 w-11"
+          >
             <X className="h-5 w-5" />
           </Button>
         </div>
@@ -82,8 +88,9 @@ export function SidebarMenu() {
                 return (
                   <button
                     key={member.id}
-                    onClick={() => handleOpenMemberProfile(member.id)}
-                    className="w-full flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted transition-colors"
+                    type="button"
+                    onClick={() => setSelectedMemberId(member.id)}
+                    className="w-full min-h-11 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-muted transition-colors"
                   >
                     {member.avatarUrl ? (
                       <img
@@ -118,13 +125,14 @@ export function SidebarMenu() {
         {/* Menu Items */}
         <nav className="flex-1 p-4">
           <div className="space-y-1">
-            {menuItems.map((item, index) => {
+            {menuItems.map((item) => {
               const Icon = item.icon;
               return (
                 <button
-                  key={index}
+                  key={item.label}
+                  type="button"
                   onClick={item.action}
-                  className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+                  className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
                   <Icon className="h-5 w-5" />
                   {item.label}
@@ -138,7 +146,7 @@ export function SidebarMenu() {
         <div className="border-t border-border px-6 py-4">
           <p className="text-xs text-muted-foreground">v{__APP_VERSION__}</p>
         </div>
-      </aside>
+      </SideSheet>
 
       {/* Family Settings Modal */}
       <FamilySettingsModal
@@ -154,6 +162,29 @@ export function SidebarMenu() {
           memberId={selectedMemberId}
         />
       )}
+
+      {/* Sign Out Confirmation */}
+      <Dialog open={showSignOutConfirm} onOpenChange={setShowSignOutConfirm}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>Sign out?</DialogTitle>
+            <DialogDescription>
+              You'll need your family username and password to sign back in.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-3 pt-4">
+            <Button
+              variant="outline"
+              onClick={() => setShowSignOutConfirm(false)}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => logout()}>
+              Sign Out
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/components/ui/side-sheet.test.tsx
+++ b/src/components/ui/side-sheet.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@/test/test-utils";
+import { SideSheet } from "./side-sheet";
+
+function renderSheet(onOpenChange = vi.fn()) {
+  render(
+    <SideSheet open onOpenChange={onOpenChange} title="Menu">
+      <div>Menu content</div>
+    </SideSheet>,
+  );
+  return {
+    onOpenChange,
+    panel: screen.getByRole("dialog", { name: "Menu" }),
+  };
+}
+
+// Radix Dialog's scroll-lock (react-remove-scroll) reads `changedTouches` on the
+// touchstart/touchmove it captures at the document level, while the SideSheet
+// handlers read `touches`/`changedTouches`. Supply both so neither crashes.
+function point(clientX: number, clientY: number) {
+  return {
+    touches: [{ clientX, clientY }],
+    changedTouches: [{ clientX, clientY }],
+  };
+}
+
+describe("SideSheet swipe-to-close", () => {
+  it("renders its children inside a labelled dialog", () => {
+    renderSheet();
+    expect(screen.getByText("Menu content")).toBeInTheDocument();
+  });
+
+  it("closes on a horizontal leftward drag past the threshold", () => {
+    const { onOpenChange, panel } = renderSheet();
+
+    fireEvent.touchStart(panel, point(200, 300));
+    fireEvent.touchMove(panel, point(100, 305));
+    fireEvent.touchEnd(panel, point(100, 305));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not close on a leftward drag below the threshold", () => {
+    const { onOpenChange, panel } = renderSheet();
+
+    fireEvent.touchStart(panel, point(200, 300));
+    fireEvent.touchMove(panel, point(170, 305));
+    fireEvent.touchEnd(panel, point(170, 305));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("does not close on a vertical-dominant gesture with incidental leftward drift", () => {
+    const { onOpenChange, panel } = renderSheet();
+
+    // 70px left, 200px down — a near-vertical scroll-flick.
+    fireEvent.touchStart(panel, point(200, 100));
+    fireEvent.touchMove(panel, point(130, 300));
+    fireEvent.touchEnd(panel, point(130, 300));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("resets the gesture on touch cancel so a trailing touchEnd cannot close it", () => {
+    const { onOpenChange, panel } = renderSheet();
+
+    fireEvent.touchStart(panel, point(200, 300));
+    fireEvent.touchMove(panel, point(100, 300));
+    fireEvent.touchCancel(panel);
+    fireEvent.touchEnd(panel, point(100, 300));
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/side-sheet.tsx
+++ b/src/components/ui/side-sheet.tsx
@@ -1,0 +1,72 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { type ReactNode, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const SWIPE_CLOSE_THRESHOLD = 60; // px of leftward drag before dismiss
+
+interface SideSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Accessible name for the dialog (visually hidden). */
+  title: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function SideSheet({
+  open,
+  onOpenChange,
+  title,
+  children,
+  className,
+}: SideSheetProps) {
+  const startX = useRef<number | null>(null);
+  const [dragX, setDragX] = useState(0);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0]?.clientX ?? null;
+  };
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (startX.current === null) return;
+    const delta = (e.touches[0]?.clientX ?? startX.current) - startX.current;
+    if (delta < 0) setDragX(delta); // track leftward drag only
+  };
+  const handleTouchEnd = () => {
+    if (dragX < -SWIPE_CLOSE_THRESHOLD) onOpenChange(false);
+    startX.current = null;
+    setDragX(0);
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-40 bg-foreground/20 backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          aria-describedby={undefined}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+          style={dragX ? { transform: `translateX(${dragX}px)` } : undefined}
+          className={cn(
+            "fixed inset-y-0 left-0 z-50 flex w-[min(20rem,85vw)] flex-col bg-card shadow-2xl",
+            "[padding-top:env(safe-area-inset-top)] [padding-bottom:env(safe-area-inset-bottom)]",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out duration-200",
+            "data-[state=open]:slide-in-from-left data-[state=closed]:slide-out-to-left",
+            className,
+          )}
+        >
+          <DialogPrimitive.Title className="sr-only">
+            {title}
+          </DialogPrimitive.Title>
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/src/components/ui/side-sheet.tsx
+++ b/src/components/ui/side-sheet.tsx
@@ -21,19 +21,57 @@ export function SideSheet({
   className,
 }: SideSheetProps) {
   const startX = useRef<number | null>(null);
+  const startY = useRef<number | null>(null);
   const [dragX, setDragX] = useState(0);
+  // True while the panel eases back to rest after a sub-threshold release, so it
+  // doesn't teleport. Cleared on transition end to restore the slide animations.
+  const [animatingBack, setAnimatingBack] = useState(false);
+
+  const resetGesture = () => {
+    startX.current = null;
+    startY.current = null;
+  };
 
   const handleTouchStart = (e: React.TouchEvent) => {
-    startX.current = e.touches[0]?.clientX ?? null;
+    const touch = e.touches[0];
+    if (!touch) return;
+    startX.current = touch.clientX;
+    startY.current = touch.clientY;
+    setAnimatingBack(false);
   };
+
   const handleTouchMove = (e: React.TouchEvent) => {
-    if (startX.current === null) return;
-    const delta = (e.touches[0]?.clientX ?? startX.current) - startX.current;
-    if (delta < 0) setDragX(delta); // track leftward drag only
+    if (startX.current === null || startY.current === null) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const deltaX = touch.clientX - startX.current;
+    const deltaY = touch.clientY - startY.current;
+    // Only follow the finger once the drag is leftward AND predominantly
+    // horizontal, so a vertical scroll never drags the sheet.
+    setDragX(deltaX < 0 && Math.abs(deltaX) > Math.abs(deltaY) ? deltaX : 0);
   };
-  const handleTouchEnd = () => {
-    if (dragX < -SWIPE_CLOSE_THRESHOLD) onOpenChange(false);
-    startX.current = null;
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (startX.current === null || startY.current === null) {
+      resetGesture();
+      return;
+    }
+    const touch = e.changedTouches[0];
+    const deltaX = (touch?.clientX ?? startX.current) - startX.current;
+    const deltaY = (touch?.clientY ?? startY.current) - startY.current;
+    const isHorizontal = Math.abs(deltaX) > Math.abs(deltaY);
+    if (isHorizontal && deltaX < -SWIPE_CLOSE_THRESHOLD) {
+      onOpenChange(false);
+    }
+    resetGesture();
+    if (dragX !== 0) setAnimatingBack(true);
+    setDragX(0);
+  };
+
+  const handleTouchCancel = () => {
+    // An OS-interrupted gesture must reset without evaluating the close threshold.
+    resetGesture();
+    if (dragX !== 0) setAnimatingBack(true);
     setDragX(0);
   };
 
@@ -52,7 +90,15 @@ export function SideSheet({
           onTouchStart={handleTouchStart}
           onTouchMove={handleTouchMove}
           onTouchEnd={handleTouchEnd}
-          style={dragX ? { transform: `translateX(${dragX}px)` } : undefined}
+          onTouchCancel={handleTouchCancel}
+          onTransitionEnd={() => setAnimatingBack(false)}
+          style={
+            dragX !== 0
+              ? { transform: `translateX(${dragX}px)`, transition: "none" }
+              : animatingBack
+                ? { transition: "transform 150ms ease-out" }
+                : undefined
+          }
           className={cn(
             "fixed inset-y-0 left-0 z-50 flex w-[min(20rem,85vw)] flex-col bg-card shadow-2xl",
             "[padding-top:env(safe-area-inset-top)] [padding-bottom:env(safe-area-inset-bottom)]",


### PR DESCRIPTION
## Summary

Mobile ergonomics + correctness pass for three surfaces so two adults can use Family Hub daily on phones: **onboarding/login**, the **sidebar/menu**, and the **settings modals**. FE-only — no backend, routing, or desktop changes. Not a visual redesign and not a bottom-sheet rebuild.

Closes #193

## Contract → code → test

| # | Contract item | Code | Test |
|---|---------------|------|------|
| 1 | `dvh` + safe-area on the 4 onboarding screens, login, and shell (kill `100vh`) | `9087dfe` App.tsx (both shells → `h-dvh`), onboarding-welcome/members/family-name (`min-h-dvh` + `env(safe-area-inset-*)`); login-form + onboarding-credentials in `9128b7e` | existing onboarding + `App.shell` suites stay green |
| 2 | Keyboard-safe auth forms (focused input above keyboard on mobile; autofocus gated off on mobile) | `9128b7e` login-form, onboarding-credentials; **`996d11a` onboarding-family-name** now `autoFocus={!isMobile}` + `overflow-y-auto` (was the one form still shipping bare `autoFocus`) | `login-form.test.tsx` + **new `onboarding-family-name.test.tsx`** — no autofocus on mobile / autofocus on desktop |
| 3 | One working header settings entry; remove dead Settings button; fix sidebar "Calendar Settings" label | `8ba7010` removes dead `<Settings>` button + import; `6f9526e` sidebar subtitle "Calendar Settings" → "Menu" | `app-header.test.tsx` — exactly one header control (Menu) |
| 4 | Sidebar rebuilt on a new Radix `SideSheet`: focus-trap, Esc, scrim, swipe-left, safe-area, ≥44px targets, focus restored | `6f9526e` new `src/components/ui/side-sheet.tsx` (Radix Dialog + 60px swipe-to-close) + `sidebar-menu.tsx` rebuilt (`min-h-11` targets, `aria-label="Close menu"`); **`0a87228`** adds a directional-intent guard (close only when the drag is horizontal-dominant past threshold), `onTouchCancel` reset, and an eased snap-back | `sidebar-menu.test.tsx` — closes on Escape; **new `side-sheet.test.tsx`** — closes past threshold, ignores sub-threshold + vertical-dominant gestures, resets on cancel; `mobile-settings-sidebar.spec.ts` — menu opens/Escape-closes; swipe verified on a real touch device (see Manual verification) |
| 5 | Confirmed Sign Out (not direct `logout`) | `6f9526e` Sign Out → destructive confirm `Dialog` (mirrors reset-family); **`0e95b61`** hardens `useLogout` so a storage-disabled webview can't leave the confirm stuck — `clearStoredFamily()` try/catch parity with `clearStoredToken()`, so `queryClient.clear()` + reload always run | `sidebar-menu.test.tsx` — `logout` only fires after confirm; **new `use-auth.test.tsx`** — logout still clears cache + reloads when `removeItem` throws |
| 6 | `MemberProfileModal` gets `max-h` + scroll parity with `FamilySettingsModal` | `83ab10f` `DialogContent` → `max-h overflow-y-auto`; **`fe3903b`** both modals now use `max-h-[90dvh]` (matches this PR's vh→dvh theme so the keyboard/URL bar can't obscure actions) | existing `member-profile-modal.test.tsx` stays green |
| 7 | Bottom nav ≤5 slots + scalable `MobileSheet` "More" overflow; Photos dropped | `e446391` `mobile-bottom-nav.tsx` single ordered `MODULES` list + `PRIMARY_COUNT=4`, More via `MobileSheet`; Photos removed from nav | `mobile-bottom-nav.test.tsx` — 4 primary + More, no Meals/Photos in bar, More flow, More active for overflow; `mobile-settings-sidebar.spec.ts` — More reaches Recipes |

## Review follow-ups (this round)

Addressed two-angle review findings (spec-conformance + technical), each TDD'd where behavior changed:

- **B1 (blocking)** — `onboarding-family-name` shipped ungated `autoFocus` and lacked the `overflow-y-auto` scroll container its siblings had → literal violation of contract item 2 / spec D2. Gated `autoFocus={!isMobile}`, added the scroll container, added the missing test. (`996d11a`)
- **M1 (medium)** — `SideSheet` swipe-to-close had no directional-intent guard, so a near-vertical scroll-flick with ~60px of horizontal drift could dismiss the sheet mid-scroll. Now closes only on a horizontal-dominant leftward drag past threshold. (`0a87228`)
- **L1** — onboarding back buttons (40px), member-profile close (32px) and camera (32px) controls were below the ≥44px AC → bumped to `icon-lg` / `w-11 h-11`. (`fe3903b`)
- **L2** — `MemberProfileModal` (and `FamilySettingsModal`, for parity) used `90vh`; switched to `90dvh` to match the PR's vh→dvh theme. (`fe3903b`)
- **L3** — `useLogout` could throw on `localStorage.removeItem` in private-mode/storage-disabled webviews, leaving the Sign-Out confirm stuck before reload. Wrapped in `clearStoredFamily()` for parity with `clearStoredToken()`. (`0e95b61`)
- **L4** — swipe polish bundled with M1: `onTouchCancel` resets a stale gesture; sub-threshold release eases back instead of teleporting. (Imperative per-frame transform optimization intentionally deferred — perf-only.)

**Nitpicks intentionally skipped (noted, not silently dropped):**
- **N1** — the "More" button and More `MobileSheet` share the accessible name "More", and `MobileSheet` doesn't trap focus / mark the background inert. The focus-trap gap is a pre-existing `MobileSheet` limitation the spec deliberately reused; renaming the sheet title is **not** cheap (3 e2e specs + a unit test locate it via `getByRole("dialog", { name: "More" })`), so it's out of scope here.
- **N2** — `colors?.bg` optional chaining is dead under the type system; cosmetic inconsistency only.
- **N3** — calendar `mobile-toolbar` Menu button (~36px) is outside this PR's three governed surfaces (file not changed); leave for a separate touch-target pass.

## Out of scope (per spec)

True bottom-sheet conversion of the settings dialogs, `vaul` migration, calendar/notifications/routing/desktop-tablet changes, reaching the Photos surface on mobile (intentionally unreachable while deferred).

## Verification

- `npm run lint` — clean (only the pre-existing Biome schema-version info notice; exit 0)
- `npm run test -- --run` — **870 passed / 75 files** (was 862/72; +8 from the new B1/M1/L3 tests)
- `npm run build` — tsc typecheck + vite build green (exit 0)
- `npm run test:e2e` — full matrix green against the published BE `1.5.0` container (`docker-compose.e2e.yml`): **68 passed / 60 skipped / 0 failed** across chromium, firefox, webkit, Mobile Chrome (60 skips are the by-design mobile/desktop project gating). Run with `--retries=2` to mirror CI; the pre-existing `family-management` member-rename test occasionally needs a retry for mutation→cache propagation (passes on retry, unrelated to this PR's files).

Existing E2E specs that tapped the old Meals/Recipes/Photos tabs (`mobile-bottom-nav`, `mobile-meals`, `mobile-recipes`) were updated to reach overflow modules through the "More" sheet; Photos navigation removed (now asserted absent).

## Manual verification (can't be asserted in jsdom)

- **(a) Swipe-left closes the sidebar** — verified on a real Chromium iPhone-14 touch device driving synthetic CDP touch events: a leftward drag past the 60px threshold dismissed the panel (`menu open before swipe: true` → `closed: true`). The new directional guard adds intent-detection on top of this without changing the close threshold.
- **(b) Onboarding/login inputs stay above the soft keyboard** — verified at 390×844: the login form renders top-aligned in an `overflow-y-auto min-h-dvh` container (no forced centering), username autofocus is off on mobile, and the focused field + Sign In CTA sit in the upper area with room to scroll above the keyboard (screenshot captured). The family-name step now matches this after `996d11a`.

## Notes

Regular merge commits preserved (release-please needs individual `feat:`/`fix:`/`test:` commits visible).
