### PR TITLE
feat(pwa): sidebar Install app row + standalone detection

### DIFF
--- a/src/components/shared/install-app-row.test.tsx
+++ b/src/components/shared/install-app-row.test.tsx
@@ -1,0 +1,40 @@
+import { render, renderWithUser, screen } from "@/test/test-utils";
+import { InstallAppRow } from "./install-app-row";
+
+let standalone = false;
+let canInstall = false;
+const promptInstall = vi.fn();
+
+vi.mock("@/lib/pwa", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/pwa")>();
+  return { ...actual, isStandalone: () => standalone };
+});
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks")>();
+  return { ...actual, useInstallPrompt: () => ({ canInstall, promptInstall }) };
+});
+
+describe("InstallAppRow", () => {
+  it("renders nothing when already installed", () => {
+    standalone = true;
+    canInstall = false;
+    const { container } = render(<InstallAppRow />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("one-taps install on Chromium", async () => {
+    standalone = false;
+    canInstall = true;
+    const { user } = renderWithUser(<InstallAppRow />);
+    await user.click(screen.getByRole("button", { name: /install app/i }));
+    expect(promptInstall).toHaveBeenCalledOnce();
+  });
+
+  it("opens the instructions sheet when no install prompt is available", async () => {
+    standalone = false;
+    canInstall = false;
+    const { user } = renderWithUser(<InstallAppRow />);
+    await user.click(screen.getByRole("button", { name: /install app/i }));
+    expect(await screen.findByText(/install family hub/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/install-app-row.tsx
+++ b/src/components/shared/install-app-row.tsx
@@ -1,0 +1,45 @@
+import { Download } from "lucide-react";
+import { useState } from "react";
+import { InstallInstructionsSheet } from "@/components/shared/install-instructions-sheet";
+import { useInstallPrompt } from "@/hooks";
+import { isStandalone } from "@/lib/pwa";
+
+/**
+ * Sidebar "Install app" row with three states:
+ * - already installed/standalone -> not rendered
+ * - Chromium (beforeinstallprompt available) -> one-tap install
+ * - otherwise (iOS Safari, Firefox) -> opens manual instructions
+ */
+export function InstallAppRow() {
+  // display-mode does not change within a session; read once at mount.
+  const [installed] = useState(() => isStandalone());
+  const { canInstall, promptInstall } = useInstallPrompt();
+  const [showInstructions, setShowInstructions] = useState(false);
+
+  if (installed) return null;
+
+  const handleClick = () => {
+    if (canInstall) {
+      void promptInstall();
+    } else {
+      setShowInstructions(true);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Download className="h-5 w-5" />
+        Install app
+      </button>
+      <InstallInstructionsSheet
+        isOpen={showInstructions}
+        onClose={() => setShowInstructions(false)}
+      />
+    </>
+  );
+}

--- a/src/components/shared/install-instructions-sheet.test.tsx
+++ b/src/components/shared/install-instructions-sheet.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@/test/test-utils";
+import { InstallInstructionsSheet } from "./install-instructions-sheet";
+
+let ios = false;
+vi.mock("@/lib/pwa", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/pwa")>();
+  return { ...actual, isIOS: () => ios };
+});
+
+describe("InstallInstructionsSheet", () => {
+  it("shows iOS Share / Add to Home Screen copy on iOS", () => {
+    ios = true;
+    render(<InstallInstructionsSheet isOpen onClose={vi.fn()} />);
+    expect(screen.getByText(/add to home screen/i)).toBeInTheDocument();
+    expect(screen.getByText("Share")).toBeInTheDocument();
+  });
+
+  it("shows generic browser-menu copy elsewhere", () => {
+    ios = false;
+    render(<InstallInstructionsSheet isOpen onClose={vi.fn()} />);
+    expect(screen.getByText(/browser menu/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/install-instructions-sheet.tsx
+++ b/src/components/shared/install-instructions-sheet.tsx
@@ -1,0 +1,57 @@
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { isIOS } from "@/lib/pwa";
+
+interface InstallInstructionsSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Manual install instructions for browsers that never fire
+ * `beforeinstallprompt` (iOS Safari, Firefox). Platform-specific copy.
+ */
+export function InstallInstructionsSheet({
+  isOpen,
+  onClose,
+}: InstallInstructionsSheetProps) {
+  const ios = isIOS();
+
+  return (
+    <MobileSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Install Family Hub"
+      initialHeight="half"
+    >
+      <div className="space-y-4 px-4 pb-6 text-sm text-foreground">
+        <p className="text-muted-foreground">
+          Add Family Hub to your home screen so it opens like an app.
+        </p>
+        {ios ? (
+          <ol className="list-decimal space-y-2 pl-5">
+            <li>
+              Tap the <span className="font-semibold">Share</span> button in
+              Safari's toolbar.
+            </li>
+            <li>
+              Choose <span className="font-semibold">Add to Home Screen</span>.
+            </li>
+            <li>
+              Tap <span className="font-semibold">Add</span> — Family Hub
+              appears on your home screen.
+            </li>
+          </ol>
+        ) : (
+          <ol className="list-decimal space-y-2 pl-5">
+            <li>Open your browser menu (⋮ or ☰).</li>
+            <li>
+              Choose <span className="font-semibold">Install</span> or{" "}
+              <span className="font-semibold">Add to Home Screen</span>.
+            </li>
+            <li>Confirm to add Family Hub to your home screen.</li>
+          </ol>
+        )}
+      </div>
+    </MobileSheet>
+  );
+}

--- a/src/components/shared/sidebar-menu.test.tsx
+++ b/src/components/shared/sidebar-menu.test.tsx
@@ -31,14 +31,19 @@ describe("SidebarMenu", () => {
     expect(useAppStore.getState().isSidebarOpen).toBe(false);
   });
 
-  it("orders menu rows: Family Settings, Preferences, Sign Out", () => {
+  it("orders menu rows: Family Settings, Preferences, Install app, Sign Out", () => {
     renderWithUser(<SidebarMenu />);
 
     const nav = screen.getByRole("navigation");
     const labels = within(nav)
       .getAllByRole("button")
       .map((button) => button.textContent?.trim());
-    expect(labels).toEqual(["Family Settings", "Preferences", "Sign Out"]);
+    expect(labels).toEqual([
+      "Family Settings",
+      "Preferences",
+      "Install app",
+      "Sign Out",
+    ]);
   });
 
   it("opens the Preferences sheet from the Preferences row", async () => {

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -1,5 +1,5 @@
 import { LogOut, SlidersHorizontal, Users, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useFamilyMembers, useFamilyName, useLogout } from "@/api";
 import {
   FamilySettingsModal,
@@ -18,6 +18,7 @@ import { SideSheet } from "@/components/ui/side-sheet";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores";
+import { InstallAppRow } from "./install-app-row";
 
 export function SidebarMenu() {
   const isOpen = useAppStore((state) => state.isSidebarOpen);
@@ -138,15 +139,18 @@ export function SidebarMenu() {
             {menuItems.map((item) => {
               const Icon = item.icon;
               return (
-                <button
-                  key={item.label}
-                  type="button"
-                  onClick={item.action}
-                  className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
-                >
-                  <Icon className="h-5 w-5" />
-                  {item.label}
-                </button>
+                <Fragment key={item.label}>
+                  {/* Install app sits just above Sign Out (hidden when installed). */}
+                  {item.label === "Sign Out" && <InstallAppRow />}
+                  <button
+                    type="button"
+                    onClick={item.action}
+                    className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    <Icon className="h-5 w-5" />
+                    {item.label}
+                  </button>
+                </Fragment>
               );
             })}
           </div>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useDebounce } from "./use-debounce";
 export { useGoogleAuthReturn } from "./use-google-auth-return";
+export { useInstallPrompt } from "./use-install-prompt";
 export { useIsMobile } from "./use-is-mobile";
 export { useMediaQuery } from "./use-media-query";

--- a/src/hooks/use-install-prompt.test.ts
+++ b/src/hooks/use-install-prompt.test.ts
@@ -1,0 +1,48 @@
+import type { BeforeInstallPromptEvent } from "@/lib/pwa";
+import { act, renderHook, waitFor } from "@/test/test-utils";
+import { useInstallPrompt } from "./use-install-prompt";
+
+function makeBeforeInstallPromptEvent() {
+  const event = new Event("beforeinstallprompt") as BeforeInstallPromptEvent & {
+    prompt: ReturnType<typeof vi.fn>;
+  };
+  (event as { prompt: unknown }).prompt = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(event, "userChoice", {
+    value: Promise.resolve({ outcome: "accepted", platform: "web" }),
+  });
+  return event;
+}
+
+describe("useInstallPrompt", () => {
+  it("becomes installable after beforeinstallprompt and clears after appinstalled", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    expect(result.current.canInstall).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(makeBeforeInstallPromptEvent());
+    });
+    await waitFor(() => expect(result.current.canInstall).toBe(true));
+
+    act(() => {
+      window.dispatchEvent(new Event("appinstalled"));
+    });
+    await waitFor(() => expect(result.current.canInstall).toBe(false));
+  });
+
+  it("promptInstall calls prompt() and consumes the event", async () => {
+    const { result } = renderHook(() => useInstallPrompt());
+    const event = makeBeforeInstallPromptEvent();
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+    await waitFor(() => expect(result.current.canInstall).toBe(true));
+
+    await act(async () => {
+      await result.current.promptInstall();
+    });
+
+    expect(event.prompt).toHaveBeenCalledOnce();
+    expect(result.current.canInstall).toBe(false);
+  });
+});

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import type { BeforeInstallPromptEvent } from "@/lib/pwa";
+
+/**
+ * Captures the Chromium `beforeinstallprompt` event so the UI can offer a
+ * one-tap install. `canInstall` is false on browsers that never fire it
+ * (iOS Safari, Firefox) and after the app has been installed.
+ */
+export function useInstallPrompt() {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const handleBeforeInstall = (event: Event) => {
+      event.preventDefault();
+      setDeferred(event as BeforeInstallPromptEvent);
+    };
+    const handleInstalled = () => setDeferred(null);
+
+    window.addEventListener("beforeinstallprompt", handleBeforeInstall);
+    window.addEventListener("appinstalled", handleInstalled);
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
+      window.removeEventListener("appinstalled", handleInstalled);
+    };
+  }, []);
+
+  async function promptInstall() {
+    if (!deferred) return;
+    await deferred.prompt();
+    await deferred.userChoice;
+    setDeferred(null); // a captured prompt can only be used once
+  }
+
+  return { canInstall: deferred !== null, promptInstall };
+}

--- a/src/lib/pwa.test.ts
+++ b/src/lib/pwa.test.ts
@@ -1,0 +1,67 @@
+import { isIOS, isStandalone } from "./pwa";
+
+function mockMatchMedia(matches: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function setUA(ua: string, maxTouchPoints = 0) {
+  Object.defineProperty(navigator, "userAgent", {
+    configurable: true,
+    value: ua,
+  });
+  Object.defineProperty(navigator, "maxTouchPoints", {
+    configurable: true,
+    value: maxTouchPoints,
+  });
+}
+
+describe("isStandalone", () => {
+  it("is true when display-mode standalone matches", () => {
+    mockMatchMedia(true);
+    expect(isStandalone()).toBe(true);
+  });
+
+  it("is false in a normal browser tab", () => {
+    mockMatchMedia(false);
+    Object.defineProperty(navigator, "standalone", {
+      configurable: true,
+      value: undefined,
+    });
+    expect(isStandalone()).toBe(false);
+  });
+
+  it("is true when navigator.standalone is true (iOS installed)", () => {
+    mockMatchMedia(false);
+    Object.defineProperty(navigator, "standalone", {
+      configurable: true,
+      value: true,
+    });
+    expect(isStandalone()).toBe(true);
+  });
+});
+
+describe("isIOS", () => {
+  it("detects an iPhone user agent", () => {
+    setUA("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X)");
+    expect(isIOS()).toBe(true);
+  });
+
+  it("detects iPadOS reporting as Mac with touch", () => {
+    setUA("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)", 5);
+    expect(isIOS()).toBe(true);
+  });
+
+  it("is false for desktop Chrome on macOS", () => {
+    setUA("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)", 0);
+    expect(isIOS()).toBe(false);
+  });
+});

--- a/src/lib/pwa.ts
+++ b/src/lib/pwa.ts
@@ -1,0 +1,31 @@
+/**
+ * The Chromium-only event fired when the browser deems the app installable.
+ * Not in the standard DOM lib, so it's declared here.
+ */
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: "accepted" | "dismissed";
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+/** True when the app is running as an installed/standalone PWA. */
+export function isStandalone(): boolean {
+  if (typeof window === "undefined") return false;
+  const standaloneDisplay =
+    window.matchMedia?.("(display-mode: standalone)").matches === true;
+  const iosStandalone =
+    (navigator as Navigator & { standalone?: boolean }).standalone === true;
+  return standaloneDisplay || iosStandalone;
+}
+
+/** True for iOS/iPadOS Safari, which never fires `beforeinstallprompt`. */
+export function isIOS(): boolean {
+  const ua = navigator.userAgent;
+  const isIPhoneFamily = /iphone|ipad|ipod/i.test(ua);
+  // iPadOS 13+ reports a Mac UA; disambiguate with the touch-point count.
+  const isIPadOSAsMac = /macintosh/i.test(ua) && navigator.maxTouchPoints > 1;
+  return isIPhoneFamily || isIPadOSAsMac;
+}


### PR DESCRIPTION
Closes #213

**Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/pwa-installability.md
**Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-13-pwa-installability-design.md (§D2)
**Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-13-pwa-installability.md (Part 3)

Group **(a)** of the PWA installability work — the install affordance. **No offline data** (Option C).

### Changes
- **`src/lib/pwa.ts`:** `isStandalone()` (display-mode standalone or `navigator.standalone`), `isIOS()` (UA + iPadOS-as-Mac touch check), and the `BeforeInstallPromptEvent` type.
- **`useInstallPrompt` hook:** captures `beforeinstallprompt` (preventDefault + stash), exposes `{ canInstall, promptInstall }`, clears on `appinstalled`; `promptInstall()` consumes the event once.
- **`InstallInstructionsSheet`:** a `MobileSheet` with platform-specific manual steps (iOS Share → Add to Home Screen; generic browser-menu / Install elsewhere).
- **`InstallAppRow`:** rendered in the sidebar just above Sign Out — **hidden when installed/standalone**, **one-tap `promptInstall()`** on Chromium, **opens the instructions sheet** otherwise.

### Acceptance checklist
- [x] Sidebar shows an "Install app" row: one-taps install on Chromium; opens manual instructions elsewhere; hidden when already installed (all three states unit-tested; sidebar order test updated to `Family Settings → Preferences → Install app → Sign Out`).
- [x] Reuses existing primitives only (`MobileSheet`, `lucide-react`, `cn`); no new UI libraries; no offline data/push.

### Verification
- `npm run test -- --run` ✓ **924 passed / 86 files** (added: `pwa.ts`, `useInstallPrompt`, `InstallInstructionsSheet`, `InstallAppRow`).
- `npm run build` ✓ · `npm run lint` ✓ (exit 0).
- **Device smoke before release** (can't be automated — `beforeinstallprompt` isn't dispatchable in Playwright): Android Chrome (Galaxy S10) one-tap install; iOS Safari instructions → Add to Home Screen → relaunch standalone hides the row; desktop Chrome/Edge install.

> Note: independent of #215/#216 (cleanups) and #214/#217 (update prompt + offline banner). Recommended merge order: (c) → (b) → (a).
