### PR TITLE
feat: native-feel interaction polish (transitions + press feedback)

### DIFF
--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -1,6 +1,7 @@
 import FamilyHub from "./App";
 import { useAppStore } from "./stores";
 import {
+  act,
   render,
   screen,
   seedAuthStore,
@@ -130,5 +131,32 @@ describe("App shell", () => {
     expect(
       screen.queryByRole("navigation", { name: /primary/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("animates the module container when the active module changes", () => {
+    // Mobile width so Home (null) is valid; reduced-motion OFF so ScreenTransition animates.
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query.includes("max-width"),
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    const animateMock = vi.fn();
+    (Element.prototype as unknown as { animate: unknown }).animate =
+      animateMock;
+
+    useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
+    render(<FamilyHub />);
+
+    // Switch between two eager modules so the container's token changes (no lazy/Suspense).
+    act(() => {
+      useAppStore.getState().setActiveModule(null);
+    });
+
+    expect(animateMock).toHaveBeenCalled();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import {
   MobileBottomNav,
   NavigationTabs,
   OfflineBanner,
+  ScreenTransition,
   SidebarMenu,
 } from "@/components/shared";
 import { Toaster } from "@/components/ui/toaster";
@@ -166,7 +167,9 @@ export default function FamilyHub() {
         <div className="flex-1 flex min-h-0 overflow-hidden">
           {!isMobile && <NavigationTabs />}
           <main className="flex-1 min-h-0 flex flex-col overflow-hidden">
-            {renderModule(activeModule)}
+            <ScreenTransition token={activeModule} mode="fade">
+              {renderModule(activeModule)}
+            </ScreenTransition>
           </main>
         </div>
 

--- a/src/components/calendar/components/event-detail-modal.test.tsx
+++ b/src/components/calendar/components/event-detail-modal.test.tsx
@@ -5,6 +5,8 @@ import { EventDetailModal } from "./event-detail-modal";
 
 vi.mock("@/hooks", () => ({
   useIsMobile: () => false,
+  // Button now calls usePressable(); this fully-mocked barrel must provide it.
+  usePressable: () => ({ className: "", onPointerDown: () => {} }),
 }));
 
 vi.mock("@/api", () => ({

--- a/src/components/lists-view.test.tsx
+++ b/src/components/lists-view.test.tsx
@@ -453,4 +453,20 @@ describe("ListsView hub", () => {
       screen.getByRole("button", { name: "Add item" }),
     ).toBeInTheDocument();
   });
+
+  it("slides the detail in from the right when a list opens", async () => {
+    const animateMock = vi.fn();
+    (Element.prototype as unknown as { animate: unknown }).animate =
+      animateMock;
+    seedMockLists([generalList]);
+
+    const { user } = renderWithUser(<ListsView />);
+    await user.click(
+      await screen.findByRole("button", { name: /Movie Night/i }),
+    );
+
+    expect(animateMock.mock.calls.at(-1)?.[0][0].transform).toBe(
+      "translateX(22%)",
+    );
+  });
 });

--- a/src/components/lists-view.test.tsx
+++ b/src/components/lists-view.test.tsx
@@ -454,6 +454,14 @@ describe("ListsView hub", () => {
     ).toBeInTheDocument();
   });
 
+  it("gives list cards press feedback", async () => {
+    seedMockLists([generalList]);
+    render(<ListsView />);
+    expect(
+      (await screen.findByRole("button", { name: /Movie Night/i })).className,
+    ).toContain("active:scale-[0.97]");
+  });
+
   it("slides the detail in from the right when a list opens", async () => {
     const animateMock = vi.fn();
     (Element.prototype as unknown as { animate: unknown }).animate =

--- a/src/components/lists-view.tsx
+++ b/src/components/lists-view.tsx
@@ -1,7 +1,7 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useListPreferences, useLists } from "@/api";
-import { OfflineUnavailable } from "@/components/shared";
+import { OfflineUnavailable, ScreenTransition } from "@/components/shared";
 import { useIsMobile } from "@/hooks";
 import { cn } from "@/lib/utils";
 import { ListCard } from "./lists/list-card";
@@ -16,34 +16,90 @@ export function ListsView() {
   const lists = useLists();
   const preferences = useListPreferences();
 
-  if (selectedListId !== null) {
-    return (
-      <ListDetailView
-        listId={selectedListId}
-        preferences={preferences.data?.data ?? null}
-        preferencesStatus={
-          preferences.isLoading
-            ? "loading"
-            : preferences.isError
-              ? "error"
-              : preferences.data?.data
-                ? "ready"
-                : "unavailable"
-        }
-        onBack={() => setSelectedListId(null)}
-      />
-    );
-  }
+  const body = (() => {
+    if (selectedListId !== null) {
+      return (
+        <ListDetailView
+          listId={selectedListId}
+          preferences={preferences.data?.data ?? null}
+          preferencesStatus={
+            preferences.isLoading
+              ? "loading"
+              : preferences.isError
+                ? "error"
+                : preferences.data?.data
+                  ? "ready"
+                  : "unavailable"
+          }
+          onBack={() => setSelectedListId(null)}
+        />
+      );
+    }
 
-  if (lists.isLoading) {
-    return (
-      <div className="flex-1 p-4 text-sm text-muted-foreground">
-        Loading lists
-      </div>
-    );
-  }
+    if (lists.isLoading) {
+      return (
+        <div className="flex-1 p-4 text-sm text-muted-foreground">
+          Loading lists
+        </div>
+      );
+    }
 
-  if (lists.isError) {
+    if (lists.isError) {
+      return (
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
+          <div className="mx-auto max-w-2xl space-y-6">
+            <div
+              className={cn(
+                "flex items-center gap-3",
+                isMobile ? "justify-end" : "justify-between",
+              )}
+            >
+              {!isMobile && (
+                <h2 className="text-[24px] font-semibold leading-8 text-foreground">
+                  My Lists
+                </h2>
+              )}
+              <Button type="button" onClick={() => setCreateOpen(true)}>
+                <Plus className="h-4 w-4" />
+                New List
+              </Button>
+            </div>
+
+            <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
+              <h3 className="text-lg font-semibold text-foreground">
+                Lists could not be loaded
+              </h3>
+              <p className="mt-2 text-sm leading-5 text-muted-foreground">
+                Check your connection and try again.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-4"
+                onClick={() => lists.refetch()}
+              >
+                Try again
+              </Button>
+            </div>
+
+            <ListCreateSheet
+              open={createOpen}
+              onOpenChange={setCreateOpen}
+              onCreated={(id) => setSelectedListId(id)}
+            />
+          </div>
+        </div>
+      );
+    }
+
+    // Offline + never loaded: the paused query has no data and no error, so
+    // distinguish "offline, nothing cached" from a genuinely empty list.
+    if (!lists.data) {
+      return <OfflineUnavailable label="lists" />;
+    }
+
+    const summaries = lists.data.data;
+
     return (
       <div className="flex-1 overflow-y-auto p-4 sm:p-6">
         <div className="mx-auto max-w-2xl space-y-6">
@@ -64,22 +120,35 @@ export function ListsView() {
             </Button>
           </div>
 
-          <div className="rounded-lg border border-border bg-card p-6 shadow-sm">
-            <h3 className="text-lg font-semibold text-foreground">
-              Lists could not be loaded
-            </h3>
-            <p className="mt-2 text-sm leading-5 text-muted-foreground">
-              Check your connection and try again.
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              className="mt-4"
-              onClick={() => lists.refetch()}
-            >
-              Try again
-            </Button>
-          </div>
+          {summaries.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center shadow-sm">
+              <h3 className="text-lg font-semibold text-foreground">
+                No lists yet
+              </h3>
+              <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-muted-foreground">
+                Create the first shared family list for groceries, errands, or
+                anything else worth keeping together.
+              </p>
+              <Button
+                type="button"
+                className="mt-4"
+                onClick={() => setCreateOpen(true)}
+              >
+                <Plus className="h-4 w-4" />
+                Create first list
+              </Button>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
+              {summaries.map((list) => (
+                <ListCard
+                  key={list.id}
+                  list={list}
+                  onOpen={() => setSelectedListId(list.id)}
+                />
+              ))}
+            </div>
+          )}
 
           <ListCreateSheet
             open={createOpen}
@@ -89,72 +158,15 @@ export function ListsView() {
         </div>
       </div>
     );
-  }
-
-  // Offline + never loaded: the paused query has no data and no error, so
-  // distinguish "offline, nothing cached" from a genuinely empty list.
-  if (!lists.data) {
-    return <OfflineUnavailable label="lists" />;
-  }
-
-  const summaries = lists.data.data;
+  })();
 
   return (
-    <div className="flex-1 overflow-y-auto p-4 sm:p-6">
-      <div className="mx-auto max-w-2xl space-y-6">
-        <div
-          className={cn(
-            "flex items-center gap-3",
-            isMobile ? "justify-end" : "justify-between",
-          )}
-        >
-          {!isMobile && (
-            <h2 className="text-[24px] font-semibold leading-8 text-foreground">
-              My Lists
-            </h2>
-          )}
-          <Button type="button" onClick={() => setCreateOpen(true)}>
-            <Plus className="h-4 w-4" />
-            New List
-          </Button>
-        </div>
-
-        {summaries.length === 0 ? (
-          <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center shadow-sm">
-            <h3 className="text-lg font-semibold text-foreground">
-              No lists yet
-            </h3>
-            <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-muted-foreground">
-              Create the first shared family list for groceries, errands, or
-              anything else worth keeping together.
-            </p>
-            <Button
-              type="button"
-              className="mt-4"
-              onClick={() => setCreateOpen(true)}
-            >
-              <Plus className="h-4 w-4" />
-              Create first list
-            </Button>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4">
-            {summaries.map((list) => (
-              <ListCard
-                key={list.id}
-                list={list}
-                onOpen={() => setSelectedListId(list.id)}
-              />
-            ))}
-          </div>
-        )}
-
-        <ListCreateSheet
-          open={createOpen}
-          onOpenChange={setCreateOpen}
-          onCreated={(id) => setSelectedListId(id)}
-        />
-      </div>
-    </div>
+    <ScreenTransition
+      token={selectedListId ?? "__list__"}
+      mode="slide"
+      direction={selectedListId ? "forward" : "back"}
+    >
+      {body}
+    </ScreenTransition>
   );
 }

--- a/src/components/lists/list-card.tsx
+++ b/src/components/lists/list-card.tsx
@@ -1,4 +1,5 @@
 import { ClipboardList, ListTodo, ShoppingCart } from "lucide-react";
+import { usePressable } from "@/hooks";
 import type { ListKind, ListSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +34,7 @@ const kindMeta: Record<
 };
 
 export function ListCard({ list, onOpen }: ListCardProps) {
+  const pressable = usePressable();
   const meta = kindMeta[list.kind];
   const Icon = meta.icon;
   const remainingItems = list.totalItems - list.completedItems;
@@ -49,7 +51,11 @@ export function ListCard({ list, onOpen }: ListCardProps) {
     <button
       type="button"
       onClick={onOpen}
-      className="min-h-32 rounded-lg border border-border bg-card p-4 text-left shadow-sm transition-all hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onPointerDown={pressable.onPointerDown}
+      className={cn(
+        "min-h-32 rounded-lg border border-border bg-card p-4 text-left shadow-sm transition-all hover:border-primary/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        pressable.className,
+      )}
     >
       <div className="flex items-start justify-between gap-3">
         <div

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -902,6 +902,31 @@ describe("RecipesView", () => {
     expect(importRecipe).toHaveBeenCalledTimes(1);
   });
 
+  it("slides the recipe detail right on open and back-left on close", async () => {
+    const animateMock = vi.fn();
+    (Element.prototype as unknown as { animate: unknown }).animate =
+      animateMock;
+    seedMockRecipes([testRecipeDetail]);
+
+    const { user } = renderWithUser(<RecipesView />);
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+    expect(animateMock.mock.calls.at(-1)?.[0][0].transform).toBe(
+      "translateX(22%)",
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: "Back to recipes" }),
+    );
+    expect(animateMock.mock.calls.at(-1)?.[0][0].transform).toBe(
+      "translateX(-22%)",
+    );
+  });
+
   it("shows an import error without selecting a partial recipe", async () => {
     seedMockRecipes([]);
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -902,6 +902,18 @@ describe("RecipesView", () => {
     expect(importRecipe).toHaveBeenCalledTimes(1);
   });
 
+  it("gives recipe cards press feedback", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    render(<RecipesView />);
+    expect(
+      (
+        await screen.findByRole("article", {
+          name: `Recipe card: ${testRecipeDetail.title}`,
+        })
+      ).className,
+    ).toContain("active:scale-[0.97]");
+  });
+
   it("slides the recipe detail right on open and back-left on close", async () => {
     const animateMock = vi.fn();
     (Element.prototype as unknown as { animate: unknown }).animate =

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -8,7 +8,7 @@ import {
   type RecipeTagFilterOption,
 } from "@/components/recipes/recipe-filter-bar";
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
-import { OfflineUnavailable } from "@/components/shared";
+import { OfflineUnavailable, ScreenTransition } from "@/components/shared";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks";
 import { formatRecipeTag } from "@/lib/recipe-tags";
@@ -172,163 +172,169 @@ export function RecipesView() {
           ) : null}
         </div>
 
-        {selectedRecipeId !== null ? (
-          selectedRecipeData ? (
-            <RecipeDetailView
-              recipe={selectedRecipeData}
-              isUpdatingFavorite={updateSelectedRecipe.isPending}
-              onAddToMeals={() => {
-                startMealPlacementFromRecipe({
-                  recipeId: selectedRecipeData.id,
-                  requestedAtWeekStartDate: formatLocalDate(
-                    getWeekStartSunday(new Date()),
-                  ),
-                  source: { kind: "recipes-library" },
-                });
-              }}
-              onBack={() => {
-                setIsEditSheetOpen(false);
-                setSelectedRecipeId(null);
-              }}
-              onEdit={() => setIsEditSheetOpen(true)}
-              onToggleFavorite={() => {
-                updateSelectedRecipe.mutate({
-                  favorite: !selectedRecipeData.favorite,
-                });
-              }}
-            />
-          ) : selectedRecipe.isLoading ? (
-            <p className="text-sm font-medium text-muted-foreground">
-              Loading recipe...
-            </p>
-          ) : selectedRecipe.isError ? (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
-              <h2 className="text-base font-semibold text-foreground">
-                Recipe could not be loaded
-              </h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                {selectedRecipe.error instanceof Error
-                  ? selectedRecipe.error.message
-                  : "Try again in a moment."}
+        <ScreenTransition
+          token={selectedRecipeId ?? "__list__"}
+          mode="slide"
+          direction={selectedRecipeId ? "forward" : "back"}
+        >
+          {selectedRecipeId !== null ? (
+            selectedRecipeData ? (
+              <RecipeDetailView
+                recipe={selectedRecipeData}
+                isUpdatingFavorite={updateSelectedRecipe.isPending}
+                onAddToMeals={() => {
+                  startMealPlacementFromRecipe({
+                    recipeId: selectedRecipeData.id,
+                    requestedAtWeekStartDate: formatLocalDate(
+                      getWeekStartSunday(new Date()),
+                    ),
+                    source: { kind: "recipes-library" },
+                  });
+                }}
+                onBack={() => {
+                  setIsEditSheetOpen(false);
+                  setSelectedRecipeId(null);
+                }}
+                onEdit={() => setIsEditSheetOpen(true)}
+                onToggleFavorite={() => {
+                  updateSelectedRecipe.mutate({
+                    favorite: !selectedRecipeData.favorite,
+                  });
+                }}
+              />
+            ) : selectedRecipe.isLoading ? (
+              <p className="text-sm font-medium text-muted-foreground">
+                Loading recipe...
               </p>
-              <div className="mt-3 flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => setSelectedRecipeId(null)}
-                >
-                  Back to recipes
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={selectedRecipe.isRefetching}
-                  onClick={() => {
-                    void selectedRecipe.refetch();
-                  }}
-                >
-                  Retry
-                </Button>
-              </div>
-            </div>
-          ) : null
-        ) : isLoading ? (
-          <div className="space-y-3">
-            <p className="text-sm font-medium text-muted-foreground">
-              Loading recipes...
-            </p>
-            <div className="grid gap-3">
-              {Array.from({ length: 3 }, (_, index) => (
-                <div
-                  key={`recipe-loading-${index}`}
-                  className="flex flex-row gap-3 overflow-hidden rounded-lg border border-border bg-card p-3 md:flex-col md:gap-0 md:p-0"
-                >
-                  <div className="size-24 shrink-0 animate-pulse rounded-lg bg-muted md:size-auto md:aspect-[4/3] md:w-full md:rounded-none" />
-                  <div className="flex min-w-0 flex-1 flex-col justify-center space-y-3 md:p-4">
-                    <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
-                    <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
-        ) : isError ? (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
-            <h2 className="text-base font-semibold text-foreground">
-              Recipes could not be loaded
-            </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {error instanceof Error
-                ? error.message
-                : "Try again in a moment."}
-            </p>
-            <Button
-              type="button"
-              variant="outline"
-              className="mt-3"
-              onClick={() => {
-                void refetch();
-              }}
-              disabled={isRefetching}
-            >
-              Retry
-            </Button>
-          </div>
-        ) : !data ? (
-          // Offline + never loaded: paused query, no data and no error.
-          <OfflineUnavailable label="recipes" />
-        ) : (
-          <>
-            <RecipeFilterBar
-              availableTags={availableTags}
-              favoritesOnly={favoritesOnly}
-              onFavoritesOnlyChange={setFavoritesOnly}
-              onSearchChange={setSearchValue}
-              onTagChange={setSelectedTag}
-              searchValue={searchValue}
-              selectedTag={selectedTag}
-            />
-
-            {recipes.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
-                <h2 className="text-lg font-semibold text-foreground">
-                  No recipes yet
+            ) : selectedRecipe.isError ? (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+                <h2 className="text-base font-semibold text-foreground">
+                  Recipe could not be loaded
                 </h2>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Add your first recipe to get started.
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {selectedRecipe.error instanceof Error
+                    ? selectedRecipe.error.message
+                    : "Try again in a moment."}
                 </p>
-                <div className="mt-4">
+                <div className="mt-3 flex flex-wrap gap-2">
                   <Button
                     type="button"
-                    onClick={() => setIsCreateSheetOpen(true)}
+                    variant="outline"
+                    onClick={() => setSelectedRecipeId(null)}
                   >
-                    Add your first recipe
+                    Back to recipes
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={selectedRecipe.isRefetching}
+                    onClick={() => {
+                      void selectedRecipe.refetch();
+                    }}
+                  >
+                    Retry
                   </Button>
                 </div>
               </div>
-            ) : filteredRecipes.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
-                <h2 className="text-lg font-semibold text-foreground">
-                  No recipes match those filters
-                </h2>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Try a different search or clear a filter chip.
-                </p>
-              </div>
-            ) : (
+            ) : null
+          ) : isLoading ? (
+            <div className="space-y-3">
+              <p className="text-sm font-medium text-muted-foreground">
+                Loading recipes...
+              </p>
               <div className="grid gap-3">
-                {filteredRecipes.map((recipe) => (
-                  <div key={recipe.id} className={cn("min-w-0")}>
-                    <RecipeLibraryCard
-                      recipe={recipe}
-                      onSelect={(recipeId) => setSelectedRecipeId(recipeId)}
-                    />
+                {Array.from({ length: 3 }, (_, index) => (
+                  <div
+                    key={`recipe-loading-${index}`}
+                    className="flex flex-row gap-3 overflow-hidden rounded-lg border border-border bg-card p-3 md:flex-col md:gap-0 md:p-0"
+                  >
+                    <div className="size-24 shrink-0 animate-pulse rounded-lg bg-muted md:size-auto md:aspect-[4/3] md:w-full md:rounded-none" />
+                    <div className="flex min-w-0 flex-1 flex-col justify-center space-y-3 md:p-4">
+                      <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+                      <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+                    </div>
                   </div>
                 ))}
               </div>
-            )}
-          </>
-        )}
+            </div>
+          ) : isError ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+              <h2 className="text-base font-semibold text-foreground">
+                Recipes could not be loaded
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {error instanceof Error
+                  ? error.message
+                  : "Try again in a moment."}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-3"
+                onClick={() => {
+                  void refetch();
+                }}
+                disabled={isRefetching}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : !data ? (
+            // Offline + never loaded: paused query, no data and no error.
+            <OfflineUnavailable label="recipes" />
+          ) : (
+            <>
+              <RecipeFilterBar
+                availableTags={availableTags}
+                favoritesOnly={favoritesOnly}
+                onFavoritesOnlyChange={setFavoritesOnly}
+                onSearchChange={setSearchValue}
+                onTagChange={setSelectedTag}
+                searchValue={searchValue}
+                selectedTag={selectedTag}
+              />
+
+              {recipes.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                  <h2 className="text-lg font-semibold text-foreground">
+                    No recipes yet
+                  </h2>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Add your first recipe to get started.
+                  </p>
+                  <div className="mt-4">
+                    <Button
+                      type="button"
+                      onClick={() => setIsCreateSheetOpen(true)}
+                    >
+                      Add your first recipe
+                    </Button>
+                  </div>
+                </div>
+              ) : filteredRecipes.length === 0 ? (
+                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                  <h2 className="text-lg font-semibold text-foreground">
+                    No recipes match those filters
+                  </h2>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Try a different search or clear a filter chip.
+                  </p>
+                </div>
+              ) : (
+                <div className="grid gap-3">
+                  {filteredRecipes.map((recipe) => (
+                    <div key={recipe.id} className={cn("min-w-0")}>
+                      <RecipeLibraryCard
+                        recipe={recipe}
+                        onSelect={(recipeId) => setSelectedRecipeId(recipeId)}
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </ScreenTransition>
 
         <RecipeCreateSheet
           defaultMode={createSheetMode}

--- a/src/components/recipes/recipe-library-card.tsx
+++ b/src/components/recipes/recipe-library-card.tsx
@@ -1,5 +1,6 @@
 import { Heart } from "lucide-react";
 import { useState } from "react";
+import { usePressable } from "@/hooks";
 import { formatRecipeTag } from "@/lib/recipe-tags";
 import type { RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -13,12 +14,15 @@ export function RecipeLibraryCard({
   recipe,
   onSelect,
 }: RecipeLibraryCardProps) {
+  const pressable = usePressable();
   const [imgFailed, setImgFailed] = useState(false);
   return (
     <article
       aria-label={`Recipe card: ${recipe.title}`}
+      onPointerDown={pressable.onPointerDown}
       className={cn(
         "relative flex w-full flex-row gap-3 overflow-hidden rounded-lg border border-border bg-card p-3 text-left shadow-xs transition-colors md:flex-col md:gap-0 md:p-0",
+        pressable.className,
       )}
     >
       <button

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -4,5 +4,6 @@ export { MobileBottomNav } from "./mobile-bottom-nav";
 export { NavigationTabs, type TabType } from "./navigation-tabs";
 export { OfflineBanner } from "./offline-banner";
 export { OfflineUnavailable } from "./offline-unavailable";
+export { ScreenTransition } from "./screen-transition";
 export { SidebarMenu } from "./sidebar-menu";
 export { ThemeProvider } from "./theme-provider";

--- a/src/components/shared/mobile-bottom-nav.test.tsx
+++ b/src/components/shared/mobile-bottom-nav.test.tsx
@@ -72,4 +72,11 @@ describe("MobileBottomNav", () => {
       "page",
     );
   });
+
+  it("gives nav tabs press feedback", () => {
+    render(<MobileBottomNav />);
+    expect(
+      screen.getByRole("button", { name: /^calendar$/i }).className,
+    ).toContain("active:scale-[0.97]");
+  });
 });

--- a/src/components/shared/mobile-bottom-nav.tsx
+++ b/src/components/shared/mobile-bottom-nav.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { usePressable } from "@/hooks";
 import { cn } from "@/lib/utils";
 import { type ModuleType, useAppStore } from "@/stores";
 
@@ -40,6 +41,7 @@ export function MobileBottomNav() {
   const activeModule = useAppStore((state) => state.activeModule);
   const setActiveModule = useAppStore((state) => state.setActiveModule);
   const [moreOpen, setMoreOpen] = useState(false);
+  const pressable = usePressable();
 
   const overflowActive = overflowModules.some((m) => m.id === activeModule);
 
@@ -67,9 +69,14 @@ export function MobileBottomNav() {
                 key={tab.label}
                 type="button"
                 onClick={() => setActiveModule(tab.id)}
+                onPointerDown={pressable.onPointerDown}
                 aria-label={tab.label}
                 aria-current={isActive ? "page" : undefined}
-                className={cn(tabBase, isActive ? tabActive : tabIdle)}
+                className={cn(
+                  tabBase,
+                  pressable.className,
+                  isActive ? tabActive : tabIdle,
+                )}
               >
                 <Icon className="h-4 w-4" />
                 <span className="whitespace-nowrap leading-3">{tab.label}</span>
@@ -81,9 +88,14 @@ export function MobileBottomNav() {
             <button
               type="button"
               onClick={() => setMoreOpen(true)}
+              onPointerDown={pressable.onPointerDown}
               aria-label="More"
               aria-current={overflowActive ? "page" : undefined}
-              className={cn(tabBase, overflowActive ? tabActive : tabIdle)}
+              className={cn(
+                tabBase,
+                pressable.className,
+                overflowActive ? tabActive : tabIdle,
+              )}
             >
               <MoreHorizontal className="h-4 w-4" />
               <span className="whitespace-nowrap leading-3">More</span>
@@ -107,9 +119,11 @@ export function MobileBottomNav() {
                 key={tab.label}
                 type="button"
                 onClick={() => selectOverflow(tab.id)}
+                onPointerDown={pressable.onPointerDown}
                 aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "flex w-full min-h-11 items-center gap-3 rounded-lg px-3 py-3 text-base font-medium transition-colors",
+                  pressable.className,
                   isActive
                     ? "bg-primary/10 text-primary"
                     : "text-foreground hover:bg-muted",

--- a/src/components/shared/screen-transition.test.tsx
+++ b/src/components/shared/screen-transition.test.tsx
@@ -1,0 +1,77 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ScreenTransition } from "./screen-transition";
+
+const animateMock = vi.fn();
+function setReduce(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+beforeEach(() => {
+  animateMock.mockReset();
+  (Element.prototype as unknown as { animate: unknown }).animate = animateMock; // jsdom lacks WAAPI
+});
+
+describe("ScreenTransition", () => {
+  it("does not animate on first mount, fades on token change", () => {
+    setReduce(false);
+    const { rerender } = render(
+      <ScreenTransition token="a" mode="fade">
+        A
+      </ScreenTransition>,
+    );
+    expect(animateMock).not.toHaveBeenCalled();
+    rerender(
+      <ScreenTransition token="b" mode="fade">
+        B
+      </ScreenTransition>,
+    );
+    expect(animateMock).toHaveBeenCalledTimes(1);
+    expect(animateMock.mock.calls[0][0][0]).toMatchObject({
+      transform: "scale(1.012)",
+    });
+  });
+  it("slides right on forward, left on back", () => {
+    setReduce(false);
+    const { rerender } = render(
+      <ScreenTransition token="l" mode="slide" direction="forward">
+        L
+      </ScreenTransition>,
+    );
+    rerender(
+      <ScreenTransition token="d" mode="slide" direction="forward">
+        D
+      </ScreenTransition>,
+    );
+    expect(animateMock.mock.calls[0][0][0].transform).toBe("translateX(22%)");
+    rerender(
+      <ScreenTransition token="l" mode="slide" direction="back">
+        L
+      </ScreenTransition>,
+    );
+    expect(animateMock.mock.calls[1][0][0].transform).toBe("translateX(-22%)");
+  });
+  it("skips animation under reduced motion but still swaps content", () => {
+    setReduce(true);
+    const { rerender, getByText } = render(
+      <ScreenTransition token="a" mode="fade">
+        A
+      </ScreenTransition>,
+    );
+    rerender(
+      <ScreenTransition token="b" mode="fade">
+        B
+      </ScreenTransition>,
+    );
+    expect(animateMock).not.toHaveBeenCalled();
+    expect(getByText("B")).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/screen-transition.tsx
+++ b/src/components/shared/screen-transition.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from "react";
+import { useLayoutEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "@/hooks";
+
+type Mode = "fade" | "slide";
+type Direction = "forward" | "back";
+
+interface ScreenTransitionProps {
+  token: string | number | null;
+  mode: Mode;
+  direction?: Direction;
+  children: ReactNode;
+}
+
+/** Enter-transition: the incoming screen animates in on `token` change. */
+export function ScreenTransition({
+  token,
+  mode,
+  direction = "forward",
+  children,
+}: ScreenTransitionProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const prev = useRef(token);
+  const reduce = usePrefersReducedMotion();
+
+  useLayoutEffect(() => {
+    if (prev.current === token) return;
+    prev.current = token;
+    const el = ref.current;
+    if (!el || reduce) return;
+    const keyframes: Keyframe[] =
+      mode === "slide"
+        ? [
+            {
+              opacity: 0,
+              transform: `translateX(${direction === "back" ? "-22%" : "22%"})`,
+            },
+            { opacity: 1, transform: "none" },
+          ]
+        : [
+            { opacity: 0, transform: "scale(1.012)" },
+            { opacity: 1, transform: "none" },
+          ];
+    el.animate(keyframes, {
+      duration: mode === "slide" ? 280 : 200,
+      easing: "cubic-bezier(0.2, 0, 0, 1)",
+    });
+  }, [token, mode, direction, reduce]);
+
+  return (
+    <div ref={ref} className="flex min-h-0 flex-1 flex-col">
+      {children}
+    </div>
+  );
+}

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -15,6 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { SideSheet } from "@/components/ui/side-sheet";
+import { usePressable } from "@/hooks";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores";
@@ -42,6 +43,8 @@ export function SidebarMenu() {
       }
     }
   }, [isOpen]);
+
+  const pressable = usePressable();
 
   const menuItems = [
     {
@@ -101,7 +104,11 @@ export function SidebarMenu() {
                     key={member.id}
                     type="button"
                     onClick={() => setSelectedMemberId(member.id)}
-                    className="w-full min-h-11 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-muted transition-colors"
+                    onPointerDown={pressable.onPointerDown}
+                    className={cn(
+                      "w-full min-h-11 flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-muted transition-colors",
+                      pressable.className,
+                    )}
                   >
                     {member.avatarUrl ? (
                       <img
@@ -145,7 +152,11 @@ export function SidebarMenu() {
                   <button
                     type="button"
                     onClick={item.action}
-                    className="w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+                    onPointerDown={pressable.onPointerDown}
+                    className={cn(
+                      "w-full min-h-11 flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-muted-foreground hover:bg-muted hover:text-foreground",
+                      pressable.className,
+                    )}
                   >
                     <Icon className="h-5 w-5" />
                     {item.label}

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Button } from "./button";
+
+describe("Button press feedback", () => {
+  it("carries the pressable class", () => {
+    render(<Button>Save</Button>);
+    expect(screen.getByRole("button").className).toContain(
+      "active:scale-[0.97]",
+    );
+  });
+  it("fires the pressable seam and the caller's onPointerDown", () => {
+    const onPointerDown = vi.fn();
+    render(<Button onPointerDown={onPointerDown}>Save</Button>);
+    screen
+      .getByRole("button")
+      .dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -2,6 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
+import { usePressable } from "@/hooks";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -41,17 +42,27 @@ function Button({
   variant,
   size,
   asChild = false,
+  onPointerDown,
   ...props
 }: React.ComponentProps<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
   }) {
   const Comp = asChild ? Slot : "button";
+  const pressable = usePressable();
 
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
+      className={cn(
+        buttonVariants({ variant, size }),
+        pressable.className,
+        className,
+      )}
+      onPointerDown={(event) => {
+        pressable.onPointerDown(event);
+        onPointerDown?.(event);
+      }}
       {...props}
     />
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,3 +4,4 @@ export { useInstallPrompt } from "./use-install-prompt";
 export { useIsMobile } from "./use-is-mobile";
 export { useMediaQuery } from "./use-media-query";
 export { useOnlineStatus } from "./use-online-status";
+export { usePrefersReducedMotion } from "./use-prefers-reduced-motion";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,3 +5,4 @@ export { useIsMobile } from "./use-is-mobile";
 export { useMediaQuery } from "./use-media-query";
 export { useOnlineStatus } from "./use-online-status";
 export { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+export { PRESSABLE, usePressable } from "./use-pressable";

--- a/src/hooks/use-prefers-reduced-motion.test.ts
+++ b/src/hooks/use-prefers-reduced-motion.test.ts
@@ -1,0 +1,31 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { usePrefersReducedMotion } from "./use-prefers-reduced-motion";
+
+function mockMatch(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("usePrefersReducedMotion", () => {
+  it("returns true when reduce is preferred", () => {
+    mockMatch(true);
+    expect(renderHook(() => usePrefersReducedMotion()).result.current).toBe(
+      true,
+    );
+  });
+  it("returns false otherwise", () => {
+    mockMatch(false);
+    expect(renderHook(() => usePrefersReducedMotion()).result.current).toBe(
+      false,
+    );
+  });
+});

--- a/src/hooks/use-prefers-reduced-motion.ts
+++ b/src/hooks/use-prefers-reduced-motion.ts
@@ -1,0 +1,6 @@
+import { useMediaQuery } from "./use-media-query";
+
+/** True when the user has requested reduced motion. */
+export function usePrefersReducedMotion(): boolean {
+  return useMediaQuery("(prefers-reduced-motion: reduce)");
+}

--- a/src/hooks/use-pressable.test.ts
+++ b/src/hooks/use-pressable.test.ts
@@ -1,0 +1,17 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PRESSABLE, usePressable } from "./use-pressable";
+
+describe("usePressable", () => {
+  it("gates the scale behind motion-safe but keeps the tint always-on", () => {
+    expect(PRESSABLE).toContain("motion-safe:active:scale-[0.97]");
+    expect(PRESSABLE).toContain("active:before:opacity-[0.06]");
+    // the tint must NOT be motion-gated — it is feedback, not decoration
+    expect(PRESSABLE).not.toContain("motion-safe:active:before");
+  });
+  it("returns the class and a callable pointer-down seam", () => {
+    const { result } = renderHook(() => usePressable());
+    expect(result.current.className).toBe(PRESSABLE);
+    expect(() => result.current.onPointerDown({} as never)).not.toThrow();
+  });
+});

--- a/src/hooks/use-pressable.ts
+++ b/src/hooks/use-pressable.ts
@@ -1,0 +1,26 @@
+import type { PointerEvent } from "react";
+import { useCallback } from "react";
+
+/**
+ * Press-feedback visual. The scale is motion-gated (reduced-motion drops it);
+ * the tint overlay is always-on (it is feedback). `rounded-[inherit]` so the
+ * overlay matches the host element's corners.
+ */
+export const PRESSABLE =
+  "relative transition-transform duration-100 ease-out motion-safe:active:scale-[0.97] " +
+  "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] " +
+  "before:bg-foreground before:opacity-0 before:transition-opacity before:duration-100 " +
+  "active:before:opacity-[0.06]";
+
+export interface Pressable {
+  className: string;
+  onPointerDown: (event: PointerEvent) => void;
+}
+
+/** Single integration point for press visuals and (later) haptics. */
+export function usePressable(): Pressable {
+  const onPointerDown = useCallback((_event: PointerEvent) => {
+    // Haptic seam: the optional-haptics story adds `useHaptics().tap()` here.
+  }, []);
+  return { className: PRESSABLE, onPointerDown };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -47,6 +47,9 @@ Element.prototype.setPointerCapture = vi.fn();
 Element.prototype.releasePointerCapture = vi.fn();
 Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
 
+// Mock Web Animations API (used by ScreenTransition; jsdom lacks it)
+Element.prototype.animate = vi.fn();
+
 // =============================================================================
 // Zustand Store Reset
 // =============================================================================


### PR DESCRIPTION
Closes #229

Adds a cohesive "acknowledgment layer" for the mobile shell: fade-through on module/tab switches, shared-axis slide on list/recipe detail open/close, and immediate scale+tint press feedback on every tappable — built on two reusable primitives with **no new dependency** (Web Animations API + `tailwindcss-animate`).

- **Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/native-feel-interaction-polish.md
- **Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-16-native-feel-interaction-polish-design.md
- **Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-16-native-feel-interaction-polish.md

## Contract checklist (non-negotiables → code + tests)

- [x] **Two primitives only, no new dependency**
  - `usePressable()` — `src/hooks/use-pressable.ts` (`PRESSABLE` class + the single `onPointerDown` haptic seam) · test `src/hooks/use-pressable.test.ts`
  - `ScreenTransition` — `src/components/shared/screen-transition.tsx` (WAAPI enter-transition, `fade` | `slide` + `direction`) · test `src/components/shared/screen-transition.test.tsx`
  - `package.json` / `package-lock.json` unchanged — no `framer-motion`/`motion`
- [x] **Fade-through on module switch** — `src/App.tsx` wraps `renderModule(activeModule)` in `<ScreenTransition token={activeModule} mode="fade">` · test `src/App.shell.test.tsx` ("animates the module container when the active module changes")
- [x] **Shared-axis slide on list/recipe detail** — keyed on `selectedListId` / `selectedRecipeId`, `direction` forward (open) / back (close): `src/components/lists-view.tsx`, `src/components/recipes-view.tsx` · tests assert both legs ("slides the detail in from the right when a list opens"; "slides the recipe detail right on open and back-left on close")
- [x] **Press feedback on every tappable** via `usePressable`
  - `Button` — `src/components/ui/button.tsx` · test `src/components/ui/button.test.tsx`
  - bottom-nav tabs / More / overflow — `src/components/shared/mobile-bottom-nav.tsx` · test ("gives nav tabs press feedback")
  - sidebar member + menu rows — `src/components/shared/sidebar-menu.tsx`
  - list cards — `src/components/lists/list-card.tsx` · test ("gives list cards press feedback")
  - recipe cards — `src/components/recipes/recipe-library-card.tsx` (on the `<article>`; `:active` + `pointerdown` bubble from the overlay button) · test ("gives recipe cards press feedback")
- [x] **Reduced-motion split** — CSS `motion-safe:` gates the scale while the `::before` tint stays always-on (`use-pressable.ts`; test asserts the tint is *not* motion-gated) **and** `ScreenTransition` JS-short-circuits to an instant cut under `prefers-reduced-motion: reduce` (test "skips animation under reduced motion but still swaps content")
- [x] **`transform`/`opacity` only, enter-transition only, existing sheet/dialog/sidebar motion untouched** — `ScreenTransition` keyframes are opacity + `translateX`/`scale`; no exit/cross-dissolve; no sheet/dialog/side-sheet primitive changed; no router/state-storage change
- [x] **Single seams for the sibling stories** — haptics plug into `usePressable().onPointerDown` (one location); the back-button story gets the reverse slide for free because the slide keys on the existing close handlers

## Verification

- `npm run lint` — pass (exit 0; only a pre-existing meals-code warning)
- `npm test -- --run` — **1007 passed** (102 files)
- `npm run build` (tsc + vite) — pass (type-check clean)
- Final senior code review (whole-branch): **Ready to merge — Yes** (0 critical, 0 important)

## Manual device pass — REQUIRED before merge (not automatable here)

The "real gate" per the Plan is a physical Galaxy S10 / Android Chrome pass — please verify:
- [ ] Module switches fade-through (not an instant cut)
- [ ] Opening a list/recipe slides in from the right; back slides in from the left
- [ ] Buttons, nav tabs, sidebar rows, list/recipe cards visibly dip + spring on press at 60fps (no jank)
- [ ] OS "reduce motion" ON → transitions are instant cuts, but presses still tint (no dip)

## Notes / accepted tradeoffs

- `Button` and `ListCard` carried `transition-all`; merging `PRESSABLE`'s `transition-transform` makes tailwind-merge keep `transition-transform`, so desktop hover color/border/shadow transitions become instant. Accepted (documented for `Button` in the Plan; same rationale for `ListCard`) — touch targets (the actual target) are unaffected.
- First visit to a lazy module fades in its `<LazyModule>` fallback, then content pops — accepted per Spec D3.
- `recipes-view` keeps its persistent header + create/edit sheets outside the slide (only the detail-vs-grid region animates) by design per Spec D4; `lists-view` wraps its whole body.