### PR TITLE
fix(offline): prevent first-session offline blank-page crash

### DIFF
--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -38,14 +38,14 @@ export async function waitForHydration(page: Page): Promise<void> {
  * Tests that navigate to a never-visited, lazily-loaded module (e.g. Chores)
  * while offline rely on that module's JS chunk being served from the Workbox
  * precache. The chunk is only served once the SW is ACTIVE (precache complete)
- * and controls this page. The PWA ships `skipWaiting` without `clientsClaim`,
- * so a tab opened before the SW activated stays uncontrolled until its next
- * navigation — on slow CI the test can go offline before that happens, the
- * chunk import hits the network, fails, and the app crashes to a blank page.
+ * and controls this page. The PWA now ships `clientsClaim`, so the SW claims
+ * this tab as soon as it activates and the controller usually appears without a
+ * reload.
  *
- * Wait for an active SW (its `ready` promise), then reload once if this page is
- * not yet controlled so the SW serves it — and its offline lazy imports — from
- * cache.
+ * Wait for an active SW (its `ready` promise), then — as a defensive guard for
+ * the brief gap between activation and the clientsClaim `controllerchange` —
+ * reload once if this page is still not controlled so the SW serves it, and its
+ * offline lazy imports, from cache.
  */
 export async function waitForServiceWorkerReady(page: Page): Promise<void> {
   const isControlled = () =>

--- a/e2e/offline-persistence.spec.ts
+++ b/e2e/offline-persistence.spec.ts
@@ -100,6 +100,58 @@ test.describe("Offline read persistence (Option C)", () => {
     ).toBeVisible();
   });
 
+  test("a precached module chunk that fails to load shows the offline empty state, not a blank page", async ({
+    page,
+    context,
+    request,
+  }) => {
+    const reg = await registerFamily(request, {
+      familyName: "Evicted Chunk",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+
+    // Load online and gain SW control so the Chores chunk is precached and would
+    // normally be served offline.
+    await seedBrowserAuth(page, reg);
+    await page.reload();
+    await waitForHydration(page);
+    await expect(page.getByRole("button", { name: "Add event" })).toBeVisible();
+    await waitForServiceWorkerReady(page);
+
+    // Force a precache miss for the Chores chunk by dropping it from BOTH the
+    // Workbox cache and the HTTP cache, so the offline dynamic import has nothing
+    // to serve and must hit the (offline) network. This is the defense-in-depth
+    // path clientsClaim cannot cover: a precached chunk that was evicted.
+    const client = await context.newCDPSession(page);
+    await client.send("Network.clearBrowserCache");
+    const evicted = await page.evaluate(async () => {
+      let count = 0;
+      for (const name of await caches.keys()) {
+        const cache = await caches.open(name);
+        for (const req of await cache.keys()) {
+          if (new URL(req.url).pathname.includes("chores-view")) {
+            if (await cache.delete(req)) count++;
+          }
+        }
+      }
+      return count;
+    });
+    expect(evicted).toBeGreaterThan(0);
+
+    // Offline, navigate to Chores — the chunk import now fails.
+    await context.setOffline(true);
+    await page.getByRole("button", { name: /chores/i }).click();
+
+    // The error boundary renders the offline empty state instead of crashing.
+    await expect(
+      page.getByText(/haven't been saved for offline viewing yet/i),
+    ).toBeVisible();
+    // It is the boundary fallback, not the loaded module: the module's own header
+    // is absent, and the app shell (nav) survived rather than blanking out.
+    await expect(page.getByRole("heading", { name: "Chores" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /chores/i })).toBeVisible();
+  });
+
   test("cross-account: a second family never sees the first family's cached data", async ({
     page,
     request,
@@ -140,5 +192,65 @@ test.describe("Offline read persistence (Option C)", () => {
 
     // Family A's persisted event must not leak into Family B's session.
     await expect(page.getByText("Family A Secret")).toHaveCount(0);
+  });
+});
+
+/**
+ * First-session case: the tab that registered the service worker is itself
+ * uncontrolled until the SW claims it. Without clientsClaim it stays uncontrolled
+ * for the whole session, so an offline lazy import hits the network and crashes
+ * the app to a blank page. These tests use a single authenticated load (auth is
+ * seeded before navigation) and never do the control-gaining reload.
+ */
+test.describe("Offline first session (clientsClaim)", () => {
+  test("a never-visited module loads offline without a control-gaining reload", async ({
+    page,
+    context,
+    request,
+  }) => {
+    const reg = await registerFamily(request, {
+      familyName: "First Session",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+
+    // Seed auth BEFORE the first navigation so the very first load — the one that
+    // registers the SW and is therefore uncontrolled — is already authenticated.
+    // No second, control-gaining reload happens after this.
+    await page.addInitScript((data) => {
+      localStorage.setItem("family-hub-auth-token", data.token);
+      localStorage.setItem(
+        "family-hub-family",
+        JSON.stringify({
+          state: { family: data.family, _hasHydrated: true },
+          version: 0,
+        }),
+      );
+    }, reg);
+
+    await page.goto("/");
+    await waitForHydration(page);
+    await expect(page.getByRole("button", { name: "Add event" })).toBeVisible();
+
+    // The SW activates after this page loaded. clientsClaim must make it take
+    // control of this already-open tab WITHOUT a reload; otherwise the controller
+    // never appears and offline lazy imports cannot be served from precache.
+    await page.evaluate(() => navigator.serviceWorker?.ready);
+    await page.waitForFunction(
+      () => navigator.serviceWorker.controller != null,
+      undefined,
+      { timeout: 15000 },
+    );
+
+    // Offline, navigate via SPA (no reload) to the never-visited Chores module.
+    await context.setOffline(true);
+    await page.getByRole("button", { name: /chores/i }).click();
+
+    // The precached chunk loads from the now-controlling SW: the module's own
+    // header renders (proof the chunk loaded, not the error-boundary fallback)…
+    await expect(page.getByRole("heading", { name: "Chores" })).toBeVisible();
+    // …alongside its honest "not saved for offline" empty state (no cached data).
+    await expect(
+      page.getByText(/haven't been saved for offline viewing yet/i),
+    ).toBeVisible();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { CalendarModule } from "@/components/calendar";
 import { HomeDashboard } from "@/components/home";
 import {
   AppHeader,
+  LazyModule,
   MobileBottomNav,
   NavigationTabs,
   OfflineBanner,
@@ -46,14 +47,6 @@ const LoginFlow = lazy(() =>
   import("@/components/auth").then((m) => ({ default: m.LoginFlow })),
 );
 
-function ModuleLoader() {
-  return (
-    <div className="flex-1 flex items-center justify-center">
-      <div className="animate-pulse text-muted-foreground">Loading...</div>
-    </div>
-  );
-}
-
 function renderModule(activeModule: ModuleType | null) {
   if (activeModule === null) {
     return <HomeDashboard />;
@@ -64,33 +57,33 @@ function renderModule(activeModule: ModuleType | null) {
       return <CalendarModule />;
     case "chores":
       return (
-        <Suspense fallback={<ModuleLoader />}>
+        <LazyModule label="chores">
           <ChoresView />
-        </Suspense>
+        </LazyModule>
       );
     case "meals":
       return (
-        <Suspense fallback={<ModuleLoader />}>
+        <LazyModule label="meals">
           <MealsView />
-        </Suspense>
+        </LazyModule>
       );
     case "recipes":
       return (
-        <Suspense fallback={<ModuleLoader />}>
+        <LazyModule label="recipes">
           <RecipesView />
-        </Suspense>
+        </LazyModule>
       );
     case "lists":
       return (
-        <Suspense fallback={<ModuleLoader />}>
+        <LazyModule label="lists">
           <ListsView />
-        </Suspense>
+        </LazyModule>
       );
     case "photos":
       return (
-        <Suspense fallback={<ModuleLoader />}>
+        <LazyModule label="photos">
           <PhotosView />
-        </Suspense>
+        </LazyModule>
       );
     default:
       return null;

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,4 +1,5 @@
 export { AppHeader } from "./app-header";
+export { LazyModule } from "./lazy-module";
 export { MobileBottomNav } from "./mobile-bottom-nav";
 export { NavigationTabs, type TabType } from "./navigation-tabs";
 export { OfflineBanner } from "./offline-banner";

--- a/src/components/shared/lazy-module.test.tsx
+++ b/src/components/shared/lazy-module.test.tsx
@@ -1,0 +1,117 @@
+import { Component, type ReactNode } from "react";
+import { render, screen } from "@/test/test-utils";
+import { ChunkLoadErrorBoundary, isChunkLoadError } from "./lazy-module";
+
+function setOnLine(value: boolean) {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value });
+}
+
+/** A child that throws the given value during render. */
+function Throw({ error }: { error: unknown }): ReactNode {
+  throw error;
+}
+
+afterEach(() => {
+  // jsdom's navigator.onLine is sticky across tests once redefined.
+  setOnLine(true);
+});
+
+describe("isChunkLoadError", () => {
+  it.each([
+    // Chromium
+    "Failed to fetch dynamically imported module: https://app/assets/chores-view-CHEO_W4C.js",
+    // Firefox
+    "error loading dynamically imported module: https://app/assets/chores-view.js",
+    // WebKit / Safari
+    "Importing a module script failed.",
+  ])("returns true for a dynamic import failure (%s)", (message) => {
+    expect(isChunkLoadError(new TypeError(message))).toBe(true);
+  });
+
+  it("returns true for a webpack-style ChunkLoadError by name", () => {
+    const error = new Error("Loading chunk 5 failed.");
+    error.name = "ChunkLoadError";
+    expect(isChunkLoadError(error)).toBe(true);
+  });
+
+  it("returns false for an unrelated runtime error", () => {
+    expect(
+      isChunkLoadError(
+        new TypeError("Cannot read properties of undefined (reading 'map')"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isChunkLoadError("Failed to fetch")).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe("ChunkLoadErrorBoundary", () => {
+  // React logs every error an error boundary catches; silence it so the test
+  // output stays pristine.
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("renders its children when nothing throws", () => {
+    render(
+      <ChunkLoadErrorBoundary label="chores">
+        <div>chores module content</div>
+      </ChunkLoadErrorBoundary>,
+    );
+    expect(screen.getByText("chores module content")).toBeInTheDocument();
+  });
+
+  it("renders the offline empty state when a chunk fails to load offline", () => {
+    setOnLine(false);
+    render(
+      <ChunkLoadErrorBoundary label="chores">
+        <Throw
+          error={
+            new TypeError(
+              "Failed to fetch dynamically imported module: /assets/chores-view-CHEO_W4C.js",
+            )
+          }
+        />
+      </ChunkLoadErrorBoundary>,
+    );
+    expect(
+      screen.getByText(/haven't been saved for offline viewing yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("re-throws non-chunk errors instead of masking real bugs", () => {
+    // An outer boundary captures whatever ChunkLoadErrorBoundary re-throws.
+    class Capture extends Component<
+      { children: ReactNode },
+      { caught: Error | null }
+    > {
+      state: { caught: Error | null } = { caught: null };
+      static getDerivedStateFromError(error: Error) {
+        return { caught: error };
+      }
+      render() {
+        return this.state.caught ? (
+          <div>captured: {this.state.caught.message}</div>
+        ) : (
+          this.props.children
+        );
+      }
+    }
+
+    render(
+      <Capture>
+        <ChunkLoadErrorBoundary label="chores">
+          <Throw error={new TypeError("Cannot read properties of undefined")} />
+        </ChunkLoadErrorBoundary>
+      </Capture>,
+    );
+
+    expect(
+      screen.getByText(/captured: Cannot read properties of undefined/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/lazy-module.tsx
+++ b/src/components/shared/lazy-module.tsx
@@ -1,0 +1,81 @@
+import { Component, type ReactNode, Suspense } from "react";
+import { OfflineUnavailable } from "./offline-unavailable";
+
+/**
+ * True when `error` is a failed dynamic `import()` of a code-split chunk — the
+ * browser could not fetch or parse the module script. Matches the per-engine
+ * messages plus the webpack-era `ChunkLoadError` name. Used to tell a precache
+ * miss (offline) apart from a genuine runtime bug inside the module, so the
+ * boundary only swallows the former.
+ */
+export function isChunkLoadError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "ChunkLoadError") return true;
+  const message = error.message.toLowerCase();
+  return (
+    // Chromium
+    message.includes("failed to fetch dynamically imported module") ||
+    // Firefox
+    message.includes("error loading dynamically imported module") ||
+    // WebKit / Safari
+    message.includes("importing a module script failed")
+  );
+}
+
+interface LazyModuleProps {
+  /** Module label for the offline empty state, e.g. "chores". */
+  label: string;
+  children: ReactNode;
+}
+
+interface ChunkLoadErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Error boundary for a lazily-loaded module. When the module's chunk fails to
+ * load — the user went offline before the service worker controlled the tab
+ * (first session), or a precached chunk was evicted — it renders the offline
+ * empty state instead of letting the rejected `import()` crash the whole app to
+ * a blank page. Non-chunk errors are re-thrown so real bugs are not masked.
+ */
+export class ChunkLoadErrorBoundary extends Component<
+  LazyModuleProps,
+  ChunkLoadErrorBoundaryState
+> {
+  state: ChunkLoadErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ChunkLoadErrorBoundaryState {
+    return { error };
+  }
+
+  render() {
+    const { error } = this.state;
+    if (error) {
+      if (!isChunkLoadError(error)) throw error;
+      return <OfflineUnavailable label={this.props.label} />;
+    }
+    return this.props.children;
+  }
+}
+
+function ModuleLoader() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <div className="animate-pulse text-muted-foreground">Loading...</div>
+    </div>
+  );
+}
+
+/**
+ * Wraps a lazily-loaded module in a Suspense boundary (loading fallback) and a
+ * ChunkLoadErrorBoundary (offline / precache-miss fallback) so a chunk that
+ * cannot be fetched degrades to an honest empty state instead of a blank page.
+ */
+export function LazyModule({ label, children }: LazyModuleProps) {
+  return (
+    <ChunkLoadErrorBoundary label={label}>
+      <Suspense fallback={<ModuleLoader />}>{children}</Suspense>
+    </ChunkLoadErrorBoundary>
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,6 +56,13 @@ export default defineConfig(() => {
           globIgnores: ["**/stats.html"],
           navigateFallback: "/index.html",
           navigateFallbackDenylist: [/^\/api/],
+          // Take control of the already-open tab as soon as the SW activates.
+          // The tab that registered the SW is otherwise uncontrolled for the rest
+          // of the session, so a first-session offline navigation to a
+          // not-yet-visited lazy module would miss the precache, hit the network,
+          // and crash the app to a blank page. Pairs with the message-driven
+          // skipWaiting the `prompt` update flow already ships.
+          clientsClaim: true,
           // No runtimeCaching: Nunito is self-hosted via @fontsource/nunito and
           // precached by the glob above; the old Google Fonts CDN rules were dead.
         },


### PR DESCRIPTION
## Summary

Fixes a real **first-session offline crash** discovered while fixing the E2E for #223 (offline read persistence, "Option C"). On a user's first visit, navigating offline to a not-yet-visited lazy module blanked the entire app. This PR addresses it with two complementary changes plus dedicated E2E coverage.

## Findings (root cause)

The generated service worker ships message-driven `skipWaiting` (the `prompt` update flow) but **not `clientsClaim`**. On the first session:

1. The SW installs and activates, but the tab that *registered* it stays **uncontrolled** for the rest of the session (a SW only controls pages it was active for at navigation time, or pages it explicitly claims).
2. The lazy modules in `src/App.tsx` (Chores, Meals, Recipes, Lists, Photos) are `React.lazy()` dynamic imports. If the user goes offline and opens one they hadn't visited, the `import()` for that chunk bypasses the uncontrolled SW, hits the network, and fails.
3. Those `<Suspense>` boundaries had **no error boundary**, so the rejected import propagated unhandled and unmounted the app — a blank `#faf8f5` page.

## Fixes

**1. `clientsClaim: true` in the Workbox config** (`vite.config.ts`) — the active SW now takes control of the open tab immediately, so precached lazy chunks load offline within the first session. This is the root-cause fix.

**2. Lazy-module error boundary** (`src/components/shared/lazy-module.tsx`, wired into `App.tsx`) — `LazyModule` pairs `Suspense` with a `ChunkLoadErrorBoundary` that renders the existing `OfflineUnavailable` empty state when a chunk fails to load. It only swallows **chunk-load** errors (matched per browser engine plus the `ChunkLoadError` name) and **re-throws everything else**, so genuine render bugs aren't masked. This is defense-in-depth: even with `clientsClaim`, a precache miss/eviction shouldn't blank the app. It also de-duplicated the five repeated `<Suspense>` wrappers.

## Test coverage

Two new tests in `e2e/offline-persistence.spec.ts`, deliberately non-overlapping so each fix has a test that fails without it:

- **first session (`clientsClaim`)** — seeds auth *before* the first navigation so the uncontrolled tab is authenticated, then asserts the SW claims the tab without a control-gaining reload and the never-visited module's own header renders offline (proving the chunk actually loaded, not the fallback).
- **evicted chunk (error boundary)** — drops the Chores chunk from both the Workbox and HTTP caches, goes offline, and asserts the offline empty state renders and the app shell survives instead of blanking.

Plus a unit test (`src/components/shared/lazy-module.test.tsx`) for the chunk-vs-non-chunk discrimination and the boundary's fallback/re-throw behavior. `e2e/helpers/test-helpers.ts` docs updated to reflect that `clientsClaim` now claims the tab on activation.

## Verification

Both new E2E tests were confirmed **red before the fix** (clientsClaim test: `controller` never set; boundary test: blank page) and **green after**. On top of the latest `main` (post-#223 merge, with the 43-package dependency bump):

- `npm run lint` — clean
- `npm run build` / `tsc --noEmit` — clean
- unit suite — **992/992**
- `--project=offline-persistence` E2E — **5/5**

## Out of scope

The login/onboarding lazy `Suspense` boundaries also lack an error boundary, but an offline first-session *unauthenticated* user can't proceed anyway (no cached data, no offline login), so the value is low. Can follow up if desired.
