### PR TITLE
fix(mobile): move list options into a half-height sheet

### DIFF
--- a/e2e/mobile-lists.spec.ts
+++ b/e2e/mobile-lists.spec.ts
@@ -34,7 +34,19 @@ test.describe("Mobile Lists", () => {
     await expect(
       page.getByRole("heading", { name: "Trader Joe's Run" }),
     ).toBeVisible();
-    await expect(page.getByLabel("Categories")).toHaveValue("grouped");
+
+    // On mobile the set-once controls live behind the "List options" sheet.
+    const optionsSheet = page.getByRole("dialog", { name: "List options" });
+    const openOptions = async () => {
+      await page.getByRole("button", { name: "List options" }).click();
+      await expect(optionsSheet).toBeVisible();
+      return optionsSheet;
+    };
+
+    let options = await openOptions();
+    await expect(options.getByLabel("Categories")).toHaveValue("grouped");
+    await options.getByRole("button", { name: "Cancel" }).click();
+    await expect(optionsSheet).toBeHidden();
 
     await page.getByRole("button", { name: "Add item" }).click();
     await page.getByLabel("Item text").fill("Bananas");
@@ -48,8 +60,11 @@ test.describe("Mobile Lists", () => {
 
     // Switch the category mode immediately — the item create may still be in
     // flight, so the list-level PATCH response must not clobber the new item.
-    await page.getByLabel("Categories").selectOption("flat");
+    options = await openOptions();
+    await options.getByLabel("Categories").selectOption("flat");
     await expect(page.getByRole("heading", { name: "Produce" })).toBeHidden();
+    await options.getByRole("button", { name: "Cancel" }).click();
+    await expect(optionsSheet).toBeHidden();
     await expect(page.getByText("Bananas")).toBeVisible();
 
     await page.getByRole("button", { name: /^Bananas$/ }).click();
@@ -58,7 +73,9 @@ test.describe("Mobile Lists", () => {
       "line-through",
     );
 
-    await page.getByRole("button", { name: "Remove all completed" }).click();
+    // "Remove all completed" runs from inside the sheet, which stays open.
+    options = await openOptions();
+    await options.getByRole("button", { name: "Remove all completed" }).click();
     await expect(page.getByText("Bananas")).toBeHidden();
   });
 });

--- a/src/components/lists/list-detail-view.test.tsx
+++ b/src/components/lists/list-detail-view.test.tsx
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ListDetail } from "@/lib/types";
+import {
+  seedMockListPreferences,
+  seedMockLists,
+  setupMswServer,
+} from "@/test/mocks/server";
+import { renderWithUser, screen, waitFor, within } from "@/test/test-utils";
+import { ListDetailView } from "./list-detail-view";
+
+const viewport = vi.hoisted(() => ({ isMobile: false }));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return {
+    ...actual,
+    useIsMobile: () => viewport.isMobile,
+  };
+});
+
+const LIST_ID = "00000000-0000-4000-8000-000000000101";
+
+const groceryList: ListDetail = {
+  id: LIST_ID,
+  name: "Trader Joe's Run",
+  kind: "grocery",
+  categoryDisplayMode: "grouped",
+  showCompletedOverride: null,
+  categories: [
+    {
+      id: "00000000-0000-4000-8000-000000000301",
+      kind: "grocery",
+      name: "Produce",
+      seeded: true,
+      sortOrder: 0,
+    },
+  ],
+  items: [
+    {
+      id: "00000000-0000-4000-8000-000000000201",
+      text: "Bananas",
+      completed: false,
+      completedAt: null,
+      categoryId: "00000000-0000-4000-8000-000000000301",
+      createdAt: "2026-05-06T09:05:00",
+      updatedAt: "2026-05-06T09:05:00",
+    },
+    {
+      id: "00000000-0000-4000-8000-000000000202",
+      text: "Spinach",
+      completed: true,
+      completedAt: "2026-05-06T10:00:00",
+      categoryId: "00000000-0000-4000-8000-000000000301",
+      createdAt: "2026-05-06T09:10:00",
+      updatedAt: "2026-05-06T10:00:00",
+    },
+  ],
+  createdAt: "2026-05-06T09:00:00",
+  updatedAt: "2026-05-06T10:00:00",
+};
+
+setupMswServer();
+
+function renderDetail() {
+  return renderWithUser(
+    <ListDetailView
+      listId={LIST_ID}
+      preferences={{ showCompletedByDefault: true }}
+      preferencesStatus="ready"
+      onBack={() => {}}
+    />,
+  );
+}
+
+beforeEach(() => {
+  seedMockLists([groceryList]);
+  seedMockListPreferences({ showCompletedByDefault: true });
+});
+
+describe("ListDetailView options placement", () => {
+  describe("mobile (<768px)", () => {
+    beforeEach(() => {
+      viewport.isMobile = true;
+    });
+
+    it("keeps the options controls out of the header and behind a trigger", async () => {
+      const { user } = renderDetail();
+
+      await screen.findByRole("heading", { name: "Trader Joe's Run" });
+
+      // Options controls are not rendered in the always-visible header.
+      expect(
+        screen.queryByLabelText("Completed items"),
+      ).not.toBeInTheDocument();
+      // "Add item" stays in the header.
+      expect(
+        screen.getByRole("button", { name: "Add item" }),
+      ).toBeInTheDocument();
+
+      // Trigger opens the half sheet with the controls inside.
+      await user.click(screen.getByRole("button", { name: "List options" }));
+      const sheet = await screen.findByRole("dialog", {
+        name: "List options",
+      });
+      expect(
+        within(sheet).getByLabelText("Completed items"),
+      ).toBeInTheDocument();
+      expect(within(sheet).getByLabelText("Categories")).toBeInTheDocument();
+    });
+
+    it("updates the visible list when an option changes in the sheet", async () => {
+      const { user } = renderDetail();
+
+      await screen.findByRole("heading", { name: "Trader Joe's Run" });
+      // Completed item is visible with the family default (show).
+      expect(screen.getByText("Spinach")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "List options" }));
+      const sheet = await screen.findByRole("dialog", {
+        name: "List options",
+      });
+      await user.selectOptions(
+        within(sheet).getByLabelText("Completed items"),
+        "Hide completed",
+      );
+
+      // The list behind the sheet re-renders and hides the completed item.
+      await waitFor(() =>
+        expect(screen.queryByText("Spinach")).not.toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("desktop (>=768px)", () => {
+    beforeEach(() => {
+      viewport.isMobile = false;
+    });
+
+    it("renders the controls inline with no options trigger", async () => {
+      renderDetail();
+
+      await screen.findByRole("heading", { name: "Trader Joe's Run" });
+
+      expect(screen.getByLabelText("Completed items")).toBeInTheDocument();
+      expect(screen.getByLabelText("Categories")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "List options" }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/lists/list-detail-view.tsx
+++ b/src/components/lists/list-detail-view.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Plus, Trash2 } from "lucide-react";
+import { ArrowLeft, Plus } from "lucide-react";
 import { useState } from "react";
 import {
   useClearCompleted,
@@ -8,16 +8,12 @@ import {
   useUpdateListItem,
   useUpdateListPreferences,
 } from "@/api";
-import type {
-  ListCategoryDisplayMode,
-  ListItem,
-  ListPreferences,
-} from "@/lib/types";
+import type { ListItem, ListPreferences } from "@/lib/types";
 import { Button } from "../ui/button";
-import { Label } from "../ui/label";
 import { buildListSections } from "./build-list-sections";
 import { ListItemRow } from "./list-item-row";
 import { ListItemSheet } from "./list-item-sheet";
+import { ListOptionsControls } from "./list-options-controls";
 
 const kindLabels = {
   grocery: "Grocery",
@@ -128,93 +124,21 @@ export function ListDetailView({
             </Button>
           </div>
 
-          <div className="mt-4 grid gap-3 sm:grid-cols-2">
-            {list.kind !== "general" && (
-              <div className="space-y-1">
-                <Label htmlFor="category-mode">Categories</Label>
-                <select
-                  id="category-mode"
-                  value={list.categoryDisplayMode}
-                  onChange={(event) =>
-                    updateList.mutate({
-                      categoryDisplayMode: event.target
-                        .value as ListCategoryDisplayMode,
-                      showCompletedOverride: list.showCompletedOverride,
-                    })
-                  }
-                  className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <option value="grouped">Show categories</option>
-                  <option value="flat">Hide categories</option>
-                </select>
-              </div>
-            )}
-
-            <div className="space-y-1">
-              <Label htmlFor="completed-items">Completed items</Label>
-              <select
-                id="completed-items"
-                value={completedOverrideValue}
-                disabled={completedControlsDisabled}
-                onChange={(event) =>
-                  updateList.mutate({
-                    categoryDisplayMode: list.categoryDisplayMode,
-                    showCompletedOverride:
-                      event.target.value === "family-default"
-                        ? null
-                        : event.target.value === "show",
-                  })
-                }
-                className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <option value="family-default">
-                  Family default (
-                  {hasPreferences
-                    ? familyShowCompletedDefault
-                      ? "show"
-                      : "hide"
-                    : "show for now"}
-                  )
-                </option>
-                <option value="show">Always show</option>
-                <option value="hide">Hide completed</option>
-              </select>
-              {completedControlsDisabled && (
-                <p className="text-xs leading-4 text-muted-foreground">
-                  {completedFallbackMessage}
-                </p>
-              )}
-            </div>
-          </div>
-
-          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-            <label
-              htmlFor="family-completed-default"
-              className="flex items-center gap-2 text-sm font-medium text-foreground"
-            >
-              <input
-                id="family-completed-default"
-                type="checkbox"
-                checked={familyShowCompletedDefault}
-                disabled={completedControlsDisabled}
-                onChange={(event) =>
-                  updatePreferences.mutate({
-                    showCompletedByDefault: event.target.checked,
-                  })
-                }
-                className="h-4 w-4 rounded border-border"
-              />
-              Show completed by default
-            </label>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => clearCompleted.mutate()}
-              disabled={clearCompletedDisabled}
-            >
-              <Trash2 className="h-4 w-4" />
-              Remove all completed
-            </Button>
+          <div className="mt-4">
+            <ListOptionsControls
+              list={list}
+              hasPreferences={hasPreferences}
+              familyShowCompletedDefault={familyShowCompletedDefault}
+              completedControlsDisabled={completedControlsDisabled}
+              completedOverrideValue={completedOverrideValue}
+              completedFallbackMessage={completedFallbackMessage}
+              clearCompletedDisabled={clearCompletedDisabled}
+              onUpdateList={(request) => updateList.mutate(request)}
+              onUpdatePreferences={(request) =>
+                updatePreferences.mutate(request)
+              }
+              onClearCompleted={() => clearCompleted.mutate()}
+            />
           </div>
         </div>
 

--- a/src/components/lists/list-detail-view.tsx
+++ b/src/components/lists/list-detail-view.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Plus } from "lucide-react";
+import { ArrowLeft, Plus, SlidersHorizontal } from "lucide-react";
 import { useState } from "react";
 import {
   useClearCompleted,
@@ -8,8 +8,10 @@ import {
   useUpdateListItem,
   useUpdateListPreferences,
 } from "@/api";
+import { useIsMobile } from "@/hooks";
 import type { ListItem, ListPreferences } from "@/lib/types";
 import { Button } from "../ui/button";
+import { MobileSheet } from "../ui/mobile-sheet";
 import { buildListSections } from "./build-list-sections";
 import { ListItemRow } from "./list-item-row";
 import { ListItemSheet } from "./list-item-sheet";
@@ -40,6 +42,8 @@ export function ListDetailView({
   const deleteItem = useDeleteListItem(listId);
   const clearCompleted = useClearCompleted(listId);
   const updatePreferences = useUpdateListPreferences();
+  const isMobile = useIsMobile();
+  const [optionsOpen, setOptionsOpen] = useState(false);
   const [itemSheet, setItemSheet] = useState<{
     mode: "create" | "edit";
     item: ListItem | null;
@@ -115,31 +119,47 @@ export function ListDetailView({
                 {list.name}
               </h2>
             </div>
-            <Button
-              type="button"
-              onClick={() => setItemSheet({ mode: "create", item: null })}
-            >
-              <Plus className="h-4 w-4" />
-              Add item
-            </Button>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                type="button"
+                onClick={() => setItemSheet({ mode: "create", item: null })}
+              >
+                <Plus className="h-4 w-4" />
+                Add item
+              </Button>
+              {isMobile && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="List options"
+                  className="h-11 w-11"
+                  onClick={() => setOptionsOpen(true)}
+                >
+                  <SlidersHorizontal className="h-5 w-5" />
+                </Button>
+              )}
+            </div>
           </div>
 
-          <div className="mt-4">
-            <ListOptionsControls
-              list={list}
-              hasPreferences={hasPreferences}
-              familyShowCompletedDefault={familyShowCompletedDefault}
-              completedControlsDisabled={completedControlsDisabled}
-              completedOverrideValue={completedOverrideValue}
-              completedFallbackMessage={completedFallbackMessage}
-              clearCompletedDisabled={clearCompletedDisabled}
-              onUpdateList={(request) => updateList.mutate(request)}
-              onUpdatePreferences={(request) =>
-                updatePreferences.mutate(request)
-              }
-              onClearCompleted={() => clearCompleted.mutate()}
-            />
-          </div>
+          {!isMobile && (
+            <div className="mt-4">
+              <ListOptionsControls
+                list={list}
+                hasPreferences={hasPreferences}
+                familyShowCompletedDefault={familyShowCompletedDefault}
+                completedControlsDisabled={completedControlsDisabled}
+                completedOverrideValue={completedOverrideValue}
+                completedFallbackMessage={completedFallbackMessage}
+                clearCompletedDisabled={clearCompletedDisabled}
+                onUpdateList={(request) => updateList.mutate(request)}
+                onUpdatePreferences={(request) =>
+                  updatePreferences.mutate(request)
+                }
+                onClearCompleted={() => clearCompleted.mutate()}
+              />
+            </div>
+          )}
         </div>
 
         {list.items.length === 0 ? (
@@ -192,6 +212,33 @@ export function ListDetailView({
               </section>
             ))}
           </div>
+        )}
+
+        {isMobile && (
+          <MobileSheet
+            isOpen={optionsOpen}
+            onClose={() => setOptionsOpen(false)}
+            title="List options"
+            initialHeight="half"
+          >
+            <div className="space-y-5">
+              <ListOptionsControls
+                list={list}
+                hasPreferences={hasPreferences}
+                familyShowCompletedDefault={familyShowCompletedDefault}
+                completedControlsDisabled={completedControlsDisabled}
+                completedOverrideValue={completedOverrideValue}
+                completedFallbackMessage={completedFallbackMessage}
+                clearCompletedDisabled={clearCompletedDisabled}
+                fullWidthClearButton
+                onUpdateList={(request) => updateList.mutate(request)}
+                onUpdatePreferences={(request) =>
+                  updatePreferences.mutate(request)
+                }
+                onClearCompleted={() => clearCompleted.mutate()}
+              />
+            </div>
+          </MobileSheet>
         )}
 
         <ListItemSheet

--- a/src/components/lists/list-options-controls.tsx
+++ b/src/components/lists/list-options-controls.tsx
@@ -1,0 +1,137 @@
+import { Trash2 } from "lucide-react";
+import type {
+  ListCategoryDisplayMode,
+  ListDetail,
+  UpdateListRequest,
+} from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Button } from "../ui/button";
+import { Label } from "../ui/label";
+
+interface ListOptionsControlsProps {
+  list: ListDetail;
+  hasPreferences: boolean;
+  familyShowCompletedDefault: boolean;
+  completedControlsDisabled: boolean;
+  completedOverrideValue: "family-default" | "show" | "hide";
+  completedFallbackMessage: string;
+  clearCompletedDisabled: boolean;
+  /** Stack the clear-completed action full-width (used inside the mobile sheet). */
+  fullWidthClearButton?: boolean;
+  onUpdateList: (request: UpdateListRequest) => void;
+  onUpdatePreferences: (request: { showCompletedByDefault: boolean }) => void;
+  onClearCompleted: () => void;
+}
+
+export function ListOptionsControls({
+  list,
+  hasPreferences,
+  familyShowCompletedDefault,
+  completedControlsDisabled,
+  completedOverrideValue,
+  completedFallbackMessage,
+  clearCompletedDisabled,
+  fullWidthClearButton = false,
+  onUpdateList,
+  onUpdatePreferences,
+  onClearCompleted,
+}: ListOptionsControlsProps) {
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {list.kind !== "general" && (
+          <div className="space-y-1">
+            <Label htmlFor="category-mode">Categories</Label>
+            <select
+              id="category-mode"
+              value={list.categoryDisplayMode}
+              onChange={(event) =>
+                onUpdateList({
+                  categoryDisplayMode: event.target
+                    .value as ListCategoryDisplayMode,
+                  showCompletedOverride: list.showCompletedOverride,
+                })
+              }
+              className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="grouped">Show categories</option>
+              <option value="flat">Hide categories</option>
+            </select>
+          </div>
+        )}
+
+        <div className="space-y-1">
+          <Label htmlFor="completed-items">Completed items</Label>
+          <select
+            id="completed-items"
+            value={completedOverrideValue}
+            disabled={completedControlsDisabled}
+            onChange={(event) =>
+              onUpdateList({
+                categoryDisplayMode: list.categoryDisplayMode,
+                showCompletedOverride:
+                  event.target.value === "family-default"
+                    ? null
+                    : event.target.value === "show",
+              })
+            }
+            className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="family-default">
+              Family default (
+              {hasPreferences
+                ? familyShowCompletedDefault
+                  ? "show"
+                  : "hide"
+                : "show for now"}
+              )
+            </option>
+            <option value="show">Always show</option>
+            <option value="hide">Hide completed</option>
+          </select>
+          {completedControlsDisabled && (
+            <p className="text-xs leading-4 text-muted-foreground">
+              {completedFallbackMessage}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div
+        className={cn(
+          "mt-4 flex flex-wrap items-center justify-between gap-3",
+          fullWidthClearButton && "flex-col items-stretch",
+        )}
+      >
+        <label
+          htmlFor="family-completed-default"
+          className="flex items-center gap-2 text-sm font-medium text-foreground"
+        >
+          <input
+            id="family-completed-default"
+            type="checkbox"
+            checked={familyShowCompletedDefault}
+            disabled={completedControlsDisabled}
+            onChange={(event) =>
+              onUpdatePreferences({
+                showCompletedByDefault: event.target.checked,
+              })
+            }
+            className="h-4 w-4 rounded border-border"
+          />
+          Show completed by default
+        </label>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClearCompleted}
+          disabled={clearCompletedDisabled}
+          className={cn(fullWidthClearButton && "w-full")}
+        >
+          <Trash2 className="h-4 w-4" />
+          Remove all completed
+        </Button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
Closes #200

Moves the list-detail set-once controls (categories, completed visibility, family default, clear completed) behind a compact options sheet on mobile so list items start within the first screen. **FE-only — no backend, no desktop changes, no preference-semantics changes.** Implemented from the issue execution brief and the linked spec/plan.

## Execution contract → code + test

| # | Contract item | Code | Test |
|---|---|---|---|
| 1 | Extract the four controls into one source of truth, mutations passed as callbacks, labels/helper copy/disabled states identical | New [`list-options-controls.tsx`](frontend/src/components/lists/list-options-controls.tsx); inline block in [`list-detail-view.tsx`](frontend/src/components/lists/list-detail-view.tsx) replaced with `<ListOptionsControls>` | Full lists unit suite stays green after the pure refactor (880 unit tests pass) |
| 2 | Mobile (<768px via `useIsMobile()`): header = kind label + name + "Add item" + ghost `SlidersHorizontal` trigger (`aria-label="List options"`, 44px); opens `MobileSheet` `initialHeight="half"`, title "List options"; "Remove all completed" full-width inside | `list-detail-view.tsx` — `isMobile` gate, trigger button, `MobileSheet` host; `fullWidthClearButton` prop on the controls | `list-detail-view.test.tsx` "keeps the options controls out of the header and behind a trigger" + "updates the visible list when an option changes in the sheet" |
| 3 | Desktop (≥768px): controls render inline exactly as today — pixel-identical | `list-detail-view.tsx` renders `<ListOptionsControls>` inline when `!isMobile` | `list-detail-view.test.tsx` "renders the controls inline with no options trigger"; desktop visual smoke (see below) |
| 4 | Semantics unchanged: selects mutate immediately, categories absent for `general`, sheet stays open after "Remove all completed" | Callbacks call `updateList`/`updatePreferences`/`clearCompleted` `.mutate` directly; `kind !== "general"` guard preserved; no auto-close on clear | Unit "updates the visible list…" asserts immediate mutation; updated `mobile-lists.spec.ts` clears completed from inside the still-open sheet |

## Acceptance criteria

- [x] 360–430px: header card has no selects/checkbox/clear button; first item visible without scrolling — confirmed by mobile visual smoke (390×844).
- [x] Options trigger opens a half sheet with all four controls, today's labels/helper/disabled states (incl. preferences-unavailable fallback, preserved verbatim in the extracted component).
- [x] Changing options from the sheet updates the visible list — unit test hides the completed item via the sheet's "Completed items" select; E2E toggles category mode from the sheet.
- [x] "Remove all completed" works from the sheet; disabled when nothing to clear (disabled state preserved).
- [x] Categories select absent for `general` lists in both homes (`kind !== "general"` guard unchanged).
- [x] ≥768px: inline controls, visually unchanged — desktop visual smoke matches the prior layout.
- [x] lint + unit + E2E green (mobile E2E updated to drive the options sheet).

## Verification

- `npm run lint` — clean (only the pre-existing biome schema-version *info*, unrelated to this change).
- `tsc --noEmit` — clean.
- `npm run test -- --run` — **880 passed** (78 files), incl. the new `list-detail-view.test.tsx` (3 cases).
- `npm run test:e2e` — full suite run against the pinned released backend (`BE_IMAGE_TAG=1.5.0`, mirroring CI). `mobile-lists.spec.ts` passes through the new options sheet. 4 desktop **calendar** specs flaked under parallel-worker contention on the shared backend (unrelated to this lists-only change) and **passed on isolated re-run** (10/10).
- Visual smoke at 390×844 (mobile header + options sheet) and a desktop width (inline controls) — both match the layout contract.

## Notes

- No real-device-only gate in this issue; the half-sheet keyboard auto-expand is the existing `MobileSheet` behavior, not introduced here.
- Regular merge commit (no squash) so release-please sees the individual `refactor:`/`fix:`/`test:` commits.
