### PR TITLE
feat(pwa): controlled update prompt + honest offline banner

### DIFF
--- a/e2e/pwa-offline-banner.spec.ts
+++ b/e2e/pwa-offline-banner.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import { clearStorage, waitForHydration } from "./helpers/test-helpers";
+
+test.describe("PWA offline banner", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("appears when offline and clears on reconnect", async ({
+    page,
+    context,
+    request,
+  }) => {
+    const reg = await registerFamily(request, {
+      familyName: "Offline Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+
+    await page.reload();
+    await waitForHydration(page);
+
+    const banner = page.getByText(/you're offline/i);
+    await expect(banner).toBeHidden();
+
+    await context.setOffline(true);
+    await expect(banner).toBeVisible({ timeout: 2000 });
+    await expect(banner).toHaveText(/won't save/i);
+
+    await context.setOffline(false);
+    await expect(banner).toBeHidden({ timeout: 2000 });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
   AppHeader,
   MobileBottomNav,
   NavigationTabs,
+  OfflineBanner,
   SidebarMenu,
 } from "@/components/shared";
 import { Toaster } from "@/components/ui/toaster";
@@ -176,6 +177,7 @@ export default function FamilyHub() {
           </main>
         </div>
 
+        <OfflineBanner />
         {isMobile && isAuthenticated && setupComplete && <MobileBottomNav />}
         <SidebarMenu />
       </div>

--- a/src/components/pwa/pwa-updater.test.tsx
+++ b/src/components/pwa/pwa-updater.test.tsx
@@ -1,0 +1,44 @@
+import { Toaster } from "@/components/ui/toaster";
+import { act, renderWithUser, screen } from "@/test/test-utils";
+
+const { updateServiceWorker, captured } = vi.hoisted(() => ({
+  updateServiceWorker: vi.fn(),
+  captured: {} as {
+    onNeedRefresh?: () => void;
+    onOfflineReady?: () => void;
+  },
+}));
+
+vi.mock("virtual:pwa-register/react", () => ({
+  useRegisterSW: (opts: {
+    onNeedRefresh?: () => void;
+    onOfflineReady?: () => void;
+  }) => {
+    captured.onNeedRefresh = opts.onNeedRefresh;
+    captured.onOfflineReady = opts.onOfflineReady;
+    return { updateServiceWorker };
+  },
+}));
+
+import { PWAUpdater } from "./pwa-updater";
+
+describe("PWAUpdater", () => {
+  it("shows an update toast with a Reload action that updates the SW", async () => {
+    const { user } = renderWithUser(
+      <>
+        <PWAUpdater />
+        <Toaster />
+      </>,
+    );
+
+    // Simulate vite-plugin-pwa signaling a waiting service worker.
+    act(() => {
+      captured.onNeedRefresh?.();
+    });
+
+    expect(screen.getByText("Update available")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /reload/i }));
+    expect(updateServiceWorker).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/pwa/pwa-updater.tsx
+++ b/src/components/pwa/pwa-updater.tsx
@@ -1,0 +1,49 @@
+import { useRegisterSW } from "virtual:pwa-register/react";
+import { useEffect, useRef } from "react";
+import { ToastAction } from "@/components/ui/toast";
+import { toast } from "@/components/ui/toaster";
+
+/**
+ * Surfaces a user-controlled "update available" prompt instead of the old
+ * `autoUpdate` silent reload. Renders nothing; mount once near the root.
+ *
+ * On a new service worker, shows a sticky toast with a Reload action that
+ * applies the update (`updateServiceWorker(true)`). The user is never
+ * force-reloaded mid-use.
+ */
+export function PWAUpdater() {
+  // The Reload action's closure can't reference the same useRegisterSW call's
+  // return value directly, so stash it in a ref updated after each render.
+  const updateRef = useRef<(reloadPage?: boolean) => void>(() => {});
+
+  const { updateServiceWorker } = useRegisterSW({
+    onNeedRefresh() {
+      toast({
+        title: "Update available",
+        description: "A new version of Family Hub is ready.",
+        duration: Number.POSITIVE_INFINITY,
+        action: (
+          <ToastAction
+            altText="Reload to update"
+            onClick={() => updateRef.current(true)}
+          >
+            Reload
+          </ToastAction>
+        ),
+      });
+    },
+    onOfflineReady() {
+      // Honest copy: only the app shell is cached, NOT your data (Option C).
+      toast({
+        title: "Ready to use",
+        description: "Family Hub is installed and the app shell is cached.",
+      });
+    },
+  });
+
+  useEffect(() => {
+    updateRef.current = updateServiceWorker;
+  }, [updateServiceWorker]);
+
+  return null;
+}

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,5 +1,6 @@
 export { AppHeader } from "./app-header";
 export { MobileBottomNav } from "./mobile-bottom-nav";
 export { NavigationTabs, type TabType } from "./navigation-tabs";
+export { OfflineBanner } from "./offline-banner";
 export { SidebarMenu } from "./sidebar-menu";
 export { ThemeProvider } from "./theme-provider";

--- a/src/components/shared/offline-banner.test.tsx
+++ b/src/components/shared/offline-banner.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@/test/test-utils";
+import { OfflineBanner } from "./offline-banner";
+
+let online = true;
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useOnlineStatus: () => online };
+});
+
+describe("OfflineBanner", () => {
+  it("renders nothing when online", () => {
+    online = true;
+    const { container } = render(<OfflineBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows an accessible status when offline", () => {
+    online = false;
+    render(<OfflineBanner />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent(/offline/i);
+    expect(status).toHaveTextContent(/won't save/i);
+    expect(status).toHaveAttribute("aria-live", "polite");
+  });
+});

--- a/src/components/shared/offline-banner.tsx
+++ b/src/components/shared/offline-banner.tsx
@@ -1,0 +1,23 @@
+import { WifiOff } from "lucide-react";
+import { useOnlineStatus } from "@/hooks";
+
+/**
+ * Slim, non-blocking, honest offline indicator. Explains TanStack Query's
+ * default `networkMode` pause (queries/mutations wait while offline). It does
+ * NOT imply offline data — viewing cached data offline is Option C.
+ */
+export function OfflineBanner() {
+  const online = useOnlineStatus();
+  if (online) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="flex items-center justify-center gap-2 border-t border-amber-500/30 bg-amber-500/15 px-3 py-1.5 text-center text-xs font-medium text-amber-900"
+    >
+      <WifiOff className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      You're offline — changes won't save until you reconnect.
+    </div>
+  );
+}

--- a/src/components/ui/toaster.test.tsx
+++ b/src/components/ui/toaster.test.tsx
@@ -1,0 +1,34 @@
+import { act, render, screen } from "@/test/test-utils";
+import { Toaster, toast } from "./toaster";
+
+describe("toast duration", () => {
+  it("stays mounted when duration is Infinity", () => {
+    vi.useFakeTimers();
+    render(<Toaster />);
+
+    act(() => {
+      toast({ title: "Sticky update", duration: Number.POSITIVE_INFINITY });
+    });
+    expect(screen.getByText("Sticky update")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(60000);
+    });
+    expect(screen.getByText("Sticky update")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses with the default duration", () => {
+    vi.useFakeTimers();
+    render(<Toaster />);
+
+    act(() => {
+      toast({ title: "Default toast" });
+    });
+    expect(screen.getByText("Default toast")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(screen.queryByText("Default toast")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -42,7 +42,8 @@ export function toast({
   description,
   action,
   variant,
-}: Omit<ToastData, "id" | "open">) {
+  duration = TOAST_REMOVE_DELAY,
+}: Omit<ToastData, "id" | "open"> & { duration?: number }) {
   const id = genId();
   const newToast: ToastData = {
     id,
@@ -57,11 +58,15 @@ export function toast({
     [newToast, ...memoryToasts.filter((t) => t.open)].slice(0, TOAST_LIMIT),
   );
 
-  setTimeout(() => {
-    dispatch(
-      memoryToasts.map((t) => (t.id === id ? { ...t, open: false } : t)),
-    );
-  }, TOAST_REMOVE_DELAY);
+  // A duration of Infinity (or <= 0) keeps the toast until the user dismisses
+  // it — used by the PWA update prompt so the Reload action can't time out.
+  if (Number.isFinite(duration) && duration > 0) {
+    setTimeout(() => {
+      dispatch(
+        memoryToasts.map((t) => (t.id === id ? { ...t, open: false } : t)),
+      );
+    }, duration);
+  }
 
   return id;
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { useDebounce } from "./use-debounce";
 export { useGoogleAuthReturn } from "./use-google-auth-return";
 export { useIsMobile } from "./use-is-mobile";
 export { useMediaQuery } from "./use-media-query";
+export { useOnlineStatus } from "./use-online-status";

--- a/src/hooks/use-online-status.test.ts
+++ b/src/hooks/use-online-status.test.ts
@@ -1,0 +1,35 @@
+import { act, renderHook } from "@/test/test-utils";
+import { useOnlineStatus } from "./use-online-status";
+
+function setOnLine(value: boolean) {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("useOnlineStatus", () => {
+  it("initializes from navigator.onLine", () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(false);
+  });
+
+  it("reacts to online and offline events", () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useOnlineStatus());
+    expect(result.current).toBe(true);
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/use-online-status.ts
+++ b/src/hooks/use-online-status.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks browser connectivity via `navigator.onLine` and the window
+ * `online`/`offline` events. Used by the offline banner to honestly reflect
+ * that TanStack Query (default `networkMode: "online"`) pauses requests while
+ * offline. Does NOT imply offline data caching.
+ */
+export function useOnlineStatus(): boolean {
+  const [online, setOnline] = useState(() => navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setOnline(true);
+    const handleOffline = () => setOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return online;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { PWAUpdater } from "@/components/pwa/pwa-updater";
 import { QueryProvider } from "@/providers/query-provider";
 import "@fontsource/nunito/latin-400.css";
 import "@fontsource/nunito/latin-500.css";
@@ -12,6 +13,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryProvider>
       <App />
+      <PWAUpdater />
     </QueryProvider>
   </StrictMode>,
 );

--- a/src/test/mocks/virtual-pwa-register.ts
+++ b/src/test/mocks/virtual-pwa-register.ts
@@ -1,0 +1,18 @@
+// Test stub for vite-plugin-pwa's `virtual:pwa-register/react` module.
+// The PWA plugin is not loaded under vitest, so the real virtual module does
+// not resolve. Individual tests override behavior with `vi.mock(...)`.
+export interface RegisterSWOptions {
+  immediate?: boolean;
+  onNeedRefresh?: () => void;
+  onOfflineReady?: () => void;
+  onRegisteredSW?: (swUrl: string, r?: ServiceWorkerRegistration) => void;
+  onRegisterError?: (error: unknown) => void;
+}
+
+export function useRegisterSW(_options?: RegisterSWOptions) {
+  return {
+    needRefresh: [false, () => {}] as [boolean, (value: boolean) => void],
+    offlineReady: [false, () => {}] as [boolean, (value: boolean) => void],
+    updateServiceWorker: async (_reloadPage?: boolean) => {},
+  };
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vite-plugin-pwa/react"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(() => {
         },
       }),
       VitePWA({
-        registerType: "autoUpdate",
+        registerType: "prompt",
         includeAssets: ["favicon.ico", "apple-touch-icon.png", "icons/*.png"],
         manifest: {
           name: "FamilyHub",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // vite-plugin-pwa's virtual module isn't available in vitest (the PWA
+      // plugin isn't loaded); resolve it to a stub so PWAUpdater can be tested.
+      "virtual:pwa-register/react": path.resolve(
+        __dirname,
+        "./src/test/mocks/virtual-pwa-register.ts",
+      ),
     },
   },
   define: {


### PR DESCRIPTION
Closes #214

**Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/pwa-installability.md
**Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-13-pwa-installability-design.md (§D1, §D3)
**Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-13-pwa-installability.md (Part 2)

Group **(b)** of the PWA installability work — controlled updates + honest offline UX. **No offline data** (that is Option C); **TanStack Query `networkMode` is unchanged**.

### Changes
- **Controlled updates:** `registerType: "autoUpdate"` → `"prompt"`. New `PWAUpdater` (mounted once in `main.tsx`) uses `useRegisterSW()`; on a new SW it shows a **sticky** toast *"Update available"* with a **Reload** action calling `updateServiceWorker(true)`. No more silent forced reloads. `onOfflineReady` shows an honest one-time toast (app shell cached — not data).
- **Toast extension:** `toast()` gains an optional `duration` (default 5s; `Infinity`/0 = sticky), fully backward-compatible.
- **Offline status:** new `useOnlineStatus` hook (`navigator.onLine` + `online`/`offline` events).
- **Offline banner:** new `OfflineBanner` (slim, `role="status"`, `aria-live="polite"`) mounted above the bottom nav; visible only when offline: *"You're offline — changes won't save until you reconnect."*
- **Types/test infra:** added `vite-plugin-pwa/react` to tsconfig `types`; vitest alias + stub so `virtual:pwa-register/react` resolves in tests.

### Acceptance checklist
- [x] New SW surfaces a user-dismissible update prompt with a working Reload action; no silent reloads (unit-tested: toast renders, Reload calls `updateServiceWorker(true)`; SW build is prompt-mode).
- [x] Offline banner appears when offline, clears on reconnect, accessible (`role="status"` + `aria-live="polite"`).
- [x] `networkMode` unchanged; no offline data / persistence / push introduced.

### Verification
- `npm run test -- --run` ✓ **918 passed / 86 files** (added: toast duration, `PWAUpdater`, `useOnlineStatus`, `OfflineBanner`).
- `npm run build` ✓ (tsc + vite; SW generated in prompt mode — `skipWaiting` now gated behind the Reload message).
- `npm run lint` ✓ (exit 0).
- **E2E** (`e2e/pwa-offline-banner.spec.ts`): added, follows the repo's real-BE `registerFamily` + `seedBrowserAuth` pattern → runs in CI against the released BE container. Not run locally (no BE on :8080). The offline banner itself is SW-independent (pure `navigator.onLine`).
- **SW update prompt** must be verified on a production build (`npm run preview` / deploy), never `npm run dev` — flagged for the device/preview smoke before release.

> Note: independent of PRs #215/#216 (cleanups) and #213 (install row). Recommended merge order: (c) → (b) → (a). On this branch `stats.html` is still precached — that's #215's fix, not this PR's scope.
