### PR TITLE
Fix mobile density quick wins for chores and recipes

### DIFF
--- a/e2e/mobile-chores.spec.ts
+++ b/e2e/mobile-chores.spec.ts
@@ -42,9 +42,11 @@ test.describe("Mobile Chores", () => {
     await expect(dialog).toBeHidden();
 
     await page.getByRole("button", { name: "Week" }).click();
-    await expect(
-      page.getByRole("heading", { name: "This Week" }),
-    ).toBeVisible();
+    await expect(page.getByRole("region", { name: "This Week" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "This Week" })).toHaveCount(
+      0,
+    );
+    await expect(page.getByText("1 left of 1")).toBeVisible();
 
     const row = page
       .locator('[data-testid^="chore-row-"]')

--- a/src/components/chores-view.test.tsx
+++ b/src/components/chores-view.test.tsx
@@ -202,16 +202,22 @@ describe("ChoresView", () => {
       "aria-pressed",
       "true",
     );
-    expect(await screen.findByRole("heading", { name: "Today" })).toBeVisible();
+    expect(await screen.findByRole("region", { name: "Today" })).toBeVisible();
     expect(
-      screen.queryByRole("heading", { name: "This Week" }),
+      screen.queryByRole("heading", { name: "Today" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "This Week" }),
     ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Week" }));
 
-    expect(screen.getByRole("heading", { name: "This Week" })).toBeVisible();
+    expect(screen.getByRole("region", { name: "This Week" })).toBeVisible();
     expect(
-      screen.queryByRole("heading", { name: "Today" }),
+      screen.queryByRole("heading", { name: "This Week" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("region", { name: "Today" }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/components/chores-view.tsx
+++ b/src/components/chores-view.tsx
@@ -165,6 +165,7 @@ export function ChoresView() {
                 <ChoreScopeColumn
                   key={scope.scope}
                   scope={scope}
+                  showHeading={!isMobile}
                   onArchive={handleArchive}
                   onComplete={handleComplete}
                   onUncomplete={handleUncomplete}

--- a/src/components/chores/chores-scope-column.test.tsx
+++ b/src/components/chores/chores-scope-column.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { ChoreScopeBoard } from "@/lib/types";
+import { render, screen } from "@/test/test-utils";
+import { ChoreScopeColumn } from "./chores-scope-column";
+
+const board: ChoreScopeBoard = {
+  scope: "TODAY",
+  periodStartDate: "2026-06-11",
+  periodEndDate: "2026-06-11",
+  summary: { total: 2, completed: 1, remaining: 1 },
+  assignees: [],
+};
+
+describe("ChoreScopeColumn", () => {
+  it("shows the period heading by default", () => {
+    render(<ChoreScopeColumn scope={board} />);
+
+    expect(screen.getByRole("heading", { name: "Today" })).toBeInTheDocument();
+  });
+
+  it("hides the heading but keeps the accessible name when showHeading is false", () => {
+    render(<ChoreScopeColumn scope={board} showHeading={false} />);
+
+    expect(screen.queryByRole("heading", { name: "Today" })).toBeNull();
+    expect(screen.getByRole("region", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByText(/1 left of 2/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/chores/chores-scope-column.tsx
+++ b/src/components/chores/chores-scope-column.tsx
@@ -3,6 +3,7 @@ import { ChoreAssigneeGroup } from "./chore-assignee-group";
 
 interface ChoreScopeColumnProps {
   scope: ChoreScopeBoard;
+  showHeading?: boolean;
   onArchive?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
   onComplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
   onUncomplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
@@ -16,30 +17,35 @@ function scopeHeading(scope: ChoreScopeBoard["scope"]): string {
 
 export function ChoreScopeColumn({
   scope,
+  showHeading = true,
   onArchive,
   onComplete,
   onUncomplete,
 }: ChoreScopeColumnProps) {
   const heading = scopeHeading(scope.scope);
+  const summary = `${scope.summary.remaining} left of ${scope.summary.total}`;
   const isFullyComplete =
     scope.summary.total > 0 && scope.summary.remaining === 0;
 
   return (
     <section
-      aria-labelledby={`${scope.scope}-heading`}
+      aria-label={showHeading ? undefined : heading}
+      aria-labelledby={showHeading ? `${scope.scope}-heading` : undefined}
       className="rounded-lg border bg-card p-4 shadow-sm"
     >
-      <header className="mb-4">
-        <h2
-          id={`${scope.scope}-heading`}
-          className="text-lg font-semibold text-foreground"
-        >
-          {heading}
-        </h2>
-        <p className="mt-1 text-sm text-muted-foreground">
-          {scope.summary.remaining} left of {scope.summary.total}
-        </p>
-      </header>
+      {showHeading ? (
+        <header className="mb-4">
+          <h2
+            id={`${scope.scope}-heading`}
+            className="text-lg font-semibold text-foreground"
+          >
+            {heading}
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">{summary}</p>
+        </header>
+      ) : (
+        <p className="mb-4 text-sm text-muted-foreground">{summary}</p>
+      )}
 
       {scope.summary.total === 0 ? (
         <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -84,10 +84,16 @@ describe("RecipesView", () => {
       }),
     );
 
-    render(<RecipesView />);
+    const { container } = render(<RecipesView />);
 
     expect(screen.getByText("Loading recipes...")).toBeInTheDocument();
     expect(screen.queryByText(testRecipeDetail.title)).not.toBeInTheDocument();
+    expect(container.querySelector(".animate-pulse")).toHaveClass(
+      "size-24",
+      "shrink-0",
+      "md:aspect-[4/3]",
+      "md:w-full",
+    );
     expect(await screen.findByText(testRecipeDetail.title)).toBeInTheDocument();
   });
 

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -228,10 +228,10 @@ export function RecipesView() {
               {Array.from({ length: 3 }, (_, index) => (
                 <div
                   key={`recipe-loading-${index}`}
-                  className="overflow-hidden rounded-lg border border-border bg-card"
+                  className="flex flex-row gap-3 overflow-hidden rounded-lg border border-border bg-card p-3 md:flex-col md:gap-0 md:p-0"
                 >
-                  <div className="aspect-[4/3] animate-pulse bg-muted" />
-                  <div className="space-y-3 p-4">
+                  <div className="size-24 shrink-0 animate-pulse rounded-lg bg-muted md:size-auto md:aspect-[4/3] md:w-full md:rounded-none" />
+                  <div className="flex min-w-0 flex-1 flex-col justify-center space-y-3 md:p-4">
                     <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
                     <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
                   </div>

--- a/src/components/recipes/recipe-library-card.test.tsx
+++ b/src/components/recipes/recipe-library-card.test.tsx
@@ -12,6 +12,27 @@ describe("RecipeLibraryCard", () => {
     expect(screen.queryByText("No photo")).not.toBeInTheDocument();
   });
 
+  it("uses a compact mobile row with the desktop vertical card restored at md", () => {
+    render(<RecipeLibraryCard recipe={testRecipeSummary} />);
+
+    const card = screen.getByRole("article", {
+      name: `Recipe card: ${testRecipeSummary.title}`,
+    });
+    const thumbnail = screen.getByRole("img", {
+      name: testRecipeSummary.title,
+    }).parentElement;
+
+    expect(card).toHaveClass("flex-row", "p-3", "md:flex-col", "md:p-0");
+    expect(thumbnail).toHaveClass(
+      "size-24",
+      "shrink-0",
+      "rounded-lg",
+      "md:aspect-[4/3]",
+      "md:w-full",
+      "md:rounded-none",
+    );
+  });
+
   it("shows the No photo placeholder when imageUrl is absent", () => {
     const recipe = { ...testRecipeSummary, imageUrl: null };
     render(<RecipeLibraryCard recipe={recipe} />);

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -18,7 +18,7 @@ export function RecipeLibraryCard({
     <article
       aria-label={`Recipe card: ${recipe.title}`}
       className={cn(
-        "relative flex w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-xs transition-colors",
+        "relative flex w-full flex-row gap-3 overflow-hidden rounded-lg border border-border bg-card p-3 text-left shadow-xs transition-colors md:flex-col md:gap-0 md:p-0",
       )}
     >
       <button
@@ -27,7 +27,7 @@ export function RecipeLibraryCard({
         className="absolute inset-0 z-10 rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         onClick={() => onSelect?.(recipe.id)}
       />
-      <div className="relative aspect-[4/3] w-full overflow-hidden bg-muted">
+      <div className="relative size-24 shrink-0 overflow-hidden rounded-lg bg-muted md:size-auto md:aspect-[4/3] md:w-full md:rounded-none">
         {recipe.imageUrl && !imgFailed ? (
           <img
             src={recipe.imageUrl}
@@ -37,39 +37,39 @@ export function RecipeLibraryCard({
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <span className="text-sm font-medium text-muted-foreground">
+            <span className="text-xs font-medium text-muted-foreground md:text-sm">
               No photo
             </span>
           </div>
         )}
-        <div className="absolute right-3 top-3 rounded-full bg-background/90 p-2 shadow-sm">
-          <Heart
-            aria-hidden={!recipe.favorite}
-            aria-label={
-              recipe.favorite ? `${recipe.title} is a favorite` : undefined
-            }
-            className={cn(
-              "h-4 w-4",
-              recipe.favorite
-                ? "fill-rose-500 text-rose-500"
-                : "fill-transparent text-muted-foreground",
-            )}
-          />
-        </div>
       </div>
 
-      <div className="flex flex-col gap-3 p-4">
-        <div className="flex items-start justify-between gap-3">
-          <h2 className="text-base leading-6 font-semibold text-foreground">
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5 md:gap-3 md:p-4">
+        <div className="flex min-w-0 items-start justify-between gap-2 md:gap-3">
+          <h2 className="line-clamp-2 min-w-0 text-base leading-6 font-semibold text-foreground md:line-clamp-none">
             {recipe.title}
           </h2>
+          <div className="shrink-0 rounded-full p-1 md:absolute md:right-3 md:top-3 md:bg-background/90 md:p-2 md:shadow-sm">
+            <Heart
+              aria-hidden={!recipe.favorite}
+              aria-label={
+                recipe.favorite ? `${recipe.title} is a favorite` : undefined
+              }
+              className={cn(
+                "h-4 w-4",
+                recipe.favorite
+                  ? "fill-rose-500 text-rose-500"
+                  : "fill-transparent text-muted-foreground",
+              )}
+            />
+          </div>
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex gap-1.5 overflow-hidden md:flex-wrap md:gap-2 md:overflow-visible">
           {recipe.tags.map((tag, index) => (
             <span
               key={`${index}-${tag}`}
-              className="rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
+              className="shrink-0 rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-secondary-foreground"
             >
               {formatRecipeTag(tag)}
             </span>


### PR DESCRIPTION
## Summary

Closes #199

- Hide redundant mobile chore scope headings while preserving the accessible region name and summary text.
- Restyle recipe library cards with a CSS-first mobile row layout, keeping the existing `md:` desktop vertical card treatment.
- Update recipe loading skeletons and the mobile chores E2E assertion to match the new structure.

## Execution Contract Checklist

- [x] `ChoreScopeColumn` gains `showHeading` defaulting to true; `ChoresView` passes `showHeading={!isMobile}`. Code: `src/components/chores/chores-scope-column.tsx:4`, `src/components/chores/chores-scope-column.tsx:18`, `src/components/chores-view.tsx:165`. Tests: `src/components/chores/chores-scope-column.test.tsx:15`, `src/components/chores-view.test.tsx:195`, `e2e/mobile-chores.spec.ts:44`.
- [x] Hidden chore heading keeps the accessible region name via `aria-label`; the summary stays visible; desktop headings stay unchanged. Code: `src/components/chores/chores-scope-column.tsx:31`, `src/components/chores/chores-scope-column.tsx:36`, `src/components/chores/chores-scope-column.tsx:47`. Tests: `src/components/chores/chores-scope-column.test.tsx:21`, `src/components/chores-view.test.tsx:224`, `e2e/mobile-chores.spec.ts:45`.
- [x] `recipe-library-card.tsx` uses a CSS-first responsive restyle: mobile horizontal row, about 96px thumbnail, line-clamped title, one-row tags, inline favorite; `md:` restores the desktop vertical card. Code: `src/components/recipes/recipe-library-card.tsx:18`, `src/components/recipes/recipe-library-card.tsx:30`, `src/components/recipes/recipe-library-card.tsx:47`, `src/components/recipes/recipe-library-card.tsx:52`, `src/components/recipes/recipe-library-card.tsx:68`. Test: `src/components/recipes/recipe-library-card.test.tsx:15`.
- [x] No `useIsMobile`, no second recipe card component, and no behavior changes to recipe selection/image fallback/favorite state. Code keeps the single component and existing open overlay/image fallback paths in `src/components/recipes/recipe-library-card.tsx:16`, `src/components/recipes/recipe-library-card.tsx:24`, `src/components/recipes/recipe-library-card.tsx:31`. Tests: `src/components/recipes/recipe-library-card.test.tsx:7`, `src/components/recipes/recipe-library-card.test.tsx:36`, `src/components/recipes/recipe-library-card.test.tsx:56`.
- [x] `recipes-view.tsx` skeleton mirrors the mobile row and `md:` vertical image sizing. Code: `src/components/recipes-view.tsx:303`; skeleton classes covered by `src/components/recipes-view.test.tsx:87`.
- [x] FE-only scope, no backend calls changed, no desktop regressions, and F1-F3/F1-F5 adjacent findings left out of scope. Evidence: changed files are limited to frontend components/tests/E2E; visual smoke covers 390x844 and 1280x900.

## Acceptance Criteria Status

- [x] Mobile chores show the selected scope once, without a duplicated period heading, while the selected scope remains a named region for assistive tech.
- [x] Desktop chores still show Today / This Week / This Month headings.
- [x] Mobile recipe cards are compact horizontal rows with 96px thumbnails and a single-row tag strip.
- [x] Desktop recipe cards remain vertical under `md:` styles.
- [x] Recipe loading skeleton follows the same responsive shape as loaded cards.
- [x] Existing recipe behaviors and backend contracts are unchanged.

## Verification

- `npm run lint`: passed. Biome checked 292 files; it only printed the existing schema-version info message.
- `npm run test -- --run`: passed. 78 test files, 880 tests.
- `npm run test:e2e`: passed. 68 passed, 60 skipped. Local backend used the latest published backend image tag `1.5.0`.
- Visual smoke: passed at 390x844 and 1280x900 using headless Playwright against the local Vite app plus real backend. Mobile chores measured `headingCount: 0` for `This Week` while the named region and `1 left of 1` summary stayed visible. Mobile recipes measured row cards with 96x96 thumbnails and one-row tags. Desktop chores retained all three headings; desktop recipes measured `flex-direction: column` with wide image media.

## Drift, Deferrals, Device Notes

- Story/spec/plan docs were readable from `../docs/...`; no source drift required changing the plan intent.
- No real-device-only fallback was triggered. The closest device check completed here was Playwright Mobile Chrome plus the 390x844 viewport smoke.
- The Codex in-app Browser could render the app shell but blocked `/api` requests as `ERR_BLOCKED_BY_CLIENT`, so the visual smoke was completed with the repo's Playwright stack instead.