### PR TITLE
feat: sidebar Preferences entry + family preferences sheet (timezone + roadmap stubs)

### DIFF
--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -94,6 +94,60 @@ export async function safeClick(
 }
 
 /**
+ * Waits for a just-opened sheet/dialog to finish moving into place before
+ * interacting with its contents.
+ *
+ * Mobile sheets (vaul drawers, SideSheet) mount translated off-screen and
+ * slide in via a transform. toBeVisible() passes while the panel is still
+ * off-viewport, so safeClick's force:true click — which skips Playwright's
+ * own stability wait — computes its point against a not-yet-positioned
+ * target and misses, or errors with "Element is outside of the viewport"
+ * on slow CI runners. Even with reduced motion (instant transitions), vaul
+ * positions snap-point drawers from JS after mount, so there is a window
+ * where the sheet is visible but still fully below the viewport.
+ *
+ * Settled means: bounding box overlaps the viewport on both axes AND is
+ * unchanged across two consecutive polls. Stability alone is not enough —
+ * a pre-positioned sheet is motionless while fully off-viewport. Overlap
+ * (rather than fully-inside) is required because half-height vaul sheets
+ * rest with their lower half translated below the viewport by design.
+ */
+export async function waitForSheetSettled(
+  sheet: Locator,
+  options?: { timeout?: number },
+): Promise<void> {
+  const timeout = options?.timeout ?? 10000;
+  await expect(sheet).toBeVisible({ timeout });
+
+  const viewport = sheet.page().viewportSize();
+  let previous: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        const box = await sheet.boundingBox();
+        if (!box) {
+          previous = null;
+          return false;
+        }
+        // Pre-positioned sheets are translated exactly 100% off-screen, so
+        // requiring ≥1px of overlap on both axes excludes them.
+        const overlapsViewport =
+          viewport === null ||
+          (box.x + box.width >= 1 &&
+            box.x <= viewport.width - 1 &&
+            box.y + box.height >= 1 &&
+            box.y <= viewport.height - 1);
+        const current = [box.x, box.y, box.width, box.height].join(",");
+        const settled = overlapsViewport && current === previous;
+        previous = current;
+        return settled;
+      },
+      { timeout, intervals: [50, 100] },
+    )
+    .toBe(true);
+}
+
+/**
  * Enhanced dialog wait that returns the dialog locator for chaining.
  * - Checks visibility with expect() auto-retry
  * - Confirms data-state="open" attribute

--- a/e2e/mobile-settings-sheets.spec.ts
+++ b/e2e/mobile-settings-sheets.spec.ts
@@ -4,6 +4,7 @@ import {
   clearStorage,
   safeClick,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 /**
@@ -31,7 +32,7 @@ test.describe("Mobile settings bottom sheets", () => {
   async function openMenu(page: import("@playwright/test").Page) {
     await safeClick(page.getByRole("button", { name: /^menu$/i }));
     const menu = page.getByRole("dialog", { name: "Menu" });
-    await expect(menu).toBeVisible();
+    await waitForSheetSettled(menu);
     return menu;
   }
 
@@ -62,12 +63,12 @@ test.describe("Mobile settings bottom sheets", () => {
     await safeClick(menu.getByRole("button", { name: "Family Settings" }));
 
     const settings = page.getByRole("dialog", { name: "Family Settings" });
-    await expect(settings).toBeVisible();
+    await waitForSheetSettled(settings);
 
     await safeClick(settings.getByRole("button", { name: "Add" }));
 
     const memberForm = page.getByRole("dialog", { name: "Add Family Member" });
-    await expect(memberForm).toBeVisible();
+    await waitForSheetSettled(memberForm);
 
     await memberForm.getByPlaceholder("Enter name").fill("Charlie");
     await safeClick(
@@ -89,7 +90,7 @@ test.describe("Mobile settings bottom sheets", () => {
     await safeClick(menu.getByRole("button", { name: "Alice" }));
 
     const profile = page.getByRole("dialog", { name: "Member Profile" });
-    await expect(profile).toBeVisible();
+    await waitForSheetSettled(profile);
 
     // The long profile content (Google Calendar section) is reachable in the
     // scrollable sheet body.

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -4,6 +4,7 @@ import {
   clearStorage,
   safeClick,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 /**
@@ -32,11 +33,11 @@ test.describe("Preferences sheet", () => {
   async function openPreferences(page: import("@playwright/test").Page) {
     await safeClick(page.getByRole("button", { name: /^menu$/i }));
     const menu = page.getByRole("dialog", { name: "Menu" });
-    await expect(menu).toBeVisible();
+    await waitForSheetSettled(menu);
     await safeClick(menu.getByRole("button", { name: "Preferences" }));
 
     const preferences = page.getByRole("dialog", { name: "Preferences" });
-    await expect(preferences).toBeVisible();
+    await waitForSheetSettled(preferences);
     return preferences;
   }
 

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+/**
+ * Sidebar Preferences entry + family preferences sheet (#208).
+ * Runs on desktop and mobile projects: the sheet renders as a full-height
+ * bottom sheet below md and a centered dialog on desktop, but the flow and
+ * locators are identical.
+ */
+test.describe("Preferences sheet", () => {
+  let token: string;
+
+  test.beforeEach(async ({ page, request }) => {
+    await page.goto("/");
+    await clearStorage(page);
+    const reg = await registerFamily(request, {
+      familyName: "Prefs Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+      timezone: "America/Los_Angeles",
+    });
+    token = reg.token;
+    await seedBrowserAuth(page, reg);
+    await page.reload();
+    await waitForHydration(page);
+  });
+
+  async function openPreferences(page: import("@playwright/test").Page) {
+    await safeClick(page.getByRole("button", { name: /^menu$/i }));
+    const menu = page.getByRole("dialog", { name: "Menu" });
+    await expect(menu).toBeVisible();
+    await safeClick(menu.getByRole("button", { name: "Preferences" }));
+
+    const preferences = page.getByRole("dialog", { name: "Preferences" });
+    await expect(preferences).toBeVisible();
+    return preferences;
+  }
+
+  test("changes the family timezone and persists it across reload", async ({
+    page,
+    request,
+  }) => {
+    const preferences = await openPreferences(page);
+
+    // Shows the BE-stored zone, not a hardcoded default.
+    const select = preferences.getByLabel(/family timezone/i);
+    await expect(select).toHaveValue("America/Los_Angeles");
+
+    const putDone = page.waitForResponse(
+      (response) =>
+        response.url().includes("/api/family") &&
+        response.request().method() === "PUT" &&
+        response.ok(),
+    );
+    await select.selectOption("America/New_York");
+    await putDone;
+
+    // The change reached the backend, not just the local cache.
+    const familyResponse = await request.get(
+      "http://127.0.0.1:8080/api/family",
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(familyResponse.ok()).toBe(true);
+    const family = await familyResponse.json();
+    expect(family.data.timezone).toBe("America/New_York");
+
+    // Survives a full reload.
+    await page.reload();
+    await waitForHydration(page);
+    const reopened = await openPreferences(page);
+    await expect(reopened.getByLabel(/family timezone/i)).toHaveValue(
+      "America/New_York",
+    );
+  });
+
+  test("shows disabled Coming soon rows for Notifications and Appearance", async ({
+    page,
+  }) => {
+    const preferences = await openPreferences(page);
+
+    const notifications = preferences.getByRole("button", {
+      name: /notifications/i,
+    });
+    const appearance = preferences.getByRole("button", {
+      name: /appearance/i,
+    });
+    await expect(notifications).toBeDisabled();
+    await expect(appearance).toBeDisabled();
+  });
+});

--- a/src/api/hooks/use-family.test.tsx
+++ b/src/api/hooks/use-family.test.tsx
@@ -429,6 +429,28 @@ describe("useUpdateFamily", () => {
     );
   });
 
+  it("updates timezone without clobbering name", async () => {
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useUpdateFamily({ onSuccess }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ timezone: "America/New_York" });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: "Test Family",
+          timezone: "America/New_York",
+        }),
+      }),
+    );
+  });
+
   it("writes updated family to localStorage", async () => {
     const { result } = renderHook(() => useUpdateFamily(), {
       wrapper: createWrapper(),
@@ -852,6 +874,66 @@ describe("rollback on error", () => {
     );
     expect(cached?.data?.name).toBe("Test Family");
     expect(onError).toHaveBeenCalled();
+  });
+
+  it("useUpdateFamily applies timezone optimistically without clobbering name", async () => {
+    // Hold the PUT open so assertions observe the optimistic cache state,
+    // not the server response.
+    server.use(
+      http.put("http://localhost:3000/api/family", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+        return HttpResponse.json({ message: "too late" }, { status: 500 });
+      }),
+    );
+
+    const { result } = renderHook(() => useUpdateFamily(), {
+      wrapper: createRollbackWrapper(),
+    });
+
+    result.current.mutate({ timezone: "America/New_York" });
+
+    await waitFor(() => {
+      const cached = rollbackQueryClient.getQueryData<FamilyApiResponse>(
+        familyKeys.family(),
+      );
+      expect(cached?.data?.timezone).toBe("America/New_York");
+      expect(cached?.data?.name).toBe("Test Family");
+    });
+  });
+
+  it("useUpdateFamily rolls back timezone on BE validation error", async () => {
+    rollbackQueryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+      data: { ...testFamily, timezone: "America/Los_Angeles" },
+    });
+    server.use(
+      http.put("http://localhost:3000/api/family", () => {
+        return HttpResponse.json(
+          { message: "Timezone must be a valid IANA timezone." },
+          { status: 400 },
+        );
+      }),
+    );
+
+    const onError = vi.fn();
+    const { result } = renderHook(() => useUpdateFamily({ onError }), {
+      wrapper: createRollbackWrapper(),
+    });
+
+    result.current.mutate({ timezone: "Not/AZone" });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    const cached = rollbackQueryClient.getQueryData<FamilyApiResponse>(
+      familyKeys.family(),
+    );
+    expect(cached?.data?.timezone).toBe("America/Los_Angeles");
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Timezone must be a valid IANA timezone.",
+      }),
+    );
   });
 
   it("useAddMember removes optimistic member on server error", async () => {

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -240,9 +240,13 @@ export function useUpdateFamily(callbacks?: UpdateFamilyCallbacks) {
       );
 
       if (previousData?.data) {
+        // Partial update: fields left undefined are unchanged (BE semantics).
         const optimisticFamily: FamilyData = {
           ...previousData.data,
-          name: request.name,
+          ...(request.name !== undefined && { name: request.name }),
+          ...(request.timezone !== undefined && {
+            timezone: request.timezone,
+          }),
         };
         queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
           ...previousData,

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -2,3 +2,4 @@ export { FamilySettingsModal } from "./family-settings-modal";
 export { GoogleCalendarPickerModal } from "./google-calendar-picker-modal";
 export { GoogleCalendarSection } from "./google-calendar-section";
 export { MemberProfileModal } from "./member-profile-modal";
+export { PreferencesSheet } from "./preferences-sheet";

--- a/src/components/settings/preferences-sheet.test.tsx
+++ b/src/components/settings/preferences-sheet.test.tsx
@@ -1,0 +1,303 @@
+import { QueryClient } from "@tanstack/react-query";
+import { HttpResponse, http } from "msw";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { type FamilyApiResponse, familyKeys } from "@/api";
+import type { FamilyData, UpdateFamilyRequest } from "@/lib/types";
+import {
+  API_BASE,
+  resetMockFamily,
+  seedMockFamily,
+} from "@/test/mocks/handlers";
+import { server } from "@/test/mocks/server";
+import { render, renderWithUser, screen, waitFor } from "@/test/test-utils";
+import { PreferencesSheet } from "./preferences-sheet";
+
+// ============================================================================
+// Test Setup
+// ============================================================================
+
+function baseFamily(timezone?: string): FamilyData {
+  return {
+    id: "family-1",
+    name: "Test Family",
+    timezone,
+    members: [{ id: "member-1", name: "Alice", color: "coral" }],
+    createdAt: "2025-01-01T00:00:00.000Z",
+  };
+}
+
+/**
+ * Dedicated client with `gcTime`/`staleTime` of Infinity so the optimistic
+ * cache survives the test and no background refetch races our assertions.
+ */
+function createClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function seedClient(family: FamilyData): QueryClient {
+  seedMockFamily(family);
+  const client = createClient();
+  client.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+    data: family,
+  });
+  return client;
+}
+
+function getTimezoneSelect(): HTMLSelectElement {
+  return screen.getByLabelText(/family timezone/i);
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
+beforeEach(() => {
+  resetMockFamily();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+const noop = () => {};
+
+// ============================================================================
+// Timezone control
+// ============================================================================
+
+describe("PreferencesSheet — timezone", () => {
+  it("shows the timezone from the family API, not a hardcoded default", () => {
+    const client = seedClient(baseFamily("America/Chicago"));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    expect(getTimezoneSelect().value).toBe("America/Chicago");
+  });
+
+  it("selects nothing while the timezone is not yet known", () => {
+    // Pre-1.6.0 localStorage cache: family exists but carries no timezone.
+    const client = seedClient(baseFamily(undefined));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    expect(getTimezoneSelect().value).toBe("");
+  });
+
+  it("offers the current non-curated zone as a selectable option", () => {
+    const client = seedClient(baseFamily("Asia/Manila"));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    const select = getTimezoneSelect();
+    expect(select.value).toBe("Asia/Manila");
+    expect(
+      screen.getByRole("option", { name: /asia\/manila/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("saves a curated zone through PUT /family and updates optimistically", async () => {
+    const putBodies: UpdateFamilyRequest[] = [];
+    server.use(
+      http.put(`${API_BASE}/family`, async ({ request }) => {
+        const body = (await request.json()) as UpdateFamilyRequest;
+        putBodies.push(body);
+        return HttpResponse.json({
+          data: { ...baseFamily("America/Chicago"), ...body },
+          message: "Family updated successfully",
+        });
+      }),
+    );
+
+    const client = seedClient(baseFamily("America/Chicago"));
+    const { user } = renderWithUser(
+      <PreferencesSheet open onOpenChange={noop} />,
+      {
+        queryClient: client,
+      },
+    );
+
+    await user.selectOptions(getTimezoneSelect(), "America/New_York");
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ timezone: "America/New_York" }]);
+    });
+    expect(getTimezoneSelect().value).toBe("America/New_York");
+  });
+
+  it("uses the device timezone via Intl when the detect action is pressed", async () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      timeZone: "Pacific/Honolulu",
+    } as Intl.ResolvedDateTimeFormatOptions);
+
+    const putBodies: UpdateFamilyRequest[] = [];
+    server.use(
+      http.put(`${API_BASE}/family`, async ({ request }) => {
+        const body = (await request.json()) as UpdateFamilyRequest;
+        putBodies.push(body);
+        return HttpResponse.json({
+          data: { ...baseFamily("America/Chicago"), ...body },
+          message: "Family updated successfully",
+        });
+      }),
+    );
+
+    const client = seedClient(baseFamily("America/Chicago"));
+    const { user } = renderWithUser(
+      <PreferencesSheet open onOpenChange={noop} />,
+      {
+        queryClient: client,
+      },
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /use this device's timezone/i }),
+    );
+
+    await waitFor(() => {
+      expect(putBodies).toEqual([{ timezone: "Pacific/Honolulu" }]);
+    });
+    expect(getTimezoneSelect().value).toBe("Pacific/Honolulu");
+  });
+
+  it("surfaces a BE validation error inline and rolls back non-destructively", async () => {
+    server.use(
+      http.put(`${API_BASE}/family`, () =>
+        HttpResponse.json(
+          { message: "Timezone must be a valid IANA timezone." },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const client = seedClient(baseFamily("America/Chicago"));
+    const { user } = renderWithUser(
+      <PreferencesSheet open onOpenChange={noop} />,
+      {
+        queryClient: client,
+      },
+    );
+
+    await user.selectOptions(getTimezoneSelect(), "America/Denver");
+
+    expect(
+      await screen.findByText("Timezone must be a valid IANA timezone."),
+    ).toBeInTheDocument();
+    // Rolled back to the server-known value; the control stays usable.
+    expect(getTimezoneSelect().value).toBe("America/Chicago");
+    expect(getTimezoneSelect()).toBeEnabled();
+  });
+});
+
+// ============================================================================
+// Coming-soon stubs
+// ============================================================================
+
+describe("PreferencesSheet — roadmap stubs", () => {
+  it("renders exactly two disabled Coming soon rows: Notifications and Appearance", () => {
+    const client = seedClient(baseFamily("America/Chicago"));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    // Exactly two stub rows — no additional stubs.
+    const stubRows = screen.getAllByRole("button", { name: /coming soon/i });
+    expect(stubRows).toHaveLength(2);
+
+    const notifications = screen.getByRole("button", {
+      name: /notifications/i,
+    });
+    const appearance = screen.getByRole("button", { name: /appearance/i });
+
+    for (const row of [notifications, appearance]) {
+      expect(row).toBeDisabled();
+      expect(row).toHaveAttribute("aria-disabled", "true");
+    }
+  });
+});
+
+// ============================================================================
+// Breakpoints (mirrors responsive-form-dialog-breakpoint.test.tsx)
+// ============================================================================
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  });
+
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => {
+    const maxWidth = Number.parseInt(
+      query.match(/max-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+    const minWidth = Number.parseInt(
+      query.match(/min-width:\s*(\d+)px/)?.[1] ?? "",
+      10,
+    );
+
+    const matchesMax = Number.isNaN(maxWidth) || width <= maxWidth;
+    const matchesMin = Number.isNaN(minWidth) || width >= minWidth;
+
+    return {
+      matches: matchesMax && matchesMin,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    };
+  });
+}
+
+describe("PreferencesSheet — breakpoints", () => {
+  it("renders the full-height mobile sheet below the 768px md breakpoint", () => {
+    setViewportWidth(767);
+    const client = seedClient(baseFamily("America/Chicago"));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Preferences" }),
+    ).toBeInTheDocument();
+    // The mobile sheet supplies the Cancel chrome.
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("renders the centered dialog at the 768px md breakpoint and up", () => {
+    setViewportWidth(768);
+    const client = seedClient(baseFamily("America/Chicago"));
+
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Preferences" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+});

--- a/src/components/settings/preferences-sheet.tsx
+++ b/src/components/settings/preferences-sheet.tsx
@@ -1,0 +1,155 @@
+import { Bell, LocateFixed, Palette, X } from "lucide-react";
+import { useState } from "react";
+import { useFamilyData, useUpdateFamily } from "@/api";
+import { Button } from "@/components/ui/button";
+import { FormError } from "@/components/ui/form-error";
+import { Label } from "@/components/ui/label";
+import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
+
+/**
+ * Curated US zones offered in the timezone select. The family's current zone
+ * is appended when it is not in this list, so non-US families always see
+ * their stored value.
+ */
+const CURATED_TIMEZONES: ReadonlyArray<{ id: string; label: string }> = [
+  { id: "America/New_York", label: "Eastern — America/New_York" },
+  { id: "America/Chicago", label: "Central — America/Chicago" },
+  { id: "America/Denver", label: "Mountain — America/Denver" },
+  { id: "America/Phoenix", label: "Arizona — America/Phoenix" },
+  { id: "America/Los_Angeles", label: "Pacific — America/Los_Angeles" },
+  { id: "America/Anchorage", label: "Alaska — America/Anchorage" },
+  { id: "Pacific/Honolulu", label: "Hawaii — Pacific/Honolulu" },
+];
+
+const COMING_SOON_ROWS = [
+  { icon: Bell, label: "Notifications" },
+  { icon: Palette, label: "Appearance" },
+] as const;
+
+interface PreferencesSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Family-wide app preferences: the BE-backed family timezone plus disabled
+ * roadmap stubs. Family Settings owns "who we are"; this surface owns "how
+ * the app behaves".
+ */
+export function PreferencesSheet({
+  open,
+  onOpenChange,
+}: PreferencesSheetProps) {
+  const family = useFamilyData();
+  // Shown straight from GET /family — undefined (no default) until it loads.
+  const timezone = family?.timezone;
+
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const updateFamilyMutation = useUpdateFamily({
+    onError: (error) => setSaveError(error.message),
+  });
+
+  const saveTimezone = (zone: string) => {
+    if (!zone || zone === timezone) return;
+    setSaveError(null);
+    updateFamilyMutation.mutate({ timezone: zone });
+  };
+
+  const useDeviceTimezone = () => {
+    saveTimezone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+  };
+
+  const zoneOptions =
+    timezone && !CURATED_TIMEZONES.some((tz) => tz.id === timezone)
+      ? [...CURATED_TIMEZONES, { id: timezone, label: timezone }]
+      : CURATED_TIMEZONES;
+
+  return (
+    <ResponsiveFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Preferences"
+      initialHeight="full"
+      dialogClassName="max-w-lg max-h-[90dvh] overflow-y-auto"
+      titleClassName="text-xl"
+      desktopHeaderRight={
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Close"
+          onClick={() => onOpenChange(false)}
+          className="h-8 w-8"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      }
+    >
+      <div className="space-y-8 py-4">
+        {/* Family Timezone Section */}
+        <section className="space-y-4">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Family Timezone
+          </h3>
+          <div className="space-y-2">
+            <Label htmlFor="family-timezone">Family timezone</Label>
+            <select
+              id="family-timezone"
+              value={timezone ?? ""}
+              onChange={(event) => saveTimezone(event.target.value)}
+              className="h-11 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {timezone === undefined && (
+                <option value="" disabled>
+                  Loading timezone…
+                </option>
+              )}
+              {zoneOptions.map((tz) => (
+                <option key={tz.id} value={tz.id}>
+                  {tz.label}
+                </option>
+              ))}
+            </select>
+            <FormError message={saveError ?? undefined} />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={useDeviceTimezone}
+            className="gap-2"
+          >
+            <LocateFixed className="h-4 w-4" />
+            Use this device's timezone
+          </Button>
+        </section>
+
+        {/* Coming Soon Section */}
+        <section className="space-y-4">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Coming Soon
+          </h3>
+          <div className="space-y-1">
+            {COMING_SOON_ROWS.map((row) => {
+              const Icon = row.icon;
+              return (
+                <button
+                  key={row.label}
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium text-muted-foreground opacity-60 cursor-not-allowed"
+                >
+                  <Icon className="h-5 w-5" />
+                  {row.label}
+                  <span className="ml-auto text-xs font-normal rounded-full border border-border px-2 py-0.5">
+                    Coming soon
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </ResponsiveFormDialog>
+  );
+}

--- a/src/components/shared/sidebar-menu.test.tsx
+++ b/src/components/shared/sidebar-menu.test.tsx
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useAppStore } from "@/stores";
-import { renderWithUser, screen, seedFamilyStore } from "@/test/test-utils";
+import {
+  renderWithUser,
+  screen,
+  seedFamilyStore,
+  within,
+} from "@/test/test-utils";
 import { SidebarMenu } from "./sidebar-menu";
 
 const logoutSpy = vi.fn();
@@ -24,6 +29,26 @@ describe("SidebarMenu", () => {
     expect(screen.getByText("Test Family")).toBeInTheDocument();
     await user.keyboard("{Escape}");
     expect(useAppStore.getState().isSidebarOpen).toBe(false);
+  });
+
+  it("orders menu rows: Family Settings, Preferences, Sign Out", () => {
+    renderWithUser(<SidebarMenu />);
+
+    const nav = screen.getByRole("navigation");
+    const labels = within(nav)
+      .getAllByRole("button")
+      .map((button) => button.textContent?.trim());
+    expect(labels).toEqual(["Family Settings", "Preferences", "Sign Out"]);
+  });
+
+  it("opens the Preferences sheet from the Preferences row", async () => {
+    const { user } = renderWithUser(<SidebarMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Preferences" }));
+
+    expect(
+      screen.getByRole("dialog", { name: "Preferences" }),
+    ).toBeInTheDocument();
   });
 
   it("requires confirmation before signing out", async () => {

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,7 +1,11 @@
-import { LogOut, Users, X } from "lucide-react";
+import { LogOut, SlidersHorizontal, Users, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useFamilyMembers, useFamilyName, useLogout } from "@/api";
-import { FamilySettingsModal, MemberProfileModal } from "@/components/settings";
+import {
+  FamilySettingsModal,
+  MemberProfileModal,
+  PreferencesSheet,
+} from "@/components/settings";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -24,6 +28,7 @@ export function SidebarMenu() {
   const logout = useLogout();
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
 
@@ -42,6 +47,11 @@ export function SidebarMenu() {
       icon: Users,
       label: "Family Settings",
       action: () => setIsSettingsOpen(true),
+    },
+    {
+      icon: SlidersHorizontal,
+      label: "Preferences",
+      action: () => setIsPreferencesOpen(true),
     },
     {
       icon: LogOut,
@@ -152,6 +162,12 @@ export function SidebarMenu() {
       <FamilySettingsModal
         open={isSettingsOpen}
         onOpenChange={setIsSettingsOpen}
+      />
+
+      {/* Preferences Sheet */}
+      <PreferencesSheet
+        open={isPreferencesOpen}
+        onOpenChange={setIsPreferencesOpen}
       />
 
       {/* Member Profile Modal */}

--- a/src/lib/types/family.ts
+++ b/src/lib/types/family.ts
@@ -23,10 +23,15 @@ export interface FamilyMember {
 
 /**
  * Family data stored in localStorage.
+ *
+ * BE DTO: FamilyResponse.java (v1.6.0) — id, name, timezone, members, createdAt.
+ * `timezone` is always present in API responses (server resolves a default),
+ * but optional here because pre-1.6.0 localStorage caches lack it.
  */
 export interface FamilyData {
   id: string;
   name: string;
+  timezone?: string;
   members: FamilyMember[];
   createdAt: string;
 }
@@ -114,10 +119,15 @@ export const familyColors: FamilyColor[] = [
 // ============================================================================
 
 /**
- * Request to update family properties.
+ * Request to update family properties. Fields left undefined are unchanged.
+ *
+ * BE DTO: FamilyRequest.java (v1.6.0) — name: @Size(1..50), timezone: IANA zone
+ * id validated server-side (invalid → 400 "Timezone must be a valid IANA
+ * timezone."). FamilyRequest also carries `username`, which the FE never updates.
  */
 export interface UpdateFamilyRequest {
-  name: string;
+  name?: string;
+  timezone?: string;
 }
 
 /**

--- a/src/lib/validations/family.test.ts
+++ b/src/lib/validations/family.test.ts
@@ -540,6 +540,35 @@ describe("family validations", () => {
       });
     });
 
+    describe("timezone field", () => {
+      it("preserves a valid IANA timezone", () => {
+        const result = familyDataSchema.safeParse({
+          ...validFamilyData,
+          timezone: "America/Chicago",
+        });
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.timezone).toBe("America/Chicago");
+        }
+      });
+
+      it("accepts data without timezone (pre-1.6.0 localStorage caches)", () => {
+        const result = familyDataSchema.safeParse(validFamilyData);
+        expect(result.success).toBe(true);
+        if (result.success) {
+          expect(result.data.timezone).toBeUndefined();
+        }
+      });
+
+      it("rejects an empty timezone string", () => {
+        const result = familyDataSchema.safeParse({
+          ...validFamilyData,
+          timezone: "",
+        });
+        expect(result.success).toBe(false);
+      });
+    });
+
     describe("complete validation", () => {
       it("validates complete valid family data", () => {
         const result = familyDataSchema.safeParse(validFamilyData);

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 // BE DTO alignment:
-//   FamilyRequest.java      — name: @Size(max=50)
+//   FamilyRequest.java      — name: @Size(max=50), timezone: optional IANA zone id
+//                             (validated server-side via ZoneId.of; invalid → 400)
 //   FamilyMemberRequest.java — name: @Size(max=30), email: @Size(max=254) @Email,
 //                              color: @NotBlank, avatarUrl: @Size(max=254)
 
@@ -150,6 +151,8 @@ export const familyMemberSchema = z.object({
 export const familyDataSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1).max(50),
+  // Optional: pre-1.6.0 BE localStorage caches lack timezone.
+  timezone: z.string().min(1).optional(),
   members: z.array(familyMemberSchema),
   createdAt: z.string().datetime({ offset: true }).or(z.string().min(1)),
 });

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -1547,10 +1547,12 @@ export const handlers = [
       );
     }
 
+    // Mirrors BE FamilyService (v1.6.0): fields left undefined are unchanged.
     const body = (await request.json()) as UpdateFamilyRequest;
     mockFamily = {
       ...mockFamily,
-      name: body.name,
+      ...(body.name !== undefined && { name: body.name }),
+      ...(body.timezone !== undefined && { timezone: body.timezone }),
     };
 
     return HttpResponse.json(

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -180,6 +180,7 @@ export function seedFamilyStore(
   const familyData: FamilyData = {
     id: data.id ?? crypto.randomUUID(),
     name: data.name ?? "Test Family",
+    timezone: data.timezone,
     members: data.members,
     createdAt: data.createdAt ?? new Date().toISOString(),
   };


### PR DESCRIPTION
Closes #208

Adds a **Preferences** entry to the sidebar that opens a new family preferences sheet: the BE-backed family timezone (editable, optimistic, validated server-side) plus exactly two disabled "Coming soon" rows. Family Settings stays "who we are"; Preferences owns "how the app behaves".

Precondition verified before starting: BE release **v1.6.0** ships `timezone` on `GET/PUT /api/family` (joe-bor/family-hub-api#57 closed); the `blocked` label was removed from #208.

## Contract checklist (item → code + tests)

| # | Contract item | Code | Tests |
|---|---------------|------|-------|
| 1 | Sidebar Preferences row between Family Settings and Sign Out, ≥44px, existing idiom; nothing else changes | `src/components/shared/sidebar-menu.tsx` (same `min-h-11` menu-item map, `SlidersHorizontal` icon) | `sidebar-menu.test.tsx`: row order asserted as `Family Settings, Preferences, Sign Out`; click opens the sheet; existing Escape/sign-out tests untouched and green |
| 2 | `PreferencesSheet` on existing `ResponsiveFormDialog`, `initialHeight="full"`, centered dialog on desktop, no new adaptive pattern | `src/components/settings/preferences-sheet.tsx` (same wrapper + chrome props as `FamilySettingsModal`) | `preferences-sheet.test.tsx` breakpoint suite: mobile sheet at 767px (Cancel chrome), desktop dialog at 768px |
| 3 | Timezone from `GET /api/family` (never hardcoded), curated US select + current value, device-detect via `Intl.DateTimeFormat().resolvedOptions().timeZone`, saved through the family update mutation with optimistic update/rollback, inline non-destructive BE errors | `preferences-sheet.tsx` (`useFamilyData` + `useUpdateFamily`); `use-family.ts` `onMutate` now merges only provided fields | `preferences-sheet.test.tsx`: API value shown, no default while unknown, non-curated zone selectable, PUT body asserted, Intl mocked for device-detect, 400 → inline message + rollback; `use-family.test.tsx`: optimistic timezone merge keeps name, rollback on 400 |
| 4 | Exactly two stub rows — Notifications, Appearance — disabled, `aria-disabled`, no click handlers | `preferences-sheet.tsx` (`COMING_SOON_ROWS`, `disabled` + `aria-disabled="true"`, no `onClick`) | `preferences-sheet.test.tsx`: exactly two stub rows by accessible name, both `toBeDisabled()` + `aria-disabled="true"` |
| 5 | `timezone` in family types + service/Zod layer with BE DTO reference comment | `src/lib/types/family.ts` (`FamilyData.timezone`, partial `UpdateFamilyRequest`, FamilyResponse/FamilyRequest v1.6.0 comments); `src/lib/validations/family.ts` (`familyDataSchema.timezone`, DTO alignment header) | `lib/validations/family.test.ts`: preserves valid zone, accepts pre-1.6.0 cache without one, rejects empty string |
| 6 | Unit + E2E coverage; existing sidebar/settings suites stay green | — | `e2e/preferences.spec.ts` (desktop + mobile projects): open Preferences → change timezone → authenticated `GET /api/family` confirms BE persistence → reload → value persisted; plus disabled-stub check |

## Out of scope (untouched per issue)

Week-start (Sunday stays), default view, per-member preferences, real notifications/dark mode, password/username, Sign Out / member rows, Lists preferences.

## Verification (local, BE 1.6.0 container)

- `npm run lint` — clean
- `npm test -- --run` — 911 passed / 82 files (baseline before branch: 894 / 81)
- `npm run build` — type-check + build green
- `npx playwright test e2e/preferences.spec.ts` — 8/8 across chromium, firefox, webkit, Mobile Chrome
- `npx playwright test e2e/mobile-settings-sheets.spec.ts e2e/mobile-settings-sidebar.spec.ts e2e/family-management.spec.ts e2e/onboarding.spec.ts` — 13 passed, 15 skipped (mobile-only on desktop projects, as usual)
