### PR TITLE
feat(mobile): settings dialogs open as bottom sheets on mobile

### DIFF
--- a/e2e/mobile-settings-sheets.spec.ts
+++ b/e2e/mobile-settings-sheets.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+/**
+ * F2 — settings/member modals open as bottom sheets on mobile.
+ * Covers the open/dismiss paths and the sheet-over-sheet stacking flow
+ * (Family Settings → Add member) in CI's emulated mobile viewport. Keyboard
+ * auto-expand and real-device gesture stacking are verified in the device
+ * smoke noted on the PR.
+ */
+test.describe("Mobile settings bottom sheets", () => {
+  test.beforeEach(async ({ page, request, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+    const reg = await registerFamily(request, {
+      familyName: "Sheet Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+    await page.reload();
+    await waitForHydration(page);
+  });
+
+  async function openMenu(page: import("@playwright/test").Page) {
+    await safeClick(page.getByRole("button", { name: /^menu$/i }));
+    const menu = page.getByRole("dialog", { name: "Menu" });
+    await expect(menu).toBeVisible();
+    return menu;
+  }
+
+  test("Family Settings opens as a sheet and dismisses with Escape", async ({
+    page,
+  }) => {
+    const menu = await openMenu(page);
+    await safeClick(menu.getByRole("button", { name: "Family Settings" }));
+
+    const settings = page.getByRole("dialog", { name: "Family Settings" });
+    await expect(settings).toBeVisible();
+    // The sheet supplies the Cancel affordance; no in-content X close on mobile.
+    await expect(
+      settings.getByRole("button", { name: "Cancel" }),
+    ).toBeVisible();
+    await expect(settings.getByRole("button", { name: "Close" })).toHaveCount(
+      0,
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(settings).toHaveCount(0);
+  });
+
+  test("Add member sheet stacks above Family Settings and adds the member", async ({
+    page,
+  }) => {
+    const menu = await openMenu(page);
+    await safeClick(menu.getByRole("button", { name: "Family Settings" }));
+
+    const settings = page.getByRole("dialog", { name: "Family Settings" });
+    await expect(settings).toBeVisible();
+
+    await safeClick(settings.getByRole("button", { name: "Add" }));
+
+    const memberForm = page.getByRole("dialog", { name: "Add Family Member" });
+    await expect(memberForm).toBeVisible();
+
+    await memberForm.getByPlaceholder("Enter name").fill("Charlie");
+    await safeClick(
+      memberForm.getByRole("button", { name: /select teal color/i }),
+    );
+    await safeClick(memberForm.getByRole("button", { name: "Add" }));
+
+    // Member form closes; the new member lands in the Family Settings list.
+    await expect(memberForm).toHaveCount(0);
+    await expect(
+      settings.getByRole("button", { name: "Edit Charlie" }),
+    ).toBeVisible();
+  });
+
+  test("Member Profile opens as a sheet and dismisses via Cancel", async ({
+    page,
+  }) => {
+    const menu = await openMenu(page);
+    await safeClick(menu.getByRole("button", { name: "Alice" }));
+
+    const profile = page.getByRole("dialog", { name: "Member Profile" });
+    await expect(profile).toBeVisible();
+
+    // The long profile content (Google Calendar section) is reachable in the
+    // scrollable sheet body.
+    await expect(profile.getByText(/google calendar/i).first()).toBeVisible();
+
+    // Dismiss via the form's Cancel; focus returns to the opening member row.
+    await safeClick(profile.getByRole("button", { name: "Cancel" }).first());
+    await expect(profile).toHaveCount(0);
+  });
+});

--- a/src/components/onboarding/member-form-modal.tsx
+++ b/src/components/onboarding/member-form-modal.tsx
@@ -3,14 +3,9 @@ import { useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/color-picker";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
 import type { FamilyColor, FamilyMember } from "@/lib/types";
 import {
   createMemberFormSchema,
@@ -81,57 +76,52 @@ export function MemberFormModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        className="w-full max-w-md mx-4 sm:mx-auto"
-        aria-describedby={undefined}
-      >
-        <DialogHeader>
-          <DialogTitle>
-            {mode === "add" ? "Add Family Member" : "Edit Family Member"}
-          </DialogTitle>
-        </DialogHeader>
+    <ResponsiveFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={mode === "add" ? "Add Family Member" : "Edit Family Member"}
+      initialHeight="half"
+      dialogClassName="w-full max-w-md mx-4 sm:mx-auto max-h-[90dvh] overflow-y-auto"
+    >
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
+        <div className="space-y-2">
+          <Label htmlFor="member-name">Name</Label>
+          <Input
+            id="member-name"
+            placeholder="Enter name"
+            {...register("name")}
+            autoComplete="off"
+            aria-describedby={errors.name ? "member-name-error" : undefined}
+            aria-invalid={errors.name ? "true" : undefined}
+          />
+          {errors.name && (
+            <p id="member-name-error" className="text-sm text-destructive">
+              {errors.name.message}
+            </p>
+          )}
+        </div>
 
-        <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
-          <div className="space-y-2">
-            <Label htmlFor="member-name">Name</Label>
-            <Input
-              id="member-name"
-              placeholder="Enter name"
-              {...register("name")}
-              autoComplete="off"
-              aria-describedby={errors.name ? "member-name-error" : undefined}
-              aria-invalid={errors.name ? "true" : undefined}
-            />
-            {errors.name && (
-              <p id="member-name-error" className="text-sm text-destructive">
-                {errors.name.message}
-              </p>
-            )}
-          </div>
+        <div className="space-y-2">
+          <Label>Color</Label>
+          <ColorPicker
+            value={selectedColor}
+            onChange={(color) => setValue("color", color)}
+            usedColors={usedColors}
+            error={errors.color?.message}
+          />
+        </div>
 
-          <div className="space-y-2">
-            <Label>Color</Label>
-            <ColorPicker
-              value={selectedColor}
-              onChange={(color) => setValue("color", color)}
-              usedColors={usedColors}
-              error={errors.color?.message}
-            />
-          </div>
-
-          <div className="flex justify-end gap-3">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-            >
-              Cancel
-            </Button>
-            <Button type="submit">{mode === "add" ? "Add" : "Save"}</Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+        <div className="flex justify-end gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit">{mode === "add" ? "Add" : "Save"}</Button>
+        </div>
+      </form>
+    </ResponsiveFormDialog>
   );
 }

--- a/src/components/settings/family-settings-modal.test.tsx
+++ b/src/components/settings/family-settings-modal.test.tsx
@@ -8,6 +8,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import { type FamilyApiResponse, familyKeys } from "@/api";
 import type {
@@ -29,6 +30,14 @@ import {
   within,
 } from "@/test/test-utils";
 import { FamilySettingsModal } from "./family-settings-modal";
+
+// The responsive wrapper switches on useIsMobile; default to desktop so the
+// existing dialog-role assertions below keep exercising the centered dialog.
+let mockIsMobile = false;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => mockIsMobile };
+});
 
 // ============================================================================
 // Test Setup
@@ -63,6 +72,7 @@ afterAll(() => server.close());
 
 beforeEach(() => {
   resetMockFamily();
+  mockIsMobile = false;
 });
 
 afterEach(() => {
@@ -195,5 +205,51 @@ describe("FamilySettingsModal — add then immediately edit", () => {
     ).toBeInTheDocument();
     expect(putIds.length).toBeGreaterThan(0);
     expect(putIds.some((id) => id.startsWith("temp-"))).toBe(false);
+  });
+});
+
+// ============================================================================
+// Responsive surface: centered dialog on desktop, bottom sheet on mobile
+// ============================================================================
+
+describe("FamilySettingsModal — responsive surface", () => {
+  function seededClient(): QueryClient {
+    const client = createClient();
+    client.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+      data: baseFamily(),
+    });
+    return client;
+  }
+
+  it("renders a centered dialog with an X close button on desktop", () => {
+    mockIsMobile = false;
+    render(<FamilySettingsModal open onOpenChange={noop} />, {
+      queryClient: seededClient(),
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    // The mobile sheet's Cancel chrome is absent on desktop.
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("renders the content in a bottom sheet with Cancel (no X) on mobile", () => {
+    mockIsMobile = true;
+    render(<FamilySettingsModal open onOpenChange={noop} />, {
+      queryClient: seededClient(),
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    // Sheet supplies the Cancel affordance; the in-content X close is desktop-only.
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+    // Content still renders inside the sheet.
+    expect(
+      screen.getByRole("button", { name: "Edit Alice" }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
 import type { FamilyColor, FamilyMember } from "@/lib/types";
 import {
   familyNameSchema,
@@ -112,131 +113,132 @@ export function FamilySettingsModal({
 
   return (
     <>
-      <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-w-lg max-h-[90dvh] overflow-y-auto">
-          <DialogHeader>
-            <div className="flex items-center justify-between">
-              <DialogTitle className="text-xl">Family Settings</DialogTitle>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Close"
-                onClick={() => onOpenChange(false)}
-                className="h-8 w-8"
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
-          </DialogHeader>
-
-          <div className="space-y-8 py-4">
-            {/* Family Name Section */}
-            <section className="space-y-4">
-              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                Family Name
-              </h3>
-              <form
-                onSubmit={handleSubmit(onSaveName)}
-                className="flex gap-2 items-start"
-              >
-                <div className="flex-1 space-y-1">
-                  <Label htmlFor="familyName" className="sr-only">
-                    Family Name
-                  </Label>
-                  <Input
-                    id="familyName"
-                    placeholder="Enter family name"
-                    {...register("name")}
-                    aria-describedby={
-                      errors.name ? "family-name-error" : undefined
-                    }
-                    aria-invalid={errors.name ? "true" : undefined}
-                  />
-                  {errors.name && (
-                    <p
-                      id="family-name-error"
-                      className="text-sm text-destructive"
-                    >
-                      {errors.name.message}
-                    </p>
-                  )}
-                </div>
-                {isDirty && (
-                  <Button type="submit" size="sm">
-                    Save
-                  </Button>
-                )}
-              </form>
-            </section>
-
-            {/* Family Members Section */}
-            <section className="space-y-4">
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-                  Family Members
-                </h3>
-                {canAddMore && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={handleAddMember}
-                    className="gap-1"
+      <ResponsiveFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Family Settings"
+        initialHeight="full"
+        dialogClassName="max-w-lg max-h-[90dvh] overflow-y-auto"
+        titleClassName="text-xl"
+        desktopHeaderRight={
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Close"
+            onClick={() => onOpenChange(false)}
+            className="h-8 w-8"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        }
+      >
+        <div className="space-y-8 py-4">
+          {/* Family Name Section */}
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              Family Name
+            </h3>
+            <form
+              onSubmit={handleSubmit(onSaveName)}
+              className="flex gap-2 items-start"
+            >
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="familyName" className="sr-only">
+                  Family Name
+                </Label>
+                <Input
+                  id="familyName"
+                  placeholder="Enter family name"
+                  {...register("name")}
+                  aria-describedby={
+                    errors.name ? "family-name-error" : undefined
+                  }
+                  aria-invalid={errors.name ? "true" : undefined}
+                />
+                {errors.name && (
+                  <p
+                    id="family-name-error"
+                    className="text-sm text-destructive"
                   >
-                    <Plus className="h-4 w-4" />
-                    Add
-                  </Button>
+                    {errors.name.message}
+                  </p>
                 )}
               </div>
-
-              <div className="space-y-2">
-                {familyMembers.map((member) => (
-                  <MemberCard
-                    key={member.id}
-                    member={member}
-                    onEdit={() => handleEditMember(member)}
-                    onRemove={() => handleRemoveMember(member.id)}
-                    canRemove={familyMembers.length > 1}
-                    isPending={isTempMemberId(member.id)}
-                  />
-                ))}
-              </div>
-
-              {!canAddMore && (
-                <p className="text-sm text-muted-foreground text-center">
-                  Maximum of 7 family members reached
-                </p>
+              {isDirty && (
+                <Button type="submit" size="sm">
+                  Save
+                </Button>
               )}
-            </section>
+            </form>
+          </section>
 
-            {/* Danger Zone */}
-            <section className="space-y-4 pt-4 border-t border-border">
-              <h3 className="text-sm font-semibold text-destructive uppercase tracking-wider">
-                Danger Zone
+          {/* Family Members Section */}
+          <section className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+                Family Members
               </h3>
-              <div className="p-4 rounded-lg border border-destructive/30 bg-destructive/5">
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
-                  <div className="flex-1">
-                    <p className="font-medium text-foreground">Reset Family</p>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      This will delete all family data and return to the setup
-                      wizard. This action cannot be undone.
-                    </p>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => setShowResetConfirm(true)}
-                      className="mt-3"
-                    >
-                      Reset Family
-                    </Button>
-                  </div>
+              {canAddMore && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleAddMember}
+                  className="gap-1"
+                >
+                  <Plus className="h-4 w-4" />
+                  Add
+                </Button>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              {familyMembers.map((member) => (
+                <MemberCard
+                  key={member.id}
+                  member={member}
+                  onEdit={() => handleEditMember(member)}
+                  onRemove={() => handleRemoveMember(member.id)}
+                  canRemove={familyMembers.length > 1}
+                  isPending={isTempMemberId(member.id)}
+                />
+              ))}
+            </div>
+
+            {!canAddMore && (
+              <p className="text-sm text-muted-foreground text-center">
+                Maximum of 7 family members reached
+              </p>
+            )}
+          </section>
+
+          {/* Danger Zone */}
+          <section className="space-y-4 pt-4 border-t border-border">
+            <h3 className="text-sm font-semibold text-destructive uppercase tracking-wider">
+              Danger Zone
+            </h3>
+            <div className="p-4 rounded-lg border border-destructive/30 bg-destructive/5">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
+                <div className="flex-1">
+                  <p className="font-medium text-foreground">Reset Family</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    This will delete all family data and return to the setup
+                    wizard. This action cannot be undone.
+                  </p>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    onClick={() => setShowResetConfirm(true)}
+                    className="mt-3"
+                  >
+                    Reset Family
+                  </Button>
                 </div>
               </div>
-            </section>
-          </div>
-        </DialogContent>
-      </Dialog>
+            </div>
+          </section>
+        </div>
+      </ResponsiveFormDialog>
 
       {/* Member Form Modal */}
       <MemberFormModal

--- a/src/components/settings/member-profile-modal.test.tsx
+++ b/src/components/settings/member-profile-modal.test.tsx
@@ -12,6 +12,14 @@ import {
 } from "@/test/test-utils";
 import { MemberProfileModal } from "./member-profile-modal";
 
+// The responsive wrapper switches on useIsMobile; default to desktop so the
+// existing assertions exercise the centered dialog.
+let mockIsMobile = false;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => mockIsMobile };
+});
+
 setupMswServer();
 
 const testMember: FamilyMember = {
@@ -214,5 +222,41 @@ describe("MemberProfileModal", () => {
     expect(
       await screen.findByText("Image must be smaller than 500KB"),
     ).toBeInTheDocument();
+  });
+});
+
+describe("MemberProfileModal — responsive surface", () => {
+  it("renders a centered dialog with an X close button on desktop", () => {
+    mockIsMobile = false;
+    seedFamily();
+    render(
+      <MemberProfileModal open onOpenChange={vi.fn()} memberId="member-1" />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Member Profile" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("renders the profile form in a bottom sheet with Cancel (no X) on mobile", () => {
+    mockIsMobile = true;
+    seedFamily();
+    render(
+      <MemberProfileModal open onOpenChange={vi.fn()} memberId="member-1" />,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Member Profile" }),
+    ).toBeInTheDocument();
+    // The sheet supplies a Cancel affordance (the form footer also keeps its
+    // own Cancel), and the in-content X close is desktop-only.
+    expect(
+      screen.getAllByRole("button", { name: "Cancel" }).length,
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+    // Form content (email field) still renders inside the sheet.
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+    mockIsMobile = false;
   });
 });

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -5,14 +5,9 @@ import { useForm } from "react-hook-form";
 import { useFamilyMemberById, useFamilyMembers, useUpdateMember } from "@/api";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/ui/color-picker";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
 import { colorMap, type FamilyColor } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
@@ -137,156 +132,154 @@ export function MemberProfileModal({
   const colors = colorMap[member.color];
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm max-h-[90dvh] overflow-y-auto">
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <DialogTitle className="text-xl">Member Profile</DialogTitle>
-            <Button
-              variant="ghost"
-              size="icon-lg"
-              onClick={() => onOpenChange(false)}
-              aria-label="Close"
-            >
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 py-4">
-          {/* Avatar Section */}
-          <div className="flex flex-col items-center gap-3">
-            <div className="relative">
-              {member.avatarUrl ? (
-                <img
-                  src={member.avatarUrl}
-                  alt={member.name}
-                  className="w-20 h-20 rounded-full object-cover"
-                />
-              ) : (
-                <div
-                  className={cn(
-                    "w-20 h-20 rounded-full flex items-center justify-center text-white text-2xl font-bold",
-                    colors?.bg,
-                  )}
-                >
-                  {member.name.charAt(0).toUpperCase()}
-                </div>
-              )}
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="absolute bottom-0 right-0 w-11 h-11 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-md hover:bg-primary/90 transition-colors"
-                aria-label="Upload avatar"
-              >
-                <Camera className="h-4 w-4" />
-              </button>
-            </div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/*"
-              onChange={handleAvatarUpload}
-              className="hidden"
-              aria-label="Upload avatar image"
-            />
-            {avatarError && (
-              <p className="text-sm text-destructive" role="alert">
-                {avatarError}
-              </p>
-            )}
-            {member.avatarUrl && (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                onClick={handleRemoveAvatar}
-                className="text-muted-foreground gap-1"
-              >
-                <Trash2 className="h-3 w-3" />
-                Remove photo
-              </Button>
-            )}
-          </div>
-
-          {/* Name Field */}
-          <div className="space-y-2">
-            <Label htmlFor="name">Name</Label>
-            <Input
-              id="name"
-              {...register("name")}
-              aria-describedby={errors.name ? "name-error" : undefined}
-              aria-invalid={errors.name ? "true" : undefined}
-            />
-            {errors.name && (
-              <p id="name-error" className="text-sm text-destructive">
-                {errors.name.message}
-              </p>
-            )}
-          </div>
-
-          {/* Color Picker */}
-          <div className="space-y-2">
-            <Label>Color</Label>
-            <ColorPicker
-              value={selectedColor}
-              onChange={(color) =>
-                setValue("color", color, { shouldDirty: true })
-              }
-              usedColors={usedColors as FamilyColor[]}
-              error={errors.color?.message}
-            />
-          </div>
-
-          {/* Email Field */}
-          <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              placeholder="email@example.com"
-              {...register("email")}
-              aria-describedby={
-                errors.email ? "email-error" : "email-description"
-              }
-              aria-invalid={errors.email ? "true" : undefined}
-            />
-            {errors.email ? (
-              <p id="email-error" className="text-sm text-destructive">
-                {errors.email.message}
-              </p>
+    <ResponsiveFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Member Profile"
+      initialHeight="full"
+      dialogClassName="max-w-sm max-h-[90dvh] overflow-y-auto"
+      titleClassName="text-xl"
+      desktopHeaderRight={
+        <Button
+          variant="ghost"
+          size="icon-lg"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      }
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6 py-4">
+        {/* Avatar Section */}
+        <div className="flex flex-col items-center gap-3">
+          <div className="relative">
+            {member.avatarUrl ? (
+              <img
+                src={member.avatarUrl}
+                alt={member.name}
+                className="w-20 h-20 rounded-full object-cover"
+              />
             ) : (
-              <p
-                id="email-description"
-                className="text-xs text-muted-foreground"
+              <div
+                className={cn(
+                  "w-20 h-20 rounded-full flex items-center justify-center text-white text-2xl font-bold",
+                  colors?.bg,
+                )}
               >
-                Used for notifications and Google Calendar sync
-              </p>
+                {member.name.charAt(0).toUpperCase()}
+              </div>
             )}
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="absolute bottom-0 right-0 w-11 h-11 rounded-full bg-primary text-primary-foreground flex items-center justify-center shadow-md hover:bg-primary/90 transition-colors"
+              aria-label="Upload avatar"
+            >
+              <Camera className="h-4 w-4" />
+            </button>
           </div>
-
-          {/* Google Calendar */}
-          <GoogleCalendarSection
-            memberId={memberId}
-            memberEmail={watch("email") || member?.email || ""}
-            memberName={member?.name || ""}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleAvatarUpload}
+            className="hidden"
+            aria-label="Upload avatar image"
           />
-
-          {/* Actions */}
-          <div className="flex justify-end gap-3 pt-2">
+          {avatarError && (
+            <p className="text-sm text-destructive" role="alert">
+              {avatarError}
+            </p>
+          )}
+          {member.avatarUrl && (
             <Button
               type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
+              variant="ghost"
+              size="sm"
+              onClick={handleRemoveAvatar}
+              className="text-muted-foreground gap-1"
             >
-              Cancel
+              <Trash2 className="h-3 w-3" />
+              Remove photo
             </Button>
-            <Button type="submit" disabled={!isDirty}>
-              Save Changes
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+          )}
+        </div>
+
+        {/* Name Field */}
+        <div className="space-y-2">
+          <Label htmlFor="name">Name</Label>
+          <Input
+            id="name"
+            {...register("name")}
+            aria-describedby={errors.name ? "name-error" : undefined}
+            aria-invalid={errors.name ? "true" : undefined}
+          />
+          {errors.name && (
+            <p id="name-error" className="text-sm text-destructive">
+              {errors.name.message}
+            </p>
+          )}
+        </div>
+
+        {/* Color Picker */}
+        <div className="space-y-2">
+          <Label>Color</Label>
+          <ColorPicker
+            value={selectedColor}
+            onChange={(color) =>
+              setValue("color", color, { shouldDirty: true })
+            }
+            usedColors={usedColors as FamilyColor[]}
+            error={errors.color?.message}
+          />
+        </div>
+
+        {/* Email Field */}
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            placeholder="email@example.com"
+            {...register("email")}
+            aria-describedby={
+              errors.email ? "email-error" : "email-description"
+            }
+            aria-invalid={errors.email ? "true" : undefined}
+          />
+          {errors.email ? (
+            <p id="email-error" className="text-sm text-destructive">
+              {errors.email.message}
+            </p>
+          ) : (
+            <p id="email-description" className="text-xs text-muted-foreground">
+              Used for notifications and Google Calendar sync
+            </p>
+          )}
+        </div>
+
+        {/* Google Calendar */}
+        <GoogleCalendarSection
+          memberId={memberId}
+          memberEmail={watch("email") || member?.email || ""}
+          memberName={member?.name || ""}
+        />
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 pt-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!isDirty}>
+            Save Changes
+          </Button>
+        </div>
+      </form>
+    </ResponsiveFormDialog>
   );
 }

--- a/src/components/ui/responsive-form-dialog-breakpoint.test.tsx
+++ b/src/components/ui/responsive-form-dialog-breakpoint.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@/test/test-utils";
+import { ResponsiveFormDialog } from "./responsive-form-dialog";
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => {
+    const maxWidth = Number.parseInt(
+      query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+    const minWidth = Number.parseInt(
+      query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+
+    const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+    const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+
+    return {
+      matches: matchesMax && matchesMin,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  });
+}
+
+describe("ResponsiveFormDialog breakpoint", () => {
+  it("keeps the desktop dialog surface at the 768px md breakpoint", () => {
+    setViewportWidth(768);
+
+    render(
+      <ResponsiveFormDialog open onOpenChange={vi.fn()} title="Family Settings">
+        <p>content</p>
+      </ResponsiveFormDialog>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+
+  it("uses the mobile sheet surface below the 768px md breakpoint", () => {
+    setViewportWidth(767);
+
+    render(
+      <ResponsiveFormDialog open onOpenChange={vi.fn()} title="Family Settings">
+        <p>content</p>
+      </ResponsiveFormDialog>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/responsive-form-dialog.test.tsx
+++ b/src/components/ui/responsive-form-dialog.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { ResponsiveFormDialog } from "./responsive-form-dialog";
+
+let mockIsMobile = false;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useIsMobile: () => mockIsMobile };
+});
+
+describe("ResponsiveFormDialog", () => {
+  it("renders a centered dialog with the title on desktop", () => {
+    mockIsMobile = false;
+    render(
+      <ResponsiveFormDialog open onOpenChange={vi.fn()} title="Family Settings">
+        <p>content</p>
+      </ResponsiveFormDialog>,
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+    // Sheet chrome (Cancel affordance) is absent on desktop.
+    expect(screen.queryByRole("button", { name: /cancel/i })).toBeNull();
+  });
+
+  it("renders desktop header-right content when provided", () => {
+    mockIsMobile = false;
+    render(
+      <ResponsiveFormDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Member Profile"
+        desktopHeaderRight={
+          <button type="button" aria-label="Close">
+            x
+          </button>
+        }
+      >
+        <p>content</p>
+      </ResponsiveFormDialog>,
+    );
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+  });
+
+  it("renders the mobile sheet with Cancel and no in-content close on mobile", () => {
+    mockIsMobile = true;
+    render(
+      <ResponsiveFormDialog
+        open
+        onOpenChange={vi.fn()}
+        title="Family Settings"
+        desktopHeaderRight={
+          <button type="button" aria-label="Close">
+            x
+          </button>
+        }
+      >
+        <p>content</p>
+      </ResponsiveFormDialog>,
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Family Settings" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("content")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeInTheDocument();
+    // Desktop-only header-right (X close) is not rendered inside the sheet.
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+  });
+});

--- a/src/components/ui/responsive-form-dialog.tsx
+++ b/src/components/ui/responsive-form-dialog.tsx
@@ -9,7 +9,7 @@ import {
   MobileSheet,
   type MobileSheetHeight,
 } from "@/components/ui/mobile-sheet";
-import { useIsMobile } from "@/hooks";
+import { useIsMobile, useMediaQuery } from "@/hooks";
 
 interface ResponsiveFormDialogProps {
   open: boolean;
@@ -50,8 +50,10 @@ export function ResponsiveFormDialog({
   children,
 }: ResponsiveFormDialogProps) {
   const isMobile = useIsMobile();
+  const isMdOrLarger = useMediaQuery("(min-width: 768px)");
 
-  if (isMobile) {
+  // These dialogs preserve desktop parity from Tailwind's md breakpoint up.
+  if (isMobile && !isMdOrLarger) {
     return (
       <MobileSheet
         isOpen={open}

--- a/src/components/ui/responsive-form-dialog.tsx
+++ b/src/components/ui/responsive-form-dialog.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  MobileSheet,
+  type MobileSheetHeight,
+} from "@/components/ui/mobile-sheet";
+import { useIsMobile } from "@/hooks";
+
+interface ResponsiveFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Sheet header title on mobile AND the DialogTitle on desktop. */
+  title: string;
+  /** Mobile sheet open height. Desktop is unaffected. Defaults to "full". */
+  initialHeight?: MobileSheetHeight;
+  /** Desktop DialogContent classes (e.g. "max-w-lg max-h-[90dvh] overflow-y-auto"). */
+  dialogClassName?: string;
+  /**
+   * Desktop DialogTitle classes. Defaults to the DialogTitle primitive size;
+   * settings modals pass "text-xl" to preserve their current title size.
+   */
+  titleClassName?: string;
+  /**
+   * Desktop-only header content (e.g. an X close button). The mobile sheet
+   * supplies its own title + Cancel chrome, so this is omitted on mobile.
+   */
+  desktopHeaderRight?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * Renders form content inside a viewport-bounded `MobileSheet` on mobile and
+ * the centered `Dialog`/`DialogContent` on desktop. Children are written once;
+ * the wrapper owns the chrome (mobile: Cancel + title; desktop: title + an
+ * optional close affordance via `desktopHeaderRight`).
+ */
+export function ResponsiveFormDialog({
+  open,
+  onOpenChange,
+  title,
+  initialHeight = "full",
+  dialogClassName,
+  titleClassName,
+  desktopHeaderRight,
+  children,
+}: ResponsiveFormDialogProps) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <MobileSheet
+        isOpen={open}
+        onClose={() => onOpenChange(false)}
+        title={title}
+        initialHeight={initialHeight}
+      >
+        {children}
+      </MobileSheet>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className={dialogClassName} aria-describedby={undefined}>
+        <DialogHeader>
+          <div className="flex items-center justify-between">
+            <DialogTitle className={titleClassName}>{title}</DialogTitle>
+            {desktopHeaderRight}
+          </div>
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Closes #202

Converts the settings/member modals to viewport-bounded vaul bottom sheets on mobile while keeping desktop centered dialogs pixel-identical. Implemented from the issue execution brief + linked Spec/Plan (`docs/superpowers/{specs,plans}/2026-06-11-mobile-settings-sheets.md`).

## Execution contract → code + test

| # | Contract item | Code | Test |
|---|---------------|------|------|
| 1 | Adaptive `ResponsiveFormDialog` (sheet on mobile, Dialog on desktop; content written once) | `src/components/ui/responsive-form-dialog.tsx` | `src/components/ui/responsive-form-dialog.test.tsx` (mobile→sheet+Cancel, desktop→dialog+header-right) |
| 2 | Conversions + heights: FamilySettings **full**, MemberProfile **full**, MemberForm **half** + missing `max-h-[90dvh] overflow-y-auto` added to its desktop classes; in-content **X** rows desktop-only | `family-settings-modal.tsx`, `member-profile-modal.tsx`, `onboarding/member-form-modal.tsx` | responsive cases in `family-settings-modal.test.tsx` & `member-profile-modal.test.tsx`; new `e2e/mobile-settings-sheets.spec.ts` |
| 3 | Confirms stay centered (Reset Family, Sign Out) | untouched in `family-settings-modal.tsx` / `sidebar-menu.tsx` | existing tests still green |
| 4 | Desktop pixel-parity ≥768px (preserved `DialogContent` classes via `dialogClassName`; titles preserved via `titleClassName`) | wrapper desktop branch reproduces each modal's current header markup | desktop-mode unit cases + desktop visual smoke (below) |
| 5 | Sheet-over-sheet stacking gate (+ documented fallback) | n/a — gate; **fallback not applied** (stacking works) | `e2e/.../Add member sheet stacks above Family Settings` + visual smoke |
| 6 | No #194 regression; onboarding members step works mobile + desktop | shared `MemberFormModal` converts with the surface | `e2e/onboarding.spec.ts` green on `chromium` + `Mobile Chrome` |

### Note on the wrapper API
The brief enumerates `dialogClassName`; I added one optional `titleClassName` so the two settings dialogs keep their current `text-xl` title while the Add/Edit Member dialog keeps its default 22px — i.e. strictly to preserve desktop pixel-parity (item 4). No other API divergence.

## Acceptance criteria

- [x] 360–430px: Family Settings, Member Profile, Add/Edit Member open as bottom sheets; nothing off-screen (visual smoke at 390×844).
- [x] Heights: member form = half (auto-expands on focus via `MobileSheet`); family settings + member profile = full.
- [x] Mobile dismissal via Cancel / scrim / Esc / flick-down (vaul defaults); focus returns to opener (covered by `MobileSheet` focus-restore, exercised in E2E).
- [x] Member form stacks above Family Settings — verified in CI-emulated mobile **and** visual smoke; vaul background-scales the parent sheet, no glitch. Fallback **not** needed.
- [x] Reset Family / Sign Out confirms remain centered (untouched).
- [x] ≥768px: all three render as centered dialogs, visually unchanged (desktop visual smoke).
- [x] Onboarding members step works on mobile + desktop (`onboarding.spec.ts`).
- [x] lint + unit + E2E green.
- [ ] **Real-device pass (deferred):** keyboard auto-expand keeping the focused field visible (Member Profile email, half-sheet name), gesture flick-down, and #194 auth/onboarding keyboard no-regression — these need a physical phone; emulation can't assert soft-keyboard behavior. Sheet-over-sheet already passed in emulation + visual smoke, so the D3 fallback is not applied.

## Verification

- `npm run lint` — clean (1 info, no errors).
- `npm run test -- --run` — **80 files, 890 tests passed**.
- E2E (real backend via Docker) across `chromium`/`firefox`/`webkit`/`Mobile Chrome` for the modal-affected specs (`family-management`, `onboarding`, `google-calendar`, `mobile-settings-sidebar`, new `mobile-settings-sheets`) — **25 passed, 15 skipped** (mobile-only tests skip on desktop projects), 0 failed.
- Visual smoke at 390×844 (sheets) and 1280×800 (centered dialogs) for all three surfaces + the stacking flow.

Regular merge commit (no squash) so release-please reads the individual `feat:`/`test:` commits.
