### PR TITLE
feat(mobile): module-aware shared header across modules

### DIFF
--- a/e2e/mobile-bottom-nav.spec.ts
+++ b/e2e/mobile-bottom-nav.spec.ts
@@ -52,7 +52,9 @@ test.describe("Mobile Bottom Navigation", () => {
     ).toBeVisible();
 
     await nav.getByRole("button", { name: "Lists" }).click();
-    await expect(page.getByRole("heading", { name: "My Lists" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Lists", level: 1, exact: true }),
+    ).toBeVisible();
 
     await nav.getByRole("button", { name: "Chores" }).click();
     await expect(

--- a/e2e/mobile-lists.spec.ts
+++ b/e2e/mobile-lists.spec.ts
@@ -25,7 +25,9 @@ test.describe("Mobile Lists", () => {
     const nav = page.getByRole("navigation", { name: /primary/i });
     await nav.getByRole("button", { name: "Lists" }).click();
 
-    await expect(page.getByRole("heading", { name: "My Lists" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Lists", level: 1, exact: true }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "New List" }).click();
     await page.getByLabel("List name").fill("Trader Joe's Run");
     await page.getByRole("radio", { name: "Grocery" }).click();

--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -76,7 +76,7 @@ describe("App shell", () => {
     expect(screen.getAllByText(/^calendar$/i)).toHaveLength(1);
   });
 
-  it("suppresses AppHeader on mobile calendar while keeping bottom nav", async () => {
+  it("renders the module-aware AppHeader on mobile calendar alongside bottom nav", async () => {
     setViewportWidth(768);
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
 
@@ -85,10 +85,13 @@ describe("App shell", () => {
     expect(
       await screen.findByRole("navigation", { name: /primary/i }),
     ).toBeInTheDocument();
+    // Calendar header shows the context label, not the family name.
     expect(
       screen.queryByRole("heading", { name: /test family/i }),
     ).not.toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: /^home$/i })).toHaveLength(1);
+    // Header carries the calendar Today action + a single Menu button.
+    expect(screen.getByRole("button", { name: /today/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^menu$/i })).toBeInTheDocument();
   });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,7 @@ export default function FamilyHub() {
   return (
     <>
       <div className="h-dvh flex flex-col bg-background">
-        {!(isMobile && activeModule === "calendar") && <AppHeader />}
+        <AppHeader />
 
         <div className="flex-1 flex min-h-0 overflow-hidden">
           {!isMobile && <NavigationTabs />}

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -41,7 +41,6 @@ import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
 import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
-  useAppStore,
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
@@ -106,9 +105,6 @@ export function CalendarModule() {
     openAddEventModal,
     closeAddEventModal,
   } = useCalendarActions();
-
-  // App store actions for mobile toolbar
-  const openSidebar = useAppStore((state) => state.openSidebar);
 
   // Family data for mobile views
   const members = useFamilyMembers();
@@ -457,7 +453,7 @@ export function CalendarModule() {
     <div className="flex-1 flex flex-col overflow-hidden">
       {/* Toolbar */}
       {isMobile ? (
-        <MobileToolbar members={members} onOpenSidebar={openSidebar} />
+        <MobileToolbar members={members} />
       ) : (
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-4 py-3 bg-card border-b border-border">
           <CalendarViewSwitcher />

--- a/src/components/calendar/components/mobile-toolbar.test.tsx
+++ b/src/components/calendar/components/mobile-toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, seedCalendarStore } from "@/test/test-utils";
+import { render, screen } from "@/test/test-utils";
 import { MobileToolbar } from "./mobile-toolbar";
 
 const mockMembers = [
@@ -6,18 +6,11 @@ const mockMembers = [
   { id: "m2", name: "Bob", color: "teal" as const },
 ];
 
+// The title / Today / Menu row moved to the shared module-aware AppHeader
+// (covered in app-header.test.tsx). MobileToolbar is now just the controls row.
 describe("MobileToolbar", () => {
-  it("renders context label based on view", () => {
-    seedCalendarStore({
-      calendarView: "monthly",
-      currentDate: new Date(2026, 2, 18), // March 2026
-    });
-    render(<MobileToolbar members={mockMembers} onOpenSidebar={vi.fn()} />);
-    expect(screen.getByText(/March 2026/)).toBeInTheDocument();
-  });
-
   it("renders view switcher with D/W/M/S pills", () => {
-    render(<MobileToolbar members={mockMembers} onOpenSidebar={vi.fn()} />);
+    render(<MobileToolbar members={mockMembers} />);
     expect(screen.getByRole("button", { name: /daily/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /weekly/i })).toBeInTheDocument();
     expect(
@@ -29,29 +22,18 @@ describe("MobileToolbar", () => {
   });
 
   it("renders member filter dots for each member", () => {
-    render(<MobileToolbar members={mockMembers} onOpenSidebar={vi.fn()} />);
+    render(<MobileToolbar members={mockMembers} />);
     expect(screen.getByText("A")).toBeInTheDocument(); // Alice initial
     expect(screen.getByText("B")).toBeInTheDocument(); // Bob initial
   });
 
-  it("renders Today button", () => {
-    render(<MobileToolbar members={mockMembers} onOpenSidebar={vi.fn()} />);
-    expect(screen.getByRole("button", { name: /today/i })).toBeInTheDocument();
-  });
-
-  it("renders hamburger menu button", () => {
-    const onOpenSidebar = vi.fn();
-    render(
-      <MobileToolbar members={mockMembers} onOpenSidebar={onOpenSidebar} />,
-    );
-    const menuButton = screen.getByRole("button", { name: /menu/i });
-    expect(menuButton).toBeInTheDocument();
-  });
-
-  it("does not render a Home button", () => {
-    render(<MobileToolbar members={mockMembers} onOpenSidebar={vi.fn()} />);
+  it("does not render the context label, Today, or Menu (now in AppHeader)", () => {
+    render(<MobileToolbar members={mockMembers} />);
     expect(
-      screen.queryByRole("button", { name: /^home$/i }),
+      screen.queryByRole("button", { name: /today/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /menu/i }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -1,9 +1,9 @@
-import { endOfWeek, format, startOfWeek } from "date-fns";
 import { Menu } from "lucide-react";
 import { useEffect } from "react";
 import type { FamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useCalendarStore, useIsViewingToday } from "@/stores";
+import { getContextLabel } from "../utils/context-label";
 import { MemberAvatar } from "./member-avatar";
 
 interface MobileToolbarProps {
@@ -17,27 +17,6 @@ const VIEW_PILLS = [
   { view: "monthly", label: "M", ariaLabel: "Monthly view" },
   { view: "schedule", label: "S", ariaLabel: "Schedule view" },
 ] as const;
-
-function getContextLabel(calendarView: string, currentDate: Date): string {
-  switch (calendarView) {
-    case "monthly":
-      return format(currentDate, "MMMM yyyy");
-    case "weekly": {
-      const weekStart = startOfWeek(currentDate);
-      const weekEnd = endOfWeek(currentDate);
-      const sameMonth = weekStart.getMonth() === weekEnd.getMonth();
-      return sameMonth
-        ? `${format(weekStart, "MMM d")} \u2013 ${format(weekEnd, "d")}`
-        : `${format(weekStart, "MMM d")} \u2013 ${format(weekEnd, "MMM d")}`;
-    }
-    case "daily":
-      return format(currentDate, "EEE, MMM d");
-    case "schedule":
-      return "Upcoming";
-    default:
-      return format(currentDate, "MMMM yyyy");
-  }
-}
 
 export function MobileToolbar({ members, onOpenSidebar }: MobileToolbarProps) {
   const calendarView = useCalendarStore((s) => s.calendarView);

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -41,7 +41,9 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
   return (
     // Controls row — the title / Today / Menu row now lives in the shared
     // module-aware AppHeader; this bar owns only the calendar-specific controls.
-    <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-4 py-3">
+    // Tight vertical padding keeps total calendar chrome (64px header + this row)
+    // no taller than the old two-row toolbar.
+    <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-4 py-1">
       {/* View Switcher */}
       <div className="flex items-center gap-0.5 rounded-xl bg-muted p-1">
         {VIEW_PILLS.map(({ view, label, ariaLabel }) => (

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -1,14 +1,11 @@
-import { Menu } from "lucide-react";
 import { useEffect } from "react";
 import type { FamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { useCalendarStore, useIsViewingToday } from "@/stores";
-import { getContextLabel } from "../utils/context-label";
+import { useCalendarStore } from "@/stores";
 import { MemberAvatar } from "./member-avatar";
 
 interface MobileToolbarProps {
   members: FamilyMember[];
-  onOpenSidebar: () => void;
 }
 
 const VIEW_PILLS = [
@@ -18,17 +15,14 @@ const VIEW_PILLS = [
   { view: "schedule", label: "S", ariaLabel: "Schedule view" },
 ] as const;
 
-export function MobileToolbar({ members, onOpenSidebar }: MobileToolbarProps) {
+export function MobileToolbar({ members }: MobileToolbarProps) {
   const calendarView = useCalendarStore((s) => s.calendarView);
-  const currentDate = useCalendarStore((s) => s.currentDate);
   const setCalendarView = useCalendarStore((s) => s.setCalendarView);
-  const goToToday = useCalendarStore((s) => s.goToToday);
   const filter = useCalendarStore((s) => s.filter);
   const toggleMember = useCalendarStore((s) => s.toggleMember);
   const initializeSelectedMembers = useCalendarStore(
     (s) => s.initializeSelectedMembers,
   );
-  const isViewingToday = useIsViewingToday();
 
   // Initialize selected members on first load or when persisted filter is stale
   useEffect(() => {
@@ -44,83 +38,51 @@ export function MobileToolbar({ members, onOpenSidebar }: MobileToolbarProps) {
     }
   }, [members, filter.selectedMembers, initializeSelectedMembers]);
 
-  const contextLabel = getContextLabel(calendarView, currentDate);
-
   return (
-    <div className="flex flex-col border-b border-border bg-background">
-      {/* Row 1: Header Bar */}
-      <div className="flex items-center justify-between px-4 py-3">
-        <span className="text-[22px] leading-7 font-semibold text-foreground">
-          {contextLabel}
-        </span>
-        <div className="flex items-center gap-2">
+    // Controls row — the title / Today / Menu row now lives in the shared
+    // module-aware AppHeader; this bar owns only the calendar-specific controls.
+    <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-4 py-3">
+      {/* View Switcher */}
+      <div className="flex items-center gap-0.5 rounded-xl bg-muted p-1">
+        {VIEW_PILLS.map(({ view, label, ariaLabel }) => (
           <button
+            key={view}
             type="button"
-            onClick={goToToday}
+            aria-label={ariaLabel}
+            onClick={() => setCalendarView(view)}
             className={cn(
-              "rounded-lg px-2.5 py-1.5 text-sm leading-5 font-semibold transition-colors",
-              isViewingToday
-                ? "text-primary/50"
-                : "text-primary hover:bg-primary/10",
+              "flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-sm leading-none font-semibold transition-colors",
+              calendarView === view
+                ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
+                : "text-muted-foreground hover:text-foreground",
             )}
           >
-            Today
+            {label}
           </button>
-          <button
-            type="button"
-            onClick={onOpenSidebar}
-            aria-label="Menu"
-            className="-my-1 flex h-11 w-11 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <Menu className="h-5 w-5" />
-          </button>
-        </div>
+        ))}
       </div>
 
-      {/* Row 2: Controls Bar */}
-      <div className="flex items-center justify-between gap-3 px-4 pb-3">
-        {/* View Switcher */}
-        <div className="flex items-center gap-0.5 rounded-xl bg-muted p-1">
-          {VIEW_PILLS.map(({ view, label, ariaLabel }) => (
+      {/* Member Filter Dots */}
+      <div className="flex items-center gap-1">
+        {members.map((member) => {
+          const isIncluded = filter.selectedMembers.includes(member.id);
+          return (
             <button
-              key={view}
+              key={member.id}
               type="button"
-              aria-label={ariaLabel}
-              onClick={() => setCalendarView(view)}
-              className={cn(
-                "flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-sm leading-none font-semibold transition-colors",
-                calendarView === view
-                  ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
+              onClick={() => toggleMember(member.id)}
+              aria-label={`${member.name} filter`}
+              className="rounded-full p-2 transition-colors hover:bg-muted"
             >
-              {label}
+              <MemberAvatar
+                name={member.name}
+                color={member.color}
+                size="md"
+                variant={isIncluded ? "filled" : "ring"}
+              />
             </button>
-          ))}
-        </div>
-
-        {/* Member Filter Dots */}
-        <div className="flex items-center gap-1">
-          {members.map((member) => {
-            const isIncluded = filter.selectedMembers.includes(member.id);
-            return (
-              <button
-                key={member.id}
-                type="button"
-                onClick={() => toggleMember(member.id)}
-                aria-label={`${member.name} filter`}
-                className="rounded-full p-2 transition-colors hover:bg-muted"
-              >
-                <MemberAvatar
-                  name={member.name}
-                  color={member.color}
-                  size="md"
-                  variant={isIncluded ? "filled" : "ring"}
-                />
-              </button>
-            );
-          })}
-        </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -5,4 +5,5 @@ export { CalendarModule } from "./calendar-module";
 
 // Re-export all calendar components
 export * from "./components";
+export * from "./utils/context-label";
 export * from "./views";

--- a/src/components/calendar/utils/context-label.ts
+++ b/src/components/calendar/utils/context-label.ts
@@ -1,0 +1,32 @@
+import { endOfWeek, format, startOfWeek } from "date-fns";
+import type { CalendarViewType } from "@/lib/types";
+
+/**
+ * Human-readable label describing the calendar's current view + date context
+ * (e.g. "June 2026", "Jun 1 – 7", "Mon, Jun 1", "Upcoming"). Shared by the
+ * module-aware app header and the calendar mobile toolbar so both render one
+ * consistent label.
+ */
+export function getContextLabel(
+  calendarView: CalendarViewType,
+  currentDate: Date,
+): string {
+  switch (calendarView) {
+    case "monthly":
+      return format(currentDate, "MMMM yyyy");
+    case "weekly": {
+      const weekStart = startOfWeek(currentDate);
+      const weekEnd = endOfWeek(currentDate);
+      const sameMonth = weekStart.getMonth() === weekEnd.getMonth();
+      return sameMonth
+        ? `${format(weekStart, "MMM d")} – ${format(weekEnd, "d")}`
+        : `${format(weekStart, "MMM d")} – ${format(weekEnd, "MMM d")}`;
+    }
+    case "daily":
+      return format(currentDate, "EEE, MMM d");
+    case "schedule":
+      return "Upcoming";
+    default:
+      return format(currentDate, "MMMM yyyy");
+  }
+}

--- a/src/components/chores-view.tsx
+++ b/src/components/chores-view.tsx
@@ -114,9 +114,11 @@ export function ChoresView() {
         <div className="mx-auto max-w-6xl">
           <div className="mb-6 flex items-start justify-between gap-3">
             <div className="space-y-3">
-              <h1 className="text-[24px] leading-8 font-semibold text-foreground">
-                Chores
-              </h1>
+              {!isMobile && (
+                <h1 className="text-[24px] leading-8 font-semibold text-foreground">
+                  Chores
+                </h1>
+              )}
               {isMobile && (
                 <ChoreScopeSwitcher
                   value={selectedScopeKey}

--- a/src/components/lists-view.tsx
+++ b/src/components/lists-view.tsx
@@ -1,12 +1,15 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useListPreferences, useLists } from "@/api";
+import { useIsMobile } from "@/hooks";
+import { cn } from "@/lib/utils";
 import { ListCard } from "./lists/list-card";
 import { ListCreateSheet } from "./lists/list-create-sheet";
 import { ListDetailView } from "./lists/list-detail-view";
 import { Button } from "./ui/button";
 
 export function ListsView() {
+  const isMobile = useIsMobile();
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
   const lists = useLists();
@@ -43,10 +46,17 @@ export function ListsView() {
     return (
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="mx-auto max-w-2xl space-y-6">
-          <div className="flex items-center justify-end gap-3 md:justify-between">
-            <h2 className="hidden text-[24px] font-semibold leading-8 text-foreground md:block">
-              My Lists
-            </h2>
+          <div
+            className={cn(
+              "flex items-center gap-3",
+              isMobile ? "justify-end" : "justify-between",
+            )}
+          >
+            {!isMobile && (
+              <h2 className="text-[24px] font-semibold leading-8 text-foreground">
+                My Lists
+              </h2>
+            )}
             <Button type="button" onClick={() => setCreateOpen(true)}>
               <Plus className="h-4 w-4" />
               New List
@@ -85,10 +95,17 @@ export function ListsView() {
   return (
     <div className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto max-w-2xl space-y-6">
-        <div className="flex items-center justify-end gap-3 md:justify-between">
-          <h2 className="hidden text-[24px] font-semibold leading-8 text-foreground md:block">
-            My Lists
-          </h2>
+        <div
+          className={cn(
+            "flex items-center gap-3",
+            isMobile ? "justify-end" : "justify-between",
+          )}
+        >
+          {!isMobile && (
+            <h2 className="text-[24px] font-semibold leading-8 text-foreground">
+              My Lists
+            </h2>
+          )}
           <Button type="button" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />
             New List

--- a/src/components/lists-view.tsx
+++ b/src/components/lists-view.tsx
@@ -43,8 +43,8 @@ export function ListsView() {
     return (
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="mx-auto max-w-2xl space-y-6">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-[24px] font-semibold leading-8 text-foreground">
+          <div className="flex items-center justify-end gap-3 md:justify-between">
+            <h2 className="hidden text-[24px] font-semibold leading-8 text-foreground md:block">
               My Lists
             </h2>
             <Button type="button" onClick={() => setCreateOpen(true)}>
@@ -85,8 +85,8 @@ export function ListsView() {
   return (
     <div className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto max-w-2xl space-y-6">
-        <div className="flex items-center justify-between gap-3">
-          <h2 className="text-[24px] font-semibold leading-8 text-foreground">
+        <div className="flex items-center justify-end gap-3 md:justify-between">
+          <h2 className="hidden text-[24px] font-semibold leading-8 text-foreground md:block">
             My Lists
           </h2>
           <Button type="button" onClick={() => setCreateOpen(true)}>

--- a/src/components/meals/week-header.tsx
+++ b/src/components/meals/week-header.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks";
 import {
   addWeeksLocal,
   formatLocalDate,
@@ -31,6 +32,7 @@ export function WeekHeader({
   readOnly,
   onWeekChange,
 }: WeekHeaderProps) {
+  const isMobile = useIsMobile();
   const currentStart = parseLocalDate(weekStartDate);
 
   return (
@@ -38,9 +40,9 @@ export function WeekHeader({
       <div>
         <div className="flex flex-wrap items-center gap-2">
           {/* Title is redundant with the mobile module-aware header; desktop keeps it. */}
-          <h1 className="hidden text-2xl font-semibold text-foreground md:block">
-            Meals
-          </h1>
+          {!isMobile && (
+            <h1 className="text-2xl font-semibold text-foreground">Meals</h1>
+          )}
           {readOnly ? (
             <span className="rounded-full bg-muted px-2 py-1 text-xs font-semibold text-muted-foreground">
               Review only

--- a/src/components/meals/week-header.tsx
+++ b/src/components/meals/week-header.tsx
@@ -37,7 +37,10 @@ export function WeekHeader({
     <div className="flex items-start justify-between gap-3">
       <div>
         <div className="flex flex-wrap items-center gap-2">
-          <h1 className="text-2xl font-semibold text-foreground">Meals</h1>
+          {/* Title is redundant with the mobile module-aware header; desktop keeps it. */}
+          <h1 className="hidden text-2xl font-semibold text-foreground md:block">
+            Meals
+          </h1>
           {readOnly ? (
             <span className="rounded-full bg-muted px-2 py-1 text-xs font-semibold text-muted-foreground">
               Review only

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/recipes/recipe-filter-bar";
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
 import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks";
 import { formatRecipeTag } from "@/lib/recipe-tags";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
 import type { RecipeSummary } from "@/lib/types";
@@ -70,6 +71,7 @@ function sortRecipes(recipes: RecipeSummary[], isSearching: boolean) {
 }
 
 export function RecipesView() {
+  const isMobile = useIsMobile();
   const { data, error, isLoading, isError, refetch, isRefetching } =
     useRecipes();
   const recipeCreationDraft = useAppStore((state) => state.recipeCreationDraft);
@@ -145,14 +147,23 @@ export function RecipesView() {
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-4">
-        <div className="flex items-start justify-end gap-3 md:justify-between">
+        <div
+          className={cn(
+            "flex items-start gap-3",
+            isMobile ? "justify-end" : "justify-between",
+          )}
+        >
           {/* Title is redundant with the mobile header; desktop keeps it. */}
-          <div className="hidden md:block">
-            <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
-            <p className="text-sm text-muted-foreground">
-              Save family favorites and discover what to cook next.
-            </p>
-          </div>
+          {!isMobile && (
+            <div>
+              <h1 className="text-2xl font-semibold text-foreground">
+                Recipes
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                Save family favorites and discover what to cook next.
+              </p>
+            </div>
+          )}
           {selectedRecipeId === null ? (
             <Button type="button" onClick={() => setIsCreateSheetOpen(true)}>
               Add recipe

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -145,8 +145,9 @@ export function RecipesView() {
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
       <div className="mx-auto flex max-w-3xl flex-col gap-4">
-        <div className="flex items-start justify-between gap-3">
-          <div>
+        <div className="flex items-start justify-end gap-3 md:justify-between">
+          {/* Title is redundant with the mobile header; desktop keeps it. */}
+          <div className="hidden md:block">
             <h1 className="text-2xl font-semibold text-foreground">Recipes</h1>
             <p className="text-sm text-muted-foreground">
               Save family favorites and discover what to cook next.

--- a/src/components/shared/app-header.test.tsx
+++ b/src/components/shared/app-header.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore, useCalendarStore } from "@/stores";
 import {
+  act,
   render,
   renderWithUser,
   screen,
@@ -45,6 +46,35 @@ describe("AppHeader (mobile)", () => {
     expect(screen.getByText("June 2026")).toBeInTheDocument();
   });
 
+  it("updates the calendar context label live as the view and date change", () => {
+    useAppStore.setState({ activeModule: "calendar" });
+    seedCalendarStore({
+      calendarView: "monthly",
+      currentDate: new Date(2026, 5, 11),
+    });
+    render(<AppHeader />);
+    expect(screen.getByText("June 2026")).toBeInTheDocument();
+
+    // Switching to the daily view + a new date should re-render the label.
+    act(() => {
+      seedCalendarStore({
+        calendarView: "daily",
+        currentDate: new Date(2026, 6, 4),
+      });
+    });
+    expect(screen.queryByText("June 2026")).toBeNull();
+    expect(screen.getByText(/Jul 4/)).toBeInTheDocument();
+
+    // And navigating to a different month while monthly updates it again.
+    act(() => {
+      seedCalendarStore({
+        calendarView: "monthly",
+        currentDate: new Date(2026, 11, 25),
+      });
+    });
+    expect(screen.getByText("December 2026")).toBeInTheDocument();
+  });
+
   it("exposes exactly one header control (Menu) outside Calendar", () => {
     useAppStore.setState({ activeModule: "lists" });
     render(<AppHeader />);
@@ -66,8 +96,10 @@ describe("AppHeader (mobile)", () => {
     expect(today).toBeInTheDocument();
 
     await user.click(today);
-    expect(useCalendarStore.getState().currentDate.getFullYear()).toBe(
-      new Date().getFullYear(),
-    );
+    const current = useCalendarStore.getState().currentDate;
+    const now = new Date();
+    expect(current.getFullYear()).toBe(now.getFullYear());
+    expect(current.getMonth()).toBe(now.getMonth());
+    expect(current.getDate()).toBe(now.getDate());
   });
 });

--- a/src/components/shared/app-header.test.tsx
+++ b/src/components/shared/app-header.test.tsx
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, seedFamilyStore } from "@/test/test-utils";
+import { useAppStore, useCalendarStore } from "@/stores";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedCalendarStore,
+  seedFamilyStore,
+} from "@/test/test-utils";
 import { AppHeader } from "./app-header";
 
 vi.mock("@/hooks", async (importOriginal) => {
@@ -15,9 +22,52 @@ describe("AppHeader (mobile)", () => {
     });
   });
 
-  it("exposes exactly one header control: Menu", () => {
+  it("shows the family name on Home (no active module)", () => {
+    useAppStore.setState({ activeModule: null });
+    render(<AppHeader />);
+    expect(screen.getByText("Test Family")).toBeInTheDocument();
+  });
+
+  it("shows the module name when a non-calendar module is active", () => {
+    useAppStore.setState({ activeModule: "chores" });
+    render(<AppHeader />);
+    expect(screen.getByText("Chores")).toBeInTheDocument();
+    expect(screen.queryByText("Test Family")).toBeNull();
+  });
+
+  it("shows the live calendar context label on Calendar", () => {
+    useAppStore.setState({ activeModule: "calendar" });
+    seedCalendarStore({
+      calendarView: "monthly",
+      currentDate: new Date(2026, 5, 11),
+    });
+    render(<AppHeader />);
+    expect(screen.getByText("June 2026")).toBeInTheDocument();
+  });
+
+  it("exposes exactly one header control (Menu) outside Calendar", () => {
+    useAppStore.setState({ activeModule: "lists" });
     render(<AppHeader />);
     expect(screen.getByRole("button", { name: /menu/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /today/i })).toBeNull();
     expect(screen.getAllByRole("button")).toHaveLength(1);
+  });
+
+  it("renders Today + Menu on Calendar and Today resets the date", async () => {
+    useAppStore.setState({ activeModule: "calendar" });
+    seedCalendarStore({
+      calendarView: "monthly",
+      currentDate: new Date(2020, 0, 1),
+    });
+    const { user } = renderWithUser(<AppHeader />);
+
+    expect(screen.getByRole("button", { name: /menu/i })).toBeInTheDocument();
+    const today = screen.getByRole("button", { name: /today/i });
+    expect(today).toBeInTheDocument();
+
+    await user.click(today);
+    expect(useCalendarStore.getState().currentDate.getFullYear()).toBe(
+      new Date().getFullYear(),
+    );
   });
 });

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,14 +1,31 @@
 import { Cloud, Menu, Sun } from "lucide-react";
 import { useFamilyMembers, useFamilyName } from "@/api";
+import { getContextLabel } from "@/components/calendar/utils/context-label";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { useAppStore, useCalendarStore } from "@/stores";
+import {
+  type ModuleType,
+  useAppStore,
+  useCalendarStore,
+  useIsViewingToday,
+} from "@/stores";
+
+const MODULE_TITLES: Record<Exclude<ModuleType, "calendar">, string> = {
+  lists: "Lists",
+  chores: "Chores",
+  meals: "Meals",
+  recipes: "Recipes",
+  photos: "Photos",
+};
 
 export function AppHeader() {
   // From calendar-store
   const currentDate = useCalendarStore((state) => state.currentDate);
+  const calendarView = useCalendarStore((state) => state.calendarView);
+  const goToToday = useCalendarStore((state) => state.goToToday);
+  const isViewingToday = useIsViewingToday();
 
   // From family-store
   const familyName = useFamilyName();
@@ -16,6 +33,7 @@ export function AppHeader() {
 
   // From app-store
   const openSidebar = useAppStore((state) => state.openSidebar);
+  const activeModule = useAppStore((state) => state.activeModule);
 
   // Mobile detection
   const isMobile = useIsMobile();
@@ -36,15 +54,60 @@ export function AppHeader() {
     });
   };
 
+  // Mobile: a single module-aware row — title left, contextual actions + Menu
+  // right. The title reflects where you are (family name on Home, calendar
+  // context label on Calendar, module name elsewhere).
+  if (isMobile) {
+    const mobileTitle =
+      activeModule === null
+        ? familyName || "Family Hub"
+        : activeModule === "calendar"
+          ? getContextLabel(calendarView, currentDate)
+          : MODULE_TITLES[activeModule];
+
+    return (
+      <header className="shrink-0 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 flex items-center justify-between gap-3 min-h-16 px-4 py-3">
+        <h1 className="min-w-0 truncate text-[22px] leading-7 font-semibold text-foreground">
+          {mobileTitle}
+        </h1>
+        <div className="flex shrink-0 items-center gap-2">
+          {activeModule === "calendar" && (
+            <button
+              type="button"
+              onClick={goToToday}
+              className={cn(
+                "rounded-lg px-2.5 py-1.5 text-sm leading-5 font-semibold transition-colors",
+                isViewingToday
+                  ? "text-primary/50"
+                  : "text-primary hover:bg-primary/10",
+              )}
+            >
+              Today
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={openSidebar}
+            aria-label="Menu"
+            className="-my-1 flex h-11 w-11 items-center justify-center rounded-lg text-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        </div>
+      </header>
+    );
+  }
+
+  // Desktop: unchanged — Menu left + family name + date/time, weather, dots.
   return (
     <header
       className={cn(
         "shrink-0 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85",
         "flex items-center justify-between",
-        isMobile ? "min-h-16 px-4 py-3" : "px-6 py-4",
+        "px-6 py-4",
       )}
     >
-      <div className={cn("flex items-center", isMobile ? "gap-3" : "gap-4")}>
+      <div className="flex items-center gap-4">
         <Button
           variant="ghost"
           size="icon"
@@ -58,31 +121,26 @@ export function AppHeader() {
           <h1 className="text-[22px] leading-7 font-semibold text-foreground">
             {familyName || "Family Hub"}
           </h1>
-          {/* Date/time - hidden on mobile (device shows in status bar) */}
-          {!isMobile && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{formatDate(currentDate)}</span>
-              <span>•</span>
-              <span>{formatTime(new Date())}</span>
-            </div>
-          )}
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span>{formatDate(currentDate)}</span>
+            <span>•</span>
+            <span>{formatTime(new Date())}</span>
+          </div>
         </div>
       </div>
 
-      <div className={cn("flex items-center", isMobile ? "gap-2" : "gap-6")}>
-        {/* Weather - hidden on mobile (future: widget on desktop) */}
-        {!isMobile && (
-          <div className="flex items-center gap-2 text-muted-foreground">
-            <div className="relative">
-              <Sun className="h-5 w-5 text-yellow-500" />
-              <Cloud className="h-4 w-4 text-gray-400 absolute -bottom-1 -right-1" />
-            </div>
-            <span className="text-sm font-medium">72°</span>
+      <div className="flex items-center gap-6">
+        {/* Weather - future: real widget */}
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="relative">
+            <Sun className="h-5 w-5 text-yellow-500" />
+            <Cloud className="h-4 w-4 text-gray-400 absolute -bottom-1 -right-1" />
           </div>
-        )}
+          <span className="text-sm font-medium">72°</span>
+        </div>
 
-        {/* Family member indicators - hidden on mobile (used for calendar filtering) */}
-        {!isMobile && familyMembers.length > 0 && (
+        {/* Family member indicators - used for calendar filtering */}
+        {familyMembers.length > 0 && (
           <div className="flex items-center gap-1.5">
             {familyMembers.slice(0, 6).map((member) => (
               <div


### PR DESCRIPTION
Closes #201

Generalizes Calendar's mobile pattern into a single **module-aware shared header** across all modules: title left, contextual actions + Menu right. Removes the `App.tsx` calendar gate and the duplicate per-module in-content titles on mobile. **FE-only; desktop header and desktop module titles are untouched.**

Implemented from the linked Spec/Plan (root repo `joe-bor/family-hub`), which were readable; executed task-by-task with TDD.

## Execution contract → code + test

| # | Contract item | Code | Test |
|---|---|---|---|
| 1 | Mobile header: single row, title left, actions + Menu (`h-11 w-11`, `aria-label="Menu"`) right, all modules; desktop untouched | `src/components/shared/app-header.tsx` (early-return mobile block; desktop JSX unchanged) | `app-header.test.tsx` (Menu present, exactly one control outside Calendar); `App.shell.test.tsx` |
| 2 | Title map: Home→family name, calendar→`getContextLabel`, others→module name; `getContextLabel` extracted to a shared calendar util | `src/components/calendar/utils/context-label.ts` (new), `app-header.tsx` `MODULE_TITLES`, `mobile-toolbar.tsx` imports it | `app-header.test.tsx` (family name on Home, "Chores" on chores, "June 2026" on Calendar) |
| 3 | Today renders in header (same `useIsViewingToday` dimming + `goToToday`); toolbar keeps only controls row + member-filter init effect; chrome no taller | `app-header.tsx` (Today for `calendar`), `mobile-toolbar.tsx` (Row 1 removed, init effect kept), `calendar-module.tsx` (drop `onOpenSidebar`) | `app-header.test.tsx` (Today resets date), `mobile-toolbar.test.tsx` (no Today/Menu in toolbar; pills + dots remain) |
| 4 | `App.tsx` renders `<AppHeader />` unconditionally | `src/App.tsx` (gate deleted) | `App.shell.test.tsx` (header present on mobile calendar) |
| 5 | Duplicate titles hidden on mobile only (Chores h1, Recipes h1+subtitle, Lists "My Lists" both branches); desktop intact; action buttons stay in content | `chores-view.tsx` (`!isMobile`), `recipes-view.tsx` + `lists-view.tsx` (`hidden md:block`) | existing `lists`/`chores`/`recipes` suites pass; E2E heading assertions updated |

## Acceptance criteria

- [x] Mobile: exactly one header row on Home/Calendar/Lists/Chores/Meals/Recipes; Menu on the right opens the sidebar from every module
- [x] Titles: family name (Home), module names, live calendar context label (updates with view/date nav)
- [x] Calendar: Today works from the header (dimmed on today); pills + member dots in the controls row; member-filter init still runs
- [x] No duplicate static module titles under the mobile header; desktop module titles unchanged
- [x] `App.tsx` has no calendar-specific header gate
- [x] Calendar chrome no taller than today — **measured 115.75px = identical to `main` (115.75px)** at 390×844
- [x] Desktop header pixel-identical
- [x] lint + unit + E2E green

## Verification

- `npm run lint` — clean
- `npm run test -- --run` — **878 passed** (77 files)
- `npm run test:e2e` — **68 passed, 60 skipped, 0 failed** (real backend, BE release `1.5.0`, resolved the same way CI does)
- Visual smoke at **390×844**: Calendar (one row: context label + Today + Menu, controls row below), Chores ("Chores" + Menu; scope switcher + `+` stay in content), Lists ("Lists" + Menu; "New List" right) — each shows its name once. **Desktop (1280px)**: header unchanged (Menu left, family name + date/time, weather, member dots).

## Drift noted

- **Meals title.** The spec assumed Meals had no static title (only a contextual `WeekHeader`). In fact `WeekHeader` (`src/components/meals/week-header.tsx`) renders a static `<h1>Meals</h1>`, which collided with the new header on mobile (duplicate title / strict-mode E2E failure). To honor the no-duplicate-title acceptance criterion while keeping the `WeekHeader` week-navigation chrome, the static `Meals` title is hidden on mobile (`hidden md:block`); desktop keeps it. The `WeekHeader` component itself is retained.
- **Calendar chrome height.** The spec's uniform `min-h-16` header (64px) plus a controls row would have been ~16px taller than the old two-row toolbar. The standalone controls row's vertical padding was tightened (`py-1`) so total chrome equals the previous toolbar exactly (115.75px), satisfying the "no taller than today" criterion without shrinking the shared header or member touch targets.

## Device-pass items

Verified via 390×844 emulation (iPhone 14 Playwright device). A real-device pass on a small Android (Galaxy S10, the original F1 report device) is still worthwhile to confirm the tightened controls-row spacing and one-row header feel right in-hand — no behavioral risk expected.
