### PR TITLE
fix(mobile): address leftover review nitpicks from #194 (More sheet a11y, touch targets)

### DIFF
--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -91,7 +91,7 @@ export function MobileToolbar({ members, onOpenSidebar }: MobileToolbarProps) {
             type="button"
             onClick={onOpenSidebar}
             aria-label="Menu"
-            className="rounded-lg p-2 text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+            className="-my-1 flex h-11 w-11 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
           >
             <Menu className="h-5 w-5" />
           </button>

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -87,7 +87,7 @@ export function AppHeader() {
             {familyMembers.slice(0, 6).map((member) => (
               <div
                 key={member.id}
-                className={`w-3 h-3 rounded-full ${colorMap[member.color]?.bg || "bg-gray-300"}`}
+                className={`w-3 h-3 rounded-full ${colorMap[member.color].bg}`}
                 title={member.name}
               />
             ))}

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -41,6 +41,29 @@ describe("MobileBottomNav", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("marks the bottom nav inert while the More sheet is open", async () => {
+    const { user } = renderWithUser(<MobileBottomNav />);
+    const nav = screen.getByRole("navigation", { name: /primary/i });
+    expect(nav).not.toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: /^more$/i }));
+    expect(nav).toHaveAttribute("inert");
+
+    await user.click(screen.getByRole("button", { name: /^meals$/i }));
+    expect(nav).not.toHaveAttribute("inert");
+  });
+
+  it("returns focus to the More trigger when the sheet closes", async () => {
+    const { user } = renderWithUser(<MobileBottomNav />);
+    const more = screen.getByRole("button", { name: /^more$/i });
+
+    await user.click(more);
+    expect(screen.getByRole("dialog", { name: /^more$/i })).toHaveFocus();
+
+    await user.click(screen.getByRole("button", { name: /^meals$/i }));
+    expect(more).toHaveFocus();
+  });
+
   it("marks More active when an overflow module is active", () => {
     useAppStore.setState({ activeModule: "recipes" });
     render(<MobileBottomNav />);

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -52,6 +52,7 @@ export function MobileBottomNav() {
     <>
       <nav
         aria-label="Primary"
+        inert={moreOpen}
         className="z-30 shrink-0 border-t border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85"
       >
         <div

--- a/src/components/ui/mobile-sheet.test.tsx
+++ b/src/components/ui/mobile-sheet.test.tsx
@@ -1,0 +1,56 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { MobileSheet } from "./mobile-sheet";
+
+function SheetHarness({ children }: { children?: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open sheet
+      </button>
+      <MobileSheet
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        title="Test sheet"
+      >
+        {children ?? <button type="button">Inside action</button>}
+      </MobileSheet>
+    </>
+  );
+}
+
+describe("MobileSheet", () => {
+  it("moves focus to the dialog when it opens", async () => {
+    const { user } = renderWithUser(<SheetHarness />);
+
+    await user.click(screen.getByRole("button", { name: "Open sheet" }));
+
+    expect(screen.getByRole("dialog", { name: "Test sheet" })).toHaveFocus();
+  });
+
+  it("returns focus to the previously focused element when it closes", async () => {
+    const { user } = renderWithUser(<SheetHarness />);
+    const trigger = screen.getByRole("button", { name: "Open sheet" });
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(trigger).toHaveFocus();
+  });
+
+  it("does not steal focus from a child that focuses itself on mount", async () => {
+    const { user } = renderWithUser(
+      <SheetHarness>
+        <button type="button" ref={(el) => el?.focus()}>
+          Inside action
+        </button>
+      </SheetHarness>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open sheet" }));
+
+    expect(screen.getByRole("button", { name: "Inside action" })).toHaveFocus();
+  });
+});

--- a/src/components/ui/mobile-sheet.tsx
+++ b/src/components/ui/mobile-sheet.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 export interface MobileSheetProps {
@@ -9,22 +9,45 @@ export interface MobileSheetProps {
   children: ReactNode;
 }
 
-export function MobileSheet({
-  isOpen,
+export function MobileSheet({ isOpen, ...props }: MobileSheetProps) {
+  if (!isOpen) return null;
+  return <MobileSheetContent {...props} />;
+}
+
+function MobileSheetContent({
   onClose,
   title,
   headerRight,
   children,
-}: MobileSheetProps) {
-  if (!isOpen) return null;
+}: Omit<MobileSheetProps, "isOpen">) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Captured during render: by the time effects run, the opener may already
+  // be unfocusable (e.g. inside a background the opener marked inert).
+  const [openerElement] = useState(() =>
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null,
+  );
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog && !dialog.contains(document.activeElement)) {
+      dialog.focus();
+    }
+    return () => {
+      openerElement?.focus();
+    };
+  }, [openerElement]);
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-label={title}
       aria-describedby={undefined}
+      tabIndex={-1}
       className={cn(
-        "fixed inset-0 z-50 flex flex-col bg-card",
+        "fixed inset-0 z-50 flex flex-col bg-card outline-none",
         "motion-safe:animate-in motion-safe:slide-in-from-bottom motion-safe:duration-200",
       )}
     >


### PR DESCRIPTION
Follow-up to #194, addressing the nitpick findings left open in that review. Each item below states what was done or why it was skipped.

## N1 — More overflow: focus management + accessible-name collision

**(a) Background inert + focus management — done.**
- The bottom-nav `<nav>` is marked `inert` while the More sheet is open, so keyboard and screen-reader users can no longer reach the covered tab bar.
- `MobileSheet` now does minimal dialog focus management: on open it moves focus to the dialog container (`tabIndex={-1}`), and on close it restores focus to the element that opened it. This is required for the inert change to be safe — without it, inerting the nav silently drops focus to `<body>` when the trigger becomes inert. The opener is captured during render rather than in the effect because, in real browsers, by effect time the trigger is already inert and `document.activeElement` has fallen back to `<body>`.
- Focus-on-open is guarded (`dialog.contains(document.activeElement)`) so any sheet child that claims focus on mount (e.g. a future autofocused input) keeps it. All 10 `MobileSheet` consumers get this behavior, not just the More sheet.
- Deliberately **not** added: `aria-modal="true"` (background is only partially inert for the other sheet consumers, and APG advises against claiming modality the keyboard can escape) and a full focus trap / Radix migration (explicitly out of scope per the original review).

**(b) Rename the sheet's accessible name — skipped.**
The trigger ("More", `role=button`) and the sheet ("More", `role=dialog`) have different roles, which screen readers announce, so the collision is theoretical. The sheet title is also *visible* header text, so renaming it is a product copy change, and the literal name is asserted across four e2e specs plus the unit test. Cost outweighs the marginal a11y gain; the real issue (reaching the background while open) is fixed by (a).

## N2 — dead `colors?.bg` optional chaining — done

`colorMap` is `Record<FamilyColor, …>`, so the `?.` and the `|| "bg-gray-300"` fallback in `app-header.tsx` were unreachable. Removed to match the unguarded indexing already used in `sidebar-menu.tsx`. One-line normalize.

## N3 — calendar mobile-toolbar Menu button below 44px — done

Bumped from ~36px (`p-2` + 20px icon) to a fixed 44×44 target (`h-11 w-11`), with `-my-1` so the toolbar's visual height is unchanged. Verified at a 360px viewport via a throwaway Playwright run: Menu bounding box ≥44×44 and `document.documentElement.scrollWidth` ≤ 360 (no horizontal overflow).

## Verification

- `npm run lint` — clean (one pre-existing Biome config-migration info)
- `npm run test -- --run` — 77 files, 877 tests passed
- `npm run build` — passes (tsc + Vite + PWA)
- Full e2e matrix against BE 1.5.0 (`docker-compose.e2e.yml`): **59 passed, 60 skipped (cross-project), 0 failed** across chromium/firefox/webkit/Mobile Chrome — including the mobile specs asserting `dialog name="More"`, which are unchanged.

New unit coverage: `mobile-sheet.test.tsx` (focus on open, restore on close, no stealing from self-focusing children) and two `mobile-bottom-nav.test.tsx` cases (nav inert while sheet open, focus returns to the More trigger on close).