### PR TITLE
feat: native hardware back-button (single-root + dismiss registry)

### DIFF
--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -133,6 +133,20 @@ describe("App shell", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("hardware back steps up to Home from a module (Android standalone)", async () => {
+    setViewportWidth(768);
+    useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
+
+    render(<FamilyHub />);
+    await screen.findByRole("navigation", { name: /primary/i });
+
+    act(() => {
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+
+    expect(useAppStore.getState().activeModule).toBeNull();
+  });
+
   it("animates the module container when the active module changes", () => {
     // Mobile width so Home (null) is valid; reduced-motion OFF so ScreenTransition animates.
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({

--- a/src/App.shell.test.tsx
+++ b/src/App.shell.test.tsx
@@ -134,6 +134,10 @@ describe("App shell", () => {
   });
 
   it("hardware back steps up to Home from a module (Android standalone)", async () => {
+    // setViewportWidth's matchMedia mock returns true for non-dimension queries,
+    // which satisfies the Android back gate (isStandalone + coarse pointer) for
+    // this integration check. The gate's exclusivity (iOS/desktop/disabled
+    // no-ops) is unit-tested in use-android-back-button.test.ts.
     setViewportWidth(768);
     useAppStore.setState({ activeModule: "calendar", isSidebarOpen: false });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,11 @@ import {
   SidebarMenu,
 } from "@/components/shared";
 import { Toaster } from "@/components/ui/toaster";
-import { useGoogleAuthReturn, useIsMobile } from "@/hooks";
+import {
+  useAndroidBackButton,
+  useGoogleAuthReturn,
+  useIsMobile,
+} from "@/hooks";
 import {
   type ModuleType,
   useAppStore,
@@ -109,6 +113,7 @@ export default function FamilyHub() {
   const isMobile = useIsMobile();
 
   useGoogleAuthReturn();
+  useAndroidBackButton(isAuthenticated && setupComplete);
 
   // State to toggle between login and onboarding for new users
   const [showOnboarding, setShowOnboarding] = useState(false);

--- a/src/components/calendar/components/edit-scope-dialog.tsx
+++ b/src/components/calendar/components/edit-scope-dialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useBackHandler } from "@/hooks";
 
 export type EditScope = "this" | "all";
 
@@ -24,6 +25,7 @@ function EditScopeDialog({
   action,
 }: EditScopeDialogProps) {
   const [scope, setScope] = useState<EditScope>("this");
+  useBackHandler(isOpen, onClose);
 
   useEffect(() => {
     if (isOpen) setScope("this");

--- a/src/components/calendar/components/event-detail-modal.test.tsx
+++ b/src/components/calendar/components/event-detail-modal.test.tsx
@@ -1,9 +1,11 @@
 import { userEvent } from "@testing-library/user-event";
 import type { CalendarEvent } from "@/lib/types";
-import { render, screen } from "@/test/test-utils";
+import { useBackStack } from "@/stores";
+import { act, render, screen } from "@/test/test-utils";
 import { EventDetailModal } from "./event-detail-modal";
 
-vi.mock("@/hooks", () => ({
+vi.mock("@/hooks", async (importActual) => ({
+  ...(await importActual<typeof import("@/hooks")>()),
   useIsMobile: () => false,
   // Button now calls usePressable(); this fully-mocked barrel must provide it.
   usePressable: () => ({ className: "", onPointerDown: () => {} }),
@@ -116,5 +118,14 @@ describe("EventDetailModal", () => {
     await user.click(screen.getByRole("button", { name: /edit/i }));
     expect(mockEdit).toHaveBeenCalled();
     expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it("registers a back handler that closes the modal", () => {
+    render(<EventDetailModal {...defaultProps} />);
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    act(() => {
+      useBackStack.getState().peek()?.handler();
+    });
+    expect(mockClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/calendar/components/event-detail-modal.tsx
+++ b/src/components/calendar/components/event-detail-modal.tsx
@@ -21,7 +21,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "@/components/ui/toaster";
-import { useIsMobile } from "@/hooks";
+import { useBackHandler, useIsMobile } from "@/hooks";
 import { formatRecurrenceLabel } from "@/lib/recurrence-utils";
 import type { CalendarEvent } from "@/lib/types";
 import { colorMap, getFamilyMember } from "@/lib/types";
@@ -50,6 +50,7 @@ function EventDetailModal({
   const isMobile = useIsMobile();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const familyMembers = useFamilyMembers();
+  useBackHandler(isOpen, onClose);
 
   // Reset confirmation state when modal closes or event changes
   useEffect(() => {

--- a/src/components/lists-view.test.tsx
+++ b/src/components/lists-view.test.tsx
@@ -1,5 +1,6 @@
 import { delay, HttpResponse, http } from "msw";
 import type { ListDetail } from "@/lib/types";
+import { useBackStack } from "@/stores";
 import {
   API_BASE,
   seedMockListPreferences,
@@ -8,6 +9,7 @@ import {
   setupMswServer,
 } from "@/test/mocks/server";
 import {
+  act,
   render,
   renderWithUser,
   screen,
@@ -476,5 +478,20 @@ describe("ListsView hub", () => {
     expect(animateMock.mock.calls.at(-1)?.[0][0].transform).toBe(
       "translateX(22%)",
     );
+  });
+
+  it("registers a back handler that closes the open list detail", async () => {
+    seedMockLists([groceryList]);
+    const { user } = renderWithUser(<ListsView />);
+    await user.click(
+      await screen.findByRole("button", { name: /Trader Joe's Run/i }),
+    );
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    act(() => {
+      useBackStack.getState().peek()?.handler();
+    });
+    expect(
+      await screen.findByRole("button", { name: /new list/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/lists-view.tsx
+++ b/src/components/lists-view.tsx
@@ -2,7 +2,7 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import { useListPreferences, useLists } from "@/api";
 import { OfflineUnavailable, ScreenTransition } from "@/components/shared";
-import { useIsMobile } from "@/hooks";
+import { useBackHandler, useIsMobile } from "@/hooks";
 import { cn } from "@/lib/utils";
 import { ListCard } from "./lists/list-card";
 import { ListCreateSheet } from "./lists/list-create-sheet";
@@ -15,6 +15,7 @@ export function ListsView() {
   const [createOpen, setCreateOpen] = useState(false);
   const lists = useLists();
   const preferences = useListPreferences();
+  useBackHandler(selectedListId !== null, () => setSelectedListId(null));
 
   const body = (() => {
     if (selectedListId !== null) {

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { useBackHandler } from "@/hooks";
 import type {
   MealCollisionMode,
   MealSlot,
@@ -71,6 +72,7 @@ export function MealComposerSheet({
   const [validationError, setValidationError] = useState<string | null>(null);
   const [collisionRequest, setCollisionRequest] =
     useState<UpsertMealSlotRequest | null>(null);
+  useBackHandler(collisionRequest !== null, () => setCollisionRequest(null));
   const recipes = useRecipes();
   const upsertSlot = useUpsertMealSlot({
     onSuccess: () => onOpenChange(false),

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { useBackHandler } from "@/hooks";
 import type {
   DuplicateMealSlotRequest,
   MealBoard,
@@ -90,6 +91,7 @@ export function MealEditorSheet({
 }: MealEditorSheetProps) {
   const [pendingCollision, setPendingCollision] =
     useState<PendingCollision | null>(null);
+  useBackHandler(pendingCollision !== null, () => setPendingCollision(null));
   const [mover, setMover] = useState<{ kind: "move" | "duplicate" } | null>(
     null,
   );

--- a/src/components/meals/meal-move-picker.tsx
+++ b/src/components/meals/meal-move-picker.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useBackHandler } from "@/hooks";
 import { parseLocalDate } from "@/lib/time-utils";
 import type { MealBoard, MealType } from "@/lib/types";
 import { formatMealType } from "./meal-type-utils";
@@ -48,6 +49,7 @@ export function MealMovePicker({
 }: MealMovePickerProps) {
   const [dayIndex, setDayIndex] = useState((source.dayIndex + 1) % 7);
   const [mealType, setMealType] = useState<MealType>(source.mealType);
+  useBackHandler(open, () => onCancel());
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -4,6 +4,7 @@ import type {
   CreateRecipeRequest,
   ImportRecipeRequest,
 } from "@/lib/types/recipes";
+import { useBackStack } from "@/stores";
 import { useAppStore } from "@/stores/app-store";
 import {
   importedRecipeDetail,
@@ -16,7 +17,13 @@ import {
   server,
   setupMswServer,
 } from "@/test/mocks/server";
-import { render, renderWithUser, screen, typeAndWait } from "@/test/test-utils";
+import {
+  act,
+  render,
+  renderWithUser,
+  screen,
+  typeAndWait,
+} from "@/test/test-utils";
 import { RecipesView } from "./recipes-view";
 
 describe("RecipesView", () => {
@@ -966,6 +973,23 @@ describe("RecipesView", () => {
     expect(
       screen.queryByRole("heading", { name: importedRecipeDetail.title }),
     ).not.toBeInTheDocument();
+  });
+
+  it("registers a back handler that closes the open recipe detail", async () => {
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(<RecipesView />);
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Open recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    act(() => {
+      useBackStack.getState().peek()?.handler();
+    });
+    expect(
+      await screen.findByRole("button", { name: /add recipe/i }),
+    ).toBeInTheDocument();
   });
 
   it("toggles favorite from detail and updates the visible saved state", async () => {

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -10,7 +10,7 @@ import {
 import { RecipeLibraryCard } from "@/components/recipes/recipe-library-card";
 import { OfflineUnavailable, ScreenTransition } from "@/components/shared";
 import { Button } from "@/components/ui/button";
-import { useIsMobile } from "@/hooks";
+import { useBackHandler, useIsMobile } from "@/hooks";
 import { formatRecipeTag } from "@/lib/recipe-tags";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
 import type { RecipeSummary } from "@/lib/types";
@@ -90,6 +90,7 @@ export function RecipesView() {
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [hasOpenedRecipeDraft, setHasOpenedRecipeDraft] = useState(false);
   const selectedRecipe = useRecipe(selectedRecipeId);
+  useBackHandler(selectedRecipeId !== null, () => setSelectedRecipeId(null));
 
   const recipes = data?.data ?? [];
   const searchQuery = normalizeValue(searchValue);

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
+import { useBackHandler } from "@/hooks";
 import type { FamilyColor, FamilyMember } from "@/lib/types";
 import {
   familyNameSchema,
@@ -58,6 +59,7 @@ export function FamilySettingsModal({
   const [isMemberFormOpen, setIsMemberFormOpen] = useState(false);
   const [editingMember, setEditingMember] = useState<FamilyMember | null>(null);
   const [showResetConfirm, setShowResetConfirm] = useState(false);
+  useBackHandler(showResetConfirm, () => setShowResetConfirm(false));
 
   // Family name form
   const {

--- a/src/components/settings/google-calendar-picker-modal.tsx
+++ b/src/components/settings/google-calendar-picker-modal.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "@/components/ui/toaster";
+import { useBackHandler } from "@/hooks";
 
 interface GoogleCalendarPickerModalProps {
   open: boolean;
@@ -29,6 +30,7 @@ export function GoogleCalendarPickerModal({
   const updateCalendars = useUpdateGoogleCalendars();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const hasSynced = useRef(false);
+  useBackHandler(open, () => onOpenChange(false));
 
   const calendars = calendarsResponse?.data ?? [];
 

--- a/src/components/shared/sidebar-menu.tsx
+++ b/src/components/shared/sidebar-menu.tsx
@@ -15,7 +15,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { SideSheet } from "@/components/ui/side-sheet";
-import { usePressable } from "@/hooks";
+import { useBackHandler, usePressable } from "@/hooks";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores";
@@ -33,6 +33,7 @@ export function SidebarMenu() {
   const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [showSignOutConfirm, setShowSignOutConfirm] = useState(false);
+  useBackHandler(showSignOutConfirm, () => setShowSignOutConfirm(false));
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ui/mobile-sheet.test.tsx
+++ b/src/components/ui/mobile-sheet.test.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
-import { renderWithUser, screen, waitFor } from "@/test/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { useBackStack } from "@/stores";
+import {
+  act,
+  render,
+  renderWithUser,
+  screen,
+  waitFor,
+} from "@/test/test-utils";
 import { MobileSheet } from "./mobile-sheet";
 
 function SheetHarness({ children }: { children?: React.ReactNode }) {
@@ -53,5 +60,19 @@ describe("MobileSheet", () => {
     await user.click(screen.getByRole("button", { name: "Open sheet" }));
 
     expect(screen.getByRole("button", { name: "Inside action" })).toHaveFocus();
+  });
+
+  it("registers its close handler on the back-stack while open", () => {
+    const onClose = vi.fn();
+    render(
+      <MobileSheet isOpen onClose={onClose} title="Test sheet">
+        <button type="button">Inside</button>
+      </MobileSheet>,
+    );
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    act(() => {
+      useBackStack.getState().peek()?.handler();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ui/mobile-sheet.tsx
+++ b/src/components/ui/mobile-sheet.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Drawer } from "vaul";
+import { useBackHandler } from "@/hooks";
 import { cn } from "@/lib/utils";
 
 const HALF_SNAP = 0.5;
@@ -75,6 +76,8 @@ export function MobileSheet({
     }
     prevOpenRef.current = isOpen;
   }, [isOpen, initialHeight]);
+
+  useBackHandler(isOpen, onClose);
 
   const isExpandable = cycleSnapPoints === HALF_SNAP_POINTS;
   const isExpanded = snap === FULL_SNAP;

--- a/src/components/ui/side-sheet.test.tsx
+++ b/src/components/ui/side-sheet.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@/test/test-utils";
+import { useBackStack } from "@/stores";
+import { act, fireEvent, render, screen } from "@/test/test-utils";
 import { SideSheet } from "./side-sheet";
 
 function renderSheet(onOpenChange = vi.fn()) {
@@ -70,5 +71,16 @@ describe("SideSheet swipe-to-close", () => {
     fireEvent.touchEnd(panel, point(100, 300));
 
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("SideSheet back-handler", () => {
+  it("registers a back handler that closes via onOpenChange(false) while open", () => {
+    const { onOpenChange } = renderSheet();
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    act(() => {
+      useBackStack.getState().peek()?.handler();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/ui/side-sheet.tsx
+++ b/src/components/ui/side-sheet.tsx
@@ -1,5 +1,6 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { type ReactNode, useRef, useState } from "react";
+import { useBackHandler } from "@/hooks";
 import { cn } from "@/lib/utils";
 
 const SWIPE_CLOSE_THRESHOLD = 60; // px of leftward drag before dismiss
@@ -20,6 +21,8 @@ export function SideSheet({
   children,
   className,
 }: SideSheetProps) {
+  useBackHandler(open, () => onOpenChange(false));
+
   const startX = useRef<number | null>(null);
   const startY = useRef<number | null>(null);
   const [dragX, setDragX] = useState(0);

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useBackHandler } from "./use-back-handler";
 export { useDebounce } from "./use-debounce";
 export { useGoogleAuthReturn } from "./use-google-auth-return";
 export { useInstallPrompt } from "./use-install-prompt";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useAndroidBackButton } from "./use-android-back-button";
 export { useBackHandler } from "./use-back-handler";
 export { useDebounce } from "./use-debounce";
 export { useGoogleAuthReturn } from "./use-google-auth-return";

--- a/src/hooks/use-android-back-button.test.ts
+++ b/src/hooks/use-android-back-button.test.ts
@@ -1,0 +1,111 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/pwa", () => ({
+  isStandalone: vi.fn(() => true),
+  isIOS: vi.fn(() => false),
+}));
+vi.mock("@/components/ui/toaster", () => ({ toast: vi.fn() }));
+
+import { toast } from "@/components/ui/toaster";
+import { isStandalone } from "@/lib/pwa";
+import { useAppStore, useBackStack } from "@/stores";
+import { useAndroidBackButton } from "./use-android-back-button";
+
+function mockCoarsePointer(coarse: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function popstate() {
+  act(() => {
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(isStandalone).mockReturnValue(true);
+  mockCoarsePointer(true);
+  useAppStore.setState({ activeModule: null });
+  vi.spyOn(window.history, "pushState").mockImplementation(() => {});
+  vi.spyOn(window.history, "back").mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useAndroidBackButton", () => {
+  it("is a no-op when disabled", () => {
+    renderHook(() => useAndroidBackButton(false));
+    expect(window.history.pushState).not.toHaveBeenCalled();
+    popstate();
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op on desktop (no coarse pointer)", () => {
+    mockCoarsePointer(false);
+    renderHook(() => useAndroidBackButton(true));
+    expect(window.history.pushState).not.toHaveBeenCalled();
+  });
+
+  it("pushes a single sentinel on mount when gated on", () => {
+    renderHook(() => useAndroidBackButton(true));
+    expect(window.history.pushState).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses the top registered handler first, leaving the module untouched", () => {
+    const handler = vi.fn();
+    useBackStack.getState().register(handler);
+    useAppStore.setState({ activeModule: "calendar" });
+    renderHook(() => useAndroidBackButton(true));
+    popstate();
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().activeModule).toBe("calendar");
+    expect(window.history.back).not.toHaveBeenCalled();
+  });
+
+  it("goes up to Home when nothing is registered and not at Home", () => {
+    useAppStore.setState({ activeModule: "lists" });
+    renderHook(() => useAndroidBackButton(true));
+    popstate();
+    expect(useAppStore.getState().activeModule).toBeNull();
+    expect(window.history.back).not.toHaveBeenCalled();
+  });
+
+  it("shows the hint on first root press and exits on the second", () => {
+    vi.useFakeTimers();
+    renderHook(() => useAndroidBackButton(true));
+    popstate(); // first
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "Press back again to exit" }),
+    );
+    expect(window.history.back).not.toHaveBeenCalled();
+    popstate(); // second, within window
+    act(() => {
+      vi.advanceTimersByTime(1); // flush the deferred history.back()
+    });
+    expect(window.history.back).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  it("re-arms after the window elapses", () => {
+    vi.useFakeTimers();
+    renderHook(() => useAndroidBackButton(true));
+    popstate(); // first → arm
+    act(() => {
+      vi.advanceTimersByTime(2000); // window elapses, disarm
+    });
+    popstate(); // treated as first again
+    expect(toast).toHaveBeenCalledTimes(2);
+    expect(window.history.back).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/src/hooks/use-android-back-button.test.ts
+++ b/src/hooks/use-android-back-button.test.ts
@@ -8,7 +8,7 @@ vi.mock("@/lib/pwa", () => ({
 vi.mock("@/components/ui/toaster", () => ({ toast: vi.fn() }));
 
 import { toast } from "@/components/ui/toaster";
-import { isStandalone } from "@/lib/pwa";
+import { isIOS, isStandalone } from "@/lib/pwa";
 import { useAppStore, useBackStack } from "@/stores";
 import { useAndroidBackButton } from "./use-android-back-button";
 
@@ -33,6 +33,7 @@ function popstate() {
 
 beforeEach(() => {
   vi.mocked(isStandalone).mockReturnValue(true);
+  vi.mocked(isIOS).mockReturnValue(false);
   mockCoarsePointer(true);
   useAppStore.setState({ activeModule: null });
   vi.spyOn(window.history, "pushState").mockImplementation(() => {});
@@ -52,6 +53,12 @@ describe("useAndroidBackButton", () => {
 
   it("is a no-op on desktop (no coarse pointer)", () => {
     mockCoarsePointer(false);
+    renderHook(() => useAndroidBackButton(true));
+    expect(window.history.pushState).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op on iOS standalone (even with a coarse pointer)", () => {
+    vi.mocked(isIOS).mockReturnValue(true);
     renderHook(() => useAndroidBackButton(true));
     expect(window.history.pushState).not.toHaveBeenCalled();
   });

--- a/src/hooks/use-android-back-button.ts
+++ b/src/hooks/use-android-back-button.ts
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from "react";
+import { toast } from "@/components/ui/toaster";
+import { isIOS, isStandalone } from "@/lib/pwa";
+import { useAppStore, useBackStack } from "@/stores";
+
+const EXIT_HINT_MS = 2000;
+const SENTINEL = { __familyHubBack: true } as const;
+
+/** Installed + Android-class + touch: the only context with a hardware back. */
+function isAndroidBackContext(): boolean {
+  if (typeof window === "undefined") return false;
+  const coarse = window.matchMedia?.("(pointer: coarse)").matches === true;
+  return isStandalone() && !isIOS() && coarse;
+}
+
+/**
+ * Hardware/gesture back handling for the installed Android PWA. Mount once in
+ * the authenticated shell — it is the single owner of history interception.
+ */
+export function useAndroidBackButton(enabled: boolean): void {
+  const armedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !isAndroidBackContext()) return;
+
+    const rebuffer = () => window.history.pushState(SENTINEL, "");
+    rebuffer(); // initial sentinel: [appEntry, sentinel]
+
+    const onPop = () => {
+      // 1. Overlay/detail layer (LIFO). The surface closes and unregisters
+      //    itself via its own useBackHandler effect; we only peek.
+      const top = useBackStack.getState().peek();
+      if (top) {
+        top.handler();
+        rebuffer();
+        return;
+      }
+      // 2. Module layer (single-root): step up to Home.
+      const { activeModule, setActiveModule } = useAppStore.getState();
+      if (activeModule !== null) {
+        setActiveModule(null);
+        rebuffer();
+        return;
+      }
+      // 3. Home root: double-press to exit.
+      if (armedRef.current) {
+        armedRef.current = false;
+        if (timerRef.current) clearTimeout(timerRef.current);
+        // Defer so the exit runs after this popstate settles.
+        setTimeout(() => window.history.back(), 0);
+        return;
+      }
+      armedRef.current = true;
+      toast({
+        description: "Press back again to exit",
+        duration: EXIT_HINT_MS,
+      });
+      timerRef.current = setTimeout(() => {
+        armedRef.current = false;
+      }, EXIT_HINT_MS);
+      rebuffer();
+    };
+
+    window.addEventListener("popstate", onPop);
+    return () => {
+      window.removeEventListener("popstate", onPop);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [enabled]);
+}

--- a/src/hooks/use-back-handler.test.ts
+++ b/src/hooks/use-back-handler.test.ts
@@ -1,0 +1,39 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useBackStack } from "@/stores";
+import { useBackHandler } from "./use-back-handler";
+
+describe("useBackHandler", () => {
+  it("registers while enabled and unregisters on unmount", () => {
+    const { unmount } = renderHook(() => useBackHandler(true, vi.fn()));
+    expect(useBackStack.getState().stack).toHaveLength(1);
+    unmount();
+    expect(useBackStack.getState().stack).toHaveLength(0);
+  });
+
+  it("does not register while disabled", () => {
+    renderHook(() => useBackHandler(false, vi.fn()));
+    expect(useBackStack.getState().stack).toHaveLength(0);
+  });
+
+  it("invokes the latest handler after a re-render (no stale closure)", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ h }) => useBackHandler(true, h), {
+      initialProps: { h: first },
+    });
+    rerender({ h: second });
+    useBackStack.getState().peek()?.handler();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-registers when enabled flips from false to true", () => {
+    const { rerender } = renderHook(({ on }) => useBackHandler(on, vi.fn()), {
+      initialProps: { on: false },
+    });
+    expect(useBackStack.getState().stack).toHaveLength(0);
+    rerender({ on: true });
+    expect(useBackStack.getState().stack).toHaveLength(1);
+  });
+});

--- a/src/hooks/use-back-handler.ts
+++ b/src/hooks/use-back-handler.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from "react";
+import { useBackStack } from "@/stores";
+
+/**
+ * Register a dismiss handler on the back-stack while `enabled`. Hardware back
+ * (see useAndroidBackButton) pops the most-recently-registered first (LIFO).
+ * The registered wrapper always calls the latest `handler` (no stale closures);
+ * it re-registers only when `enabled` flips.
+ */
+export function useBackHandler(enabled: boolean, handler: () => void): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  const register = useBackStack((s) => s.register);
+  const unregister = useBackStack((s) => s.unregister);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = register(() => handlerRef.current());
+    return () => unregister(id);
+  }, [enabled, register, unregister]);
+}

--- a/src/stores/back-stack-store.test.ts
+++ b/src/stores/back-stack-store.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { useBackStack } from "./back-stack-store";
+
+describe("useBackStack", () => {
+  it("peek returns undefined when empty", () => {
+    expect(useBackStack.getState().peek()).toBeUndefined();
+  });
+
+  it("register returns unique ids and peek returns the most recent (LIFO)", () => {
+    const a = () => {};
+    const b = () => {};
+    const idA = useBackStack.getState().register(a);
+    const idB = useBackStack.getState().register(b);
+    expect(idA).not.toBe(idB);
+    expect(useBackStack.getState().peek()?.handler).toBe(b);
+  });
+
+  it("unregister by id restores the previous top", () => {
+    const a = () => {};
+    const b = () => {};
+    useBackStack.getState().register(a);
+    const idB = useBackStack.getState().register(b);
+    useBackStack.getState().unregister(idB);
+    expect(useBackStack.getState().peek()?.handler).toBe(a);
+  });
+});

--- a/src/stores/back-stack-store.ts
+++ b/src/stores/back-stack-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+export interface BackHandlerEntry {
+  id: number;
+  handler: () => void;
+}
+
+interface BackStackState {
+  stack: BackHandlerEntry[];
+  register: (handler: () => void) => number;
+  unregister: (id: number) => void;
+  peek: () => BackHandlerEntry | undefined;
+}
+
+let nextId = 0;
+
+/**
+ * LIFO registry of "dismissable now" handlers. Open surfaces register via
+ * useBackHandler; useAndroidBackButton peeks the most-recent on hardware back.
+ */
+export const useBackStack = create<BackStackState>((set, get) => ({
+  stack: [],
+  register: (handler) => {
+    const id = nextId++;
+    set((s) => ({ stack: [...s.stack, { id, handler }] }));
+    return id;
+  },
+  unregister: (id) =>
+    set((s) => ({ stack: s.stack.filter((e) => e.id !== id) })),
+  peek: () => {
+    const { stack } = get();
+    return stack[stack.length - 1];
+  },
+}));

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -12,6 +12,8 @@ export {
   useAuthStore,
   useIsAuthenticated,
 } from "./auth-store";
+// Back Stack Store
+export { type BackHandlerEntry, useBackStack } from "./back-stack-store";
 // Calendar Store
 export {
   useCalendarActions,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -58,6 +58,7 @@ Element.prototype.animate = vi.fn();
 import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
 import { useAppStore } from "@/stores/app-store";
 import { useAuthStore } from "@/stores/auth-store";
+import { useBackStack } from "@/stores/back-stack-store";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useFamilyStore } from "@/stores/family-store";
 import { resetTestQueryClient } from "@/test/test-utils";
@@ -103,6 +104,9 @@ function resetAllStores(): void {
     isAuthenticated: false,
   });
   localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+
+  // Reset back stack store
+  useBackStack.setState({ stack: [] });
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Makes the hardware/gesture **back** button behave natively in the **installed Android PWA**: a single back press dismisses the top-most open overlay (LIFO), else steps up to Home, and only a confirmed second press at Home exits — after a brief "Press back again to exit" hint.

FamilyHub has no router (modules switch via `useAppStore.setActiveModule()`) and dismiss state is scattered across local `useState` + two Zustand stores, so this is **not** route history. Instead:

- **`useBackStack`** (Zustand) — a LIFO registry of "dismissable now" close handlers.
- **`useBackHandler(enabled, handler)`** — per-surface seam; open surfaces register their existing close handler (stale-closure-safe via a ref).
- **`useAndroidBackButton(enabled)`** — a single `popstate`/sentinel interceptor mounted **once** in the authenticated shell; the only place `history` is touched. On each back it runs the cascade: dismiss top handler → up to Home (`setActiveModule(null)`) → exit-hint → confirmed-second-press exit.

It drives only the **existing** close handlers, so the sibling [native-feel-interaction-polish](https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/native-feel-interaction-polish.md) transitions animate the back **for free**. **No router, no new motion code, no new dependency.**

Closes #231

- **Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/native-back-button.md
- **Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-17-native-back-button-design.md
- **Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-17-native-back-button.md

## Non-negotiable contract → code + tests

| # | Contract requirement | Code | Tests |
|---|---|---|---|
| 1 | **Gate:** active only when `isStandalone() && !isIOS() && matchMedia("(pointer: coarse)")`; browser tabs, iOS standalone, desktop PWAs are no-ops | `isAndroidBackContext()` — `src/hooks/use-android-back-button.ts` | no-op when disabled / on desktop (no coarse pointer) / on iOS standalone — `src/hooks/use-android-back-button.test.ts` |
| 2 | **Single interceptor** mounted once in the authed shell (`enabled = isAuthenticated && setupComplete`); only place `history` is touched — one re-pushed sentinel; deferred `history.back()` only on a confirmed 2nd press; no leak/trap | `useAndroidBackButton` + mount in `src/App.tsx` (above early returns) | full interceptor suite + `src/App.shell.test.tsx` (popstate → up to Home) |
| 3 | **LIFO dismiss registry**, register-once per overlay; `MobileSheet`/`SideSheet` leaves auto-cover, raw-`Dialog`/custom self-register **above early returns**; `event-form-modal` **excluded**; most-recent dismisses first | `useBackStack` + `useBackHandler`; leaf registration in `mobile-sheet.tsx`/`side-sheet.tsx`; 8 raw sites registered; `event-form-modal.tsx` untouched | `back-stack-store.test.ts` (LIFO), `use-back-handler.test.ts` (register/unregister + stale-closure + re-enable), `mobile-sheet`/`side-sheet`/`event-detail-modal` registration tests |
| 4 | **Cascade (single-root):** top overlay → up to Home → 1st-press toast (2000ms) → 2nd-press exit. No module-history stack | three-branch `onPop` in `use-android-back-button.ts` | cascade branch tests + re-arm — `use-android-back-button.test.ts` |
| 5 | **No new transition code** — drive only existing close handlers; no new dependency | registrations call existing `onClose`/`onOpenChange(false)`/`setSelected…(null)`/`setActiveModule(null)` | `package.json`/lockfile unchanged in diff |
| 6 | **Test harness:** `useBackStack` added to `resetAllStores()` (resets by explicit name) | `src/test/setup.ts` | n/a (infra) |
| 7 | **Done = green** | — | `npm run lint` exit 0; `npm test -- --run` → **1028 passed** |

## Test plan

- [x] `npm run lint` — exit 0 (only a pre-existing `meals-view.tsx` warning in an untouched file)
- [x] `npm test -- --run` — **105 files, 1028 tests pass** (+21 over the pre-branch 1007 baseline)
- [x] Unit: `useBackStack` LIFO; `useBackHandler` register/unregister/stale-closure/re-enable; `useAndroidBackButton` gate (disabled/desktop/**iOS**), single-sentinel mount, all three cascade branches, double-press exit (fake timers), re-arm
- [x] Integration: `App.shell` (back → up to Home), `MobileSheet`/`SideSheet`/lists/recipes/`event-detail-modal` registration → close round-trips
- [ ] **Manual Galaxy-S10 / Chrome installed-PWA pass (the real acceptance gate — NOT run in CI; requires a human on-device):**
  - Open a list/recipe detail → back closes it (slides), back again → Home (fades), back → "Press back again to exit" toast, back again → exits.
  - Repeat with the "More" sheet, a form sheet, a confirm-dialog-inside-settings (confirm closes before its parent), and the sidebar — most-recent always closes first.
  - Refresh mid-session → lands on Home, back still buffered (doesn't instantly exit).
  - Normal browser tab and (if available) iOS standalone → back unaffected (browser default).

> E2E note: Playwright can't emulate `display-mode: standalone`, so the standalone-gated behavior isn't E2E-testable — coverage is unit + the manual device pass above.

## Known limitation (out of v1 scope)

Per the spec's non-goals (login/onboarding back-handling is deferred), the interceptor is scoped to the authenticated session. If `enabled` toggles `true → false → true` within one page session (a logout→login **without** a reload), a second sentinel is pushed without the first being popped, so the user would need one extra back press to exit until the next reload. This is bounded and benign (never a trap), and the normal overlay open/close cycle keeps history at ~2 entries (no leak). Hardening this would require popping history on cleanup, which the spec deliberately avoids; flagged here for transparency.
