### PR TITLE
fix(pwa): capture beforeinstallprompt at app root for one-tap install

### DIFF
--- a/src/hooks/use-install-prompt.test.ts
+++ b/src/hooks/use-install-prompt.test.ts
@@ -1,6 +1,10 @@
 import type { BeforeInstallPromptEvent } from "@/lib/pwa";
 import { act, renderHook, waitFor } from "@/test/test-utils";
-import { useInstallPrompt } from "./use-install-prompt";
+import {
+  resetInstallPromptCaptureForTests,
+  startInstallPromptCapture,
+  useInstallPrompt,
+} from "./use-install-prompt";
 
 function makeBeforeInstallPromptEvent() {
   const event = new Event("beforeinstallprompt") as BeforeInstallPromptEvent & {
@@ -14,7 +18,23 @@ function makeBeforeInstallPromptEvent() {
 }
 
 describe("useInstallPrompt", () => {
+  // The capture singleton lives at module scope; reset it (and its window
+  // listeners) between tests so each case starts from a clean slate.
+  afterEach(() => {
+    resetInstallPromptCaptureForTests();
+  });
+
+  it("captures beforeinstallprompt fired before the consumer mounts", () => {
+    startInstallPromptCapture(); // root capture active from bootstrap
+    window.dispatchEvent(makeBeforeInstallPromptEvent()); // BEFORE renderHook
+
+    const { result } = renderHook(() => useInstallPrompt());
+
+    expect(result.current.canInstall).toBe(true);
+  });
+
   it("becomes installable after beforeinstallprompt and clears after appinstalled", async () => {
+    startInstallPromptCapture();
     const { result } = renderHook(() => useInstallPrompt());
     expect(result.current.canInstall).toBe(false);
 
@@ -30,6 +50,7 @@ describe("useInstallPrompt", () => {
   });
 
   it("promptInstall calls prompt() and consumes the event", async () => {
+    startInstallPromptCapture();
     const { result } = renderHook(() => useInstallPrompt());
     const event = makeBeforeInstallPromptEvent();
 

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -1,37 +1,89 @@
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import type { BeforeInstallPromptEvent } from "@/lib/pwa";
 
 /**
- * Captures the Chromium `beforeinstallprompt` event so the UI can offer a
- * one-tap install. `canInstall` is false on browsers that never fire it
+ * Module-level capture of the Chromium `beforeinstallprompt` event.
+ *
+ * Chrome fires `beforeinstallprompt` once, early, at window scope — before the
+ * user ever opens the sidebar where `InstallAppRow` lives. If we only listened
+ * while that component is mounted (as a hook-local `useEffect` would), the event
+ * would already be gone and one-tap install could never trigger. So the capture
+ * lives here as a singleton and is started once at app bootstrap (see
+ * `main.tsx`), independent of any component lifecycle. The event is never
+ * persisted — it is only meaningful for the current page session.
+ */
+let deferredPrompt: BeforeInstallPromptEvent | null = null;
+const subscribers = new Set<() => void>();
+let capturing = false;
+
+function notifySubscribers() {
+  for (const callback of subscribers) callback();
+}
+
+function handleBeforeInstall(event: Event) {
+  event.preventDefault();
+  deferredPrompt = event as BeforeInstallPromptEvent;
+  notifySubscribers();
+}
+
+function handleInstalled() {
+  deferredPrompt = null;
+  notifySubscribers();
+}
+
+/**
+ * Start capturing install-prompt events at the window scope. Idempotent: safe
+ * to call more than once; only the first call attaches listeners. Call this
+ * once during app bootstrap so the prompt is captured even before the consumer
+ * component mounts.
+ */
+export function startInstallPromptCapture() {
+  if (capturing) return;
+  capturing = true;
+  window.addEventListener("beforeinstallprompt", handleBeforeInstall);
+  window.addEventListener("appinstalled", handleInstalled);
+}
+
+function subscribe(callback: () => void) {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+}
+
+function getSnapshot() {
+  return deferredPrompt;
+}
+
+/**
+ * Reads the install prompt captured by {@link startInstallPromptCapture}.
+ * `canInstall` is false on browsers that never fire `beforeinstallprompt`
  * (iOS Safari, Firefox) and after the app has been installed.
  */
 export function useInstallPrompt() {
-  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(
-    null,
-  );
-
-  useEffect(() => {
-    const handleBeforeInstall = (event: Event) => {
-      event.preventDefault();
-      setDeferred(event as BeforeInstallPromptEvent);
-    };
-    const handleInstalled = () => setDeferred(null);
-
-    window.addEventListener("beforeinstallprompt", handleBeforeInstall);
-    window.addEventListener("appinstalled", handleInstalled);
-    return () => {
-      window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
-      window.removeEventListener("appinstalled", handleInstalled);
-    };
-  }, []);
+  // getSnapshot doubles as the server snapshot: this is a client-only SPA, and
+  // deferredPrompt is null until a real browser event arrives.
+  const deferred = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   async function promptInstall() {
-    if (!deferred) return;
-    await deferred.prompt();
-    await deferred.userChoice;
-    setDeferred(null); // a captured prompt can only be used once
+    if (!deferredPrompt) return;
+    await deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    deferredPrompt = null; // a captured prompt can only be used once
+    notifySubscribers();
   }
 
   return { canInstall: deferred !== null, promptInstall };
+}
+
+/**
+ * Test-only: tear down the capture singleton (listeners + state) so each test
+ * starts clean. Not exported from the `@/hooks` barrel; not for production use.
+ */
+export function resetInstallPromptCaptureForTests() {
+  window.removeEventListener("beforeinstallprompt", handleBeforeInstall);
+  window.removeEventListener("appinstalled", handleInstalled);
+  capturing = false;
+  deferredPrompt = null;
+  subscribers.clear();
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { PWAUpdater } from "@/components/pwa/pwa-updater";
+import { startInstallPromptCapture } from "@/hooks/use-install-prompt";
 import { QueryProvider } from "@/providers/query-provider";
 import "@fontsource/nunito/latin-400.css";
 import "@fontsource/nunito/latin-500.css";
@@ -8,6 +9,10 @@ import "@fontsource/nunito/latin-600.css";
 import "@fontsource/nunito/latin-700.css";
 import "./index.css";
 import App from "./App.tsx";
+
+// Capture the Chromium `beforeinstallprompt` event from bootstrap — Chrome fires
+// it once, early, before the sidebar (and `InstallAppRow`) ever mounts.
+startInstallPromptCapture();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION
## Problem

On Android Chrome the sidebar **Install app** row showed the *manual instructions* sheet instead of the intended **one-tap native install**.

Chrome fires `beforeinstallprompt` once, early, at window scope — before the user opens the sidebar. The capture listener lived inside `useInstallPrompt`'s `useEffect`, and that hook is consumed only by `InstallAppRow`, which renders only inside the sidebar (`SideSheet`, a Radix `Dialog` with no `forceMount`). So the listener wasn't attached yet when the event fired, the event was missed, `canInstall` stayed `false`, and the row always fell back to the instructions sheet. One-tap install could never trigger.

## Fix

Move the `beforeinstallprompt` / `appinstalled` capture to the **app root** so it's active from bootstrap, independent of the sidebar:

- `use-install-prompt.ts` now holds the deferred prompt in a module-level external store (subscriber set), exposing an idempotent `startInstallPromptCapture()` that attaches the window listeners.
- `useInstallPrompt()` reads the already-captured prompt via `useSyncExternalStore`. Its public API is unchanged: `{ canInstall, promptInstall }`.
- `main.tsx` calls `startInstallPromptCapture()` once at bootstrap (alongside `<PWAUpdater/>`).
- The event is never persisted; `promptInstall()` calls `.prompt()`, awaits `userChoice`, then clears it (single use).

`InstallAppRow`, its test, and `sidebar-menu.tsx` are untouched — they keep reading `canInstall`/`promptInstall` exactly as before.

## TDD

Added a regression test that fails on the old code: with root capture started, an event fired **before** the consumer mounts is still captured.

```ts
it("captures beforeinstallprompt fired before the consumer mounts", () => {
  startInstallPromptCapture();                          // root capture active
  window.dispatchEvent(makeBeforeInstallPromptEvent()); // BEFORE renderHook
  const { result } = renderHook(() => useInstallPrompt());
  expect(result.current.canInstall).toBe(true);
});
```

Existing coverage retained: `appinstalled` clears `canInstall`, and `promptInstall()` calls `.prompt()` and consumes the event.

## Context

Follows up FE #218 and the PWA installability story in the `joe-bor/family-hub` product docs. Restores the **"one-tap install on Chromium"** acceptance criterion for the sidebar Install app row.

## Verification

- [x] `npm run lint` — exit 0
- [x] `npm run test -- --run` — 932 passed
- [x] `npm run build` — passes
- [x] New regression test fails on `main` (event missed before mount), passes with root capture
- [ ] CI green (lint + unit + build + Lighthouse + E2E vs real backend)
