### PR TITLE
docs: clarify Zustand store reset is by-name, not generic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ See `src/test/test-utils.tsx` for `waitForMemberSelected`, `typeAndWait`, `TEST_
 
 **Optimistic update tests need `gcTime: Infinity`:** The default test `QueryClient` uses `gcTime: 0` — cache is GC'd before assertions. Create a dedicated client for any test asserting cache state after mutations.
 
-**Store auto-reset:** All Zustand stores reset after each test via `src/test/setup.ts`. Use `seedCalendarStore`, `seedFamilyStore`, `seedAuthStore` from `@/test/test-utils` to set up state.
+**Store reset (by name, not generic):** `resetAllStores()` in `src/test/setup.ts` (called from `afterEach`) resets each store explicitly **by name** — `useFamilyStore`, `useCalendarStore`, `useAppStore`, `useAuthStore`. It is NOT generic: a newly added store leaks its state across tests until you add a reset for it there (e.g. `useFoo.setState({ ... })`). Use `seedCalendarStore`, `seedFamilyStore`, `seedAuthStore` from `@/test/test-utils` to set up state.
 
 **E2E helpers** (`e2e/helpers/`): `safeClick`, `waitForDialogReady`, `waitForCalendarReady`, `waitForDialogClosed`, `waitForHydration`, `registerFamily`, `seedBrowserAuth`.
 


### PR DESCRIPTION
## Summary

Clarifies the **Store auto-reset** entry in the CLAUDE.md "Testing Gotchas" section.

The old wording — "All Zustand stores reset after each test via `src/test/setup.ts`" — implied a generic/automatic reset. In reality, `resetAllStores()` (called from `afterEach`) resets four stores **by explicit name**: `useFamilyStore`, `useCalendarStore`, `useAppStore`, `useAuthStore`. It is not generic, so a **newly added** store leaks its state across tests until a reset is manually added there. This recently caused a spec bug. The note now spells out the by-name behavior and the action required when adding a store.

## Test Plan

Docs-only change — no application code touched, so tests/lint are unaffected. Verified the four store names against the current `resetAllStores()` in `src/test/setup.ts` before writing.

## Checklist

- [ ] Tests pass (`npm test`) — N/A, docs-only (no code changed)
- [ ] Linting passes (`npm run lint`) — N/A, docs-only (markdown not covered by Biome/lint-staged)
- [x] No breaking changes

### Documentation
- [x] If this PR changes patterns or conventions, I've updated `CLAUDE.md` (this PR *is* the CLAUDE.md clarification)