### PR TITLE
fix(pwa): config cleanups (stats.html leak, dead font rules, Lighthouse PWA category, metadata)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ test-results/
 # Lighthouse CI
 .lighthouseci/
 
+# Bundle analysis (rollup-plugin-visualizer, ANALYZE=true)
+.analyze/
+
 # Personal learning notes
 docs/VERSIONING-WALKTHROUGH.md
 .worktrees/

--- a/docs/TECHNICAL-DEBT.md
+++ b/docs/TECHNICAL-DEBT.md
@@ -88,23 +88,22 @@ Lighthouse detected unused JavaScript in the bundle.
 ---
 
 ### 5. PWA Optimizations
-**Source:** Lighthouse CI (PR #60)
-**Files:** `vite.config.ts` (vite-plugin-pwa)
-**Status:** Deferred - PWA basics in place
+**Source:** Lighthouse CI (PR #60); revisited by the PWA installability story (2026-06-13)
+**Files:** `vite.config.ts` (vite-plugin-pwa), `index.html`, `lighthouserc.cjs`
+**Status:** Installability polish shipped (Option B); offline *data* deferred to Option C
 
-**Current State:**
-PWA is configured via `vite-plugin-pwa` but not fully optimized.
+**Shipped — Option B / [PWA installability story](https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/pwa-installability.md):**
+- Controlled update prompt (`registerType: "prompt"` + `PWAUpdater`) — no more silent reloads
+- Sidebar **Install app** affordance (one-tap on Chromium / manual instructions elsewhere / hidden when installed)
+- Honest, accessible offline banner (does **not** imply offline data)
+- Config cleanups: `stats.html` no longer deployed/precached; dead Google-Fonts CDN cache rules removed; dead Lighthouse `pwa` category removed; manifest/meta description reconciled; modern `mobile-web-app-capable`; orientation unlocked
 
-**Optimization Opportunities:**
-- **Offline support**: Cache critical assets and API responses (see Backend Compatibility Notes #3)
-- **Installability**: Ensure manifest meets all criteria
-- **Service worker**: Implement background sync for offline mutations
-- **App shell**: Cache the app shell for instant loading
+**Deferred to Option C / offline reads (NOT done):**
+- Cache API responses (calendar/module data) for offline *viewing* (see Backend Compatibility Notes #3)
+- Background sync for offline mutations; offline write queue
+- TanStack Query persistence / IndexedDB
 
-**Lighthouse PWA Checklist:**
-- [ ] Installable (valid manifest, service worker)
-- [ ] Optimized (fast page loads, responsive)
-- [ ] Network resilience (works offline/flaky network)
+> Note: Lighthouse 12 removed the standalone PWA category; installability is now tracked via manifest/SW checks rather than a Lighthouse PWA score.
 
 ---
 
@@ -185,6 +184,7 @@ Types: `src/lib/types/family.ts`
 
 | Item | Sprint | PR | Date |
 |------|--------|----|----|
+| PWA config cleanup (stats.html leak, dead Google-Fonts cache rules, Lighthouse PWA category, metadata) | - | #215 | Jun 13, 2026 |
 | "Edit All" Clears Recurrence Rule (BE includes recurrenceRule on instances) | - | BE #21 | Mar 13, 2026 |
 | Recurring Event Detail Generic Label (formatRecurrenceLabel now receives RRULE) | - | BE #21 | Mar 13, 2026 |
 | E2E Tests for Recurring Events (8 tests: create, edit this/all, delete this/all, monthly, all-day, end date) | - | #119 | Mar 13, 2026 |

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#faf8f5" />
-    <meta name="description" content="Family calendar and organizer" />
+    <meta name="description" content="Your family's command center for calendar, lists, chores, and meals." />
 
     <!-- Favicons -->
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -14,6 +14,7 @@
     <!-- iOS PWA -->
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="FamilyHub" />
     <title>FamilyHub - Family Calendar & Organizer</title>

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -11,7 +11,6 @@ module.exports = {
           "accessibility",
           "best-practices",
           "seo",
-          "pwa",
         ],
         skipAudits: ["uses-http2"],
       },
@@ -32,7 +31,6 @@ module.exports = {
         "categories:accessibility": ["warn", { minScore: 0.9 }],
         "categories:best-practices": ["warn", { minScore: 0.9 }],
         "categories:seo": ["warn", { minScore: 0.9 }],
-        "categories:pwa": ["warn", { minScore: 0.5 }],
       },
     },
     upload: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "analyze": "npm run build && echo 'Bundle analysis available at dist/stats.html'",
+    "analyze": "ANALYZE=true npm run build && echo 'Bundle analysis available at .analyze/stats.html'",
     "lighthouse": "npm run build && lhci autorun"
   },
   "lint-staged": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,12 +22,13 @@ export default defineConfig(() => {
         manifest: {
           name: "FamilyHub",
           short_name: "FamilyHub",
-          description: "Your family's command center",
+          description:
+            "Your family's command center for calendar, lists, chores, and meals.",
           id: "/",
           scope: "/",
           start_url: "/",
           display: "standalone",
-          orientation: "portrait",
+          orientation: "any",
           background_color: "#faf8f5",
           theme_color: "#faf8f5",
           icons: [
@@ -51,40 +52,26 @@ export default defineConfig(() => {
         },
         workbox: {
           globPatterns: ["**/*.{js,css,html,ico,png,svg,woff,woff2}"],
+          // Never precache the bundle-analysis report (only present with ANALYZE=true).
+          globIgnores: ["**/stats.html"],
           navigateFallback: "/index.html",
           navigateFallbackDenylist: [/^\/api/],
-          runtimeCaching: [
-            {
-              urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
-              handler: "CacheFirst",
-              options: {
-                cacheName: "google-fonts-cache",
-                expiration: {
-                  maxEntries: 10,
-                  maxAgeSeconds: 60 * 60 * 24 * 365,
-                },
-              },
-            },
-            {
-              urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
-              handler: "CacheFirst",
-              options: {
-                cacheName: "gstatic-fonts-cache",
-                expiration: {
-                  maxEntries: 10,
-                  maxAgeSeconds: 60 * 60 * 24 * 365,
-                },
-              },
-            },
-          ],
+          // No runtimeCaching: Nunito is self-hosted via @fontsource/nunito and
+          // precached by the glob above; the old Google Fonts CDN rules were dead.
         },
       }),
-      visualizer({
-        filename: "dist/stats.html",
-        open: false,
-        gzipSize: true,
-        brotliSize: true,
-      }),
+      // Bundle analysis is opt-in (ANALYZE=true) and written outside dist/ so it
+      // is never deployed or swept into the service-worker precache.
+      ...(process.env.ANALYZE === "true"
+        ? [
+            visualizer({
+              filename: ".analyze/stats.html",
+              open: false,
+              gzipSize: true,
+              brotliSize: true,
+            }),
+          ]
+        : []),
     ],
     define: {
       __APP_VERSION__: JSON.stringify(version),


### PR DESCRIPTION
Closes #215

**Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/pwa-installability.md
**Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-13-pwa-installability-design.md (§D4)
**Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-13-pwa-installability.md (Part 1)

Group **(c)** of the PWA installability work — **config + metadata + docs only, no runtime behavior** (offline *data* is the separate Option C).

### Changes
- **stats.html out of production:** `rollup-plugin-visualizer` is now opt-in (`ANALYZE=true`) and writes to `.analyze/stats.html` (gitignored), never `dist/`. Added workbox `globIgnores: ["**/stats.html"]` as belt-and-suspenders. Updated the `analyze` script.
- **Dead font rules removed:** deleted both Google-Fonts CDN `runtimeCaching` rules (Nunito is self-hosted via `@fontsource/nunito` and precached).
- **Lighthouse:** removed the `pwa` category from `onlyCategories` and the `categories:pwa` assertion (Lighthouse 12 removed the category).
- **Description reconciled (PD2):** manifest `description` and `index.html` meta `description` are now identical: *"Your family's command center for calendar, lists, chores, and meals."*
- **Modern meta:** added `<meta name="mobile-web-app-capable" content="yes">` (kept the apple one for older iOS).
- **Orientation (PD1, confirmed):** manifest `orientation` `"portrait"` → `"any"`.
- **Tech debt:** updated `docs/TECHNICAL-DEBT.md` §5 (Option B shipped; offline data → Option C).

### Acceptance checklist
- [x] `npm run build` produces a `dist/` with **no `stats.html`**; not in the `dist/sw.js` precache (verified: 40 precache entries, `grep stats.html dist/sw.js` → 0).
- [x] No Google-Fonts CDN runtime-cache rules remain; fonts still load (Nunito `woff2` precached; `grep fonts.googleapis|gstatic` over `index.html`/`src` → 0).
- [x] `lighthouserc.cjs` no longer references the removed PWA category (parses; `onlyCategories = performance,accessibility,best-practices,seo`). Full `lhci` runs in CI (needs Chrome).
- [x] Manifest description == meta description; `mobile-web-app-capable` present; `orientation: "any"`.
- [x] No offline data / persistence / push introduced.

### Verification
- `npm run build` ✓ · `npm run lint` ✓ (exit 0) · `npm run test -- --run` ✓ **911 passed / 82 files**.
