### PR TITLE
feat(mobile-ux): optional haptic feedback (Vibration API) with per-device toggles

### DIFF
--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { haptics } from "@/lib/haptics";
+import type { ChoreBoardItem } from "@/lib/types";
+import { ChoreRow } from "./chore-row";
+
+// Cast: the row only reads templateId/title/cadence/completed.
+const baseChore = {
+  templateId: "t1",
+  title: "Dishes",
+  cadence: "DAILY",
+  completed: false,
+} as ChoreBoardItem;
+
+describe("ChoreRow haptics", () => {
+  it("fires success() on the complete path", async () => {
+    const success = vi.spyOn(haptics, "success").mockImplementation(() => {});
+    render(
+      <ChoreRow
+        chore={baseChore}
+        onComplete={vi.fn()}
+        onUncomplete={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /mark dishes complete/i }),
+    );
+    expect(success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire success() on the uncomplete path", async () => {
+    const success = vi.spyOn(haptics, "success").mockImplementation(() => {});
+    render(
+      <ChoreRow
+        chore={{ ...baseChore, completed: true }}
+        onComplete={vi.fn()}
+        onUncomplete={vi.fn()}
+      />,
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /mark dishes incomplete/i }),
+    );
+    expect(success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -33,6 +33,13 @@ export function ChoreRow({
           : "border-transparent bg-card hover:border-border",
       )}
     >
+      {/*
+        Keep this a raw <button>, not <Button>/usePressable (the Archive control
+        beside it uses <Button>): a pressable would fire haptics.tap() on
+        pointerdown, and the shared 40ms throttle would then coalesce away the
+        haptics.success() pulse on click. The single completion pulse depends on
+        no preceding tap. Guarded by the throttle-coupling test in haptics.test.ts.
+      */}
       <button
         type="button"
         aria-label={

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -1,5 +1,6 @@
 import { Archive, Check, Circle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { haptics } from "@/lib/haptics";
 import type { ChoreBoardItem } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -39,7 +40,14 @@ export function ChoreRow({
             ? `Mark ${chore.title} incomplete`
             : `Mark ${chore.title} complete`
         }
-        onClick={chore.completed ? onUncomplete : onComplete}
+        onClick={() => {
+          if (chore.completed) {
+            onUncomplete?.();
+          } else {
+            haptics.success();
+            onComplete?.();
+          }
+        }}
         className={cn(
           "flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
           chore.completed

--- a/src/components/lists/list-item-row.test.tsx
+++ b/src/components/lists/list-item-row.test.tsx
@@ -1,8 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { haptics } from "@/lib/haptics";
 import type { ListItem } from "@/lib/types";
+import { useHapticsPreference } from "@/stores";
 import { ListItemRow } from "./list-item-row";
 
 // Cast: the row only reads id/text/completed; ListItem requires more fields.
@@ -35,5 +36,63 @@ describe("ListItemRow haptics", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: /milk/i }));
     expect(success).not.toHaveBeenCalled();
+  });
+});
+
+// Drives the REAL haptics.success() (no spy) through to navigator.vibrate on a
+// capable + opted-in device. This is the regression guard for the "no
+// double-pulse" invariant: the raw <button> emits success() with no preceding
+// tap, so the [12,40,12] pulse survives the shared 40ms throttle. If the
+// complete control ever gains a pointerdown tap() (e.g. switched to
+// <Button>/usePressable), the success would be coalesced away and this fails.
+describe("ListItemRow haptics — real fire reaches the device", () => {
+  function setCapableTouchDevice() {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: query.includes("coarse"), // touch-primary → canVibrate() true
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    Object.defineProperty(navigator, "vibrate", {
+      value: vi.fn(() => true),
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  beforeEach(() => {
+    // The spied tests above install vi.spyOn(haptics, "success"); the global
+    // afterEach clears call history but does NOT restore spies, so without this
+    // haptics.success would still be a no-op and never reach navigator.vibrate.
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    delete (navigator as { vibrate?: unknown }).vibrate;
+  });
+
+  it("vibrates the success double-pulse [12,40,12] on completion", async () => {
+    setCapableTouchDevice();
+    useHapticsPreference.setState({
+      enabled: true,
+      categories: { taps: true, completions: true, back: true },
+    });
+    const vibrate = navigator.vibrate as ReturnType<typeof vi.fn>;
+
+    render(
+      <ListItemRow
+        item={baseItem}
+        onToggle={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+
+    expect(vibrate).toHaveBeenCalledWith([12, 40, 12]);
   });
 });

--- a/src/components/lists/list-item-row.test.tsx
+++ b/src/components/lists/list-item-row.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { haptics } from "@/lib/haptics";
+import type { ListItem } from "@/lib/types";
+import { ListItemRow } from "./list-item-row";
+
+// Cast: the row only reads id/text/completed; ListItem requires more fields.
+const baseItem = { id: "1", text: "Milk", completed: false } as ListItem;
+
+describe("ListItemRow haptics", () => {
+  it("fires success() when completing an item", async () => {
+    const success = vi.spyOn(haptics, "success").mockImplementation(() => {});
+    render(
+      <ListItemRow
+        item={baseItem}
+        onToggle={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+    expect(success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire success() when un-completing", async () => {
+    const success = vi.spyOn(haptics, "success").mockImplementation(() => {});
+    render(
+      <ListItemRow
+        item={{ ...baseItem, completed: true }}
+        onToggle={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+    expect(success).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/lists/list-item-row.tsx
+++ b/src/components/lists/list-item-row.tsx
@@ -19,6 +19,13 @@ export function ListItemRow({
 }: ListItemRowProps) {
   return (
     <div className="flex min-h-14 items-center gap-2 rounded-lg border border-border bg-card p-2 shadow-sm">
+      {/*
+        Keep this a raw <button>, not <Button>/usePressable: a pressable would
+        fire haptics.tap() on pointerdown, and the shared 40ms throttle would
+        then coalesce away the haptics.success() pulse on click. The single
+        completion pulse depends on no preceding tap on the same gesture.
+        Guarded by the throttle-coupling test in haptics.test.ts.
+      */}
       <button
         type="button"
         aria-pressed={item.completed}

--- a/src/components/lists/list-item-row.tsx
+++ b/src/components/lists/list-item-row.tsx
@@ -1,4 +1,5 @@
 import { Check, Pencil, Trash2 } from "lucide-react";
+import { haptics } from "@/lib/haptics";
 import type { ListItem } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
@@ -21,7 +22,10 @@ export function ListItemRow({
       <button
         type="button"
         aria-pressed={item.completed}
-        onClick={() => onToggle(!item.completed)}
+        onClick={() => {
+          if (!item.completed) haptics.success(); // completing transition only
+          onToggle(!item.completed);
+        }}
         className="flex min-w-0 flex-1 items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <span

--- a/src/components/settings/preferences-sheet.test.tsx
+++ b/src/components/settings/preferences-sheet.test.tsx
@@ -12,6 +12,7 @@ import {
 } from "vitest";
 import { type FamilyApiResponse, familyKeys } from "@/api";
 import type { FamilyData, UpdateFamilyRequest } from "@/lib/types";
+import { useHapticsPreference } from "@/stores";
 import {
   API_BASE,
   resetMockFamily,
@@ -236,6 +237,23 @@ describe("PreferencesSheet — roadmap stubs", () => {
 });
 
 // ============================================================================
+// Haptics helpers
+// ============================================================================
+
+function setVibrate(on: boolean) {
+  if (on) {
+    Object.defineProperty(navigator, "vibrate", {
+      value: () => true,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    // biome-ignore lint/performance/noDelete: capability removal for the test
+    delete (navigator as { vibrate?: unknown }).vibrate;
+  }
+}
+
+// ============================================================================
 // Breakpoints (mirrors responsive-form-dialog-breakpoint.test.tsx)
 // ============================================================================
 
@@ -299,5 +317,43 @@ describe("PreferencesSheet — breakpoints", () => {
       screen.getByRole("dialog", { name: "Preferences" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+  });
+});
+
+// ============================================================================
+// Haptics section
+// ============================================================================
+
+describe("PreferencesSheet — Haptics section", () => {
+  afterEach(() => setVibrate(false));
+
+  it("is absent when navigator.vibrate is unsupported", () => {
+    setVibrate(false);
+    const client = seedClient(baseFamily("America/Chicago"));
+    render(<PreferencesSheet open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+    expect(screen.queryByRole("heading", { name: /haptics/i })).toBeNull();
+  });
+
+  it("shows the master switch and reveals sub-switches when enabled", async () => {
+    setVibrate(true);
+    const client = seedClient(baseFamily("America/Chicago"));
+    const { user } = renderWithUser(
+      <PreferencesSheet open onOpenChange={noop} />,
+      { queryClient: client },
+    );
+    expect(
+      screen.getByRole("heading", { name: /haptics/i }),
+    ).toBeInTheDocument();
+    // sub-switches hidden while master is off
+    expect(screen.queryByRole("switch", { name: /taps/i })).toBeNull();
+
+    await user.click(screen.getByRole("switch", { name: /enable haptics/i }));
+    expect(useHapticsPreference.getState().enabled).toBe(true);
+
+    // sub-switches now visible; toggling one writes its category
+    await user.click(screen.getByRole("switch", { name: /taps/i }));
+    expect(useHapticsPreference.getState().categories.taps).toBe(false);
   });
 });

--- a/src/components/settings/preferences-sheet.test.tsx
+++ b/src/components/settings/preferences-sheet.test.tsx
@@ -241,6 +241,19 @@ describe("PreferencesSheet — roadmap stubs", () => {
 // ============================================================================
 
 function setVibrate(on: boolean) {
+  // A capable device is touch-primary (coarse pointer) AND exposes the
+  // Vibration API — canVibrate() now requires both, so a mouse-primary desktop
+  // (fine pointer, no-op vibrate) hides the section.
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches: query.includes("coarse") ? on : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
   if (on) {
     Object.defineProperty(navigator, "vibrate", {
       value: () => true,

--- a/src/components/settings/preferences-sheet.test.tsx
+++ b/src/components/settings/preferences-sheet.test.tsx
@@ -248,7 +248,6 @@ function setVibrate(on: boolean) {
       writable: true,
     });
   } else {
-    // biome-ignore lint/performance/noDelete: capability removal for the test
     delete (navigator as { vibrate?: unknown }).vibrate;
   }
 }

--- a/src/components/settings/preferences-sheet.tsx
+++ b/src/components/settings/preferences-sheet.tsx
@@ -1,10 +1,13 @@
-import { Bell, LocateFixed, Palette, X } from "lucide-react";
+import { Bell, LocateFixed, Palette, Vibrate, X } from "lucide-react";
 import { useState } from "react";
 import { useFamilyData, useUpdateFamily } from "@/api";
 import { Button } from "@/components/ui/button";
 import { FormError } from "@/components/ui/form-error";
 import { Label } from "@/components/ui/label";
 import { ResponsiveFormDialog } from "@/components/ui/responsive-form-dialog";
+import { Switch } from "@/components/ui/switch";
+import { canVibrate } from "@/lib/haptics";
+import { type HapticCategory, useHapticsPreference } from "@/stores";
 
 /**
  * Curated US zones offered in the timezone select. The family's current zone
@@ -25,6 +28,12 @@ const COMING_SOON_ROWS = [
   { icon: Bell, label: "Notifications" },
   { icon: Palette, label: "Appearance" },
 ] as const;
+
+const SUB_TOGGLES: ReadonlyArray<{ key: HapticCategory; label: string }> = [
+  { key: "taps", label: "Taps" },
+  { key: "completions", label: "Completions" },
+  { key: "back", label: "Back" },
+];
 
 interface PreferencesSheetProps {
   open: boolean;
@@ -48,6 +57,12 @@ export function PreferencesSheet({
   const updateFamilyMutation = useUpdateFamily({
     onError: (error) => setSaveError(error.message),
   });
+
+  const hapticsSupported = canVibrate();
+  const hapticsEnabled = useHapticsPreference((s) => s.enabled);
+  const hapticCategories = useHapticsPreference((s) => s.categories);
+  const setHapticsEnabled = useHapticsPreference((s) => s.setEnabled);
+  const setHapticCategory = useHapticsPreference((s) => s.setCategory);
 
   const saveTimezone = (zone: string) => {
     if (!zone || zone === timezone) return;
@@ -122,6 +137,49 @@ export function PreferencesSheet({
             Use this device's timezone
           </Button>
         </section>
+
+        {/* Haptics Section (capability-gated: hidden on iOS/desktop) */}
+        {hapticsSupported && (
+          <section className="space-y-4">
+            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              Haptics
+            </h3>
+            <Label
+              htmlFor="haptics-master"
+              className="flex min-h-11 items-center justify-between gap-3 font-medium"
+            >
+              <span className="flex items-center gap-2">
+                <Vibrate className="h-4 w-4" />
+                Enable haptics
+              </span>
+              <Switch
+                id="haptics-master"
+                aria-label="Enable haptics"
+                checked={hapticsEnabled}
+                onCheckedChange={setHapticsEnabled}
+              />
+            </Label>
+            {hapticsEnabled && (
+              <div className="space-y-1 pl-6">
+                {SUB_TOGGLES.map(({ key, label }) => (
+                  <Label
+                    key={key}
+                    htmlFor={`haptics-${key}`}
+                    className="flex min-h-11 items-center justify-between gap-3 font-normal text-muted-foreground"
+                  >
+                    {label}
+                    <Switch
+                      id={`haptics-${key}`}
+                      aria-label={label}
+                      checked={hapticCategories[key]}
+                      onCheckedChange={(on) => setHapticCategory(key, on)}
+                    />
+                  </Label>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
 
         {/* Coming Soon Section */}
         <section className="space-y-4">

--- a/src/components/settings/preferences-sheet.tsx
+++ b/src/components/settings/preferences-sheet.tsx
@@ -138,7 +138,9 @@ export function PreferencesSheet({
           </Button>
         </section>
 
-        {/* Haptics Section (capability-gated: hidden on iOS/desktop) */}
+        {/* Haptics Section — canVibrate() gates on the Vibration API + a coarse
+            (touch) pointer, so this is hidden on iOS Safari and on desktop
+            Chrome/Edge/Firefox (which define a no-op navigator.vibrate). */}
         {hapticsSupported && (
           <section className="space-y-4">
             <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">

--- a/src/components/ui/switch.test.tsx
+++ b/src/components/ui/switch.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Switch } from "./switch";
+
+describe("Switch", () => {
+  it("renders a switch reflecting checked state", () => {
+    render(<Switch checked aria-label="Haptics" onCheckedChange={() => {}} />);
+    const sw = screen.getByRole("switch", { name: "Haptics" });
+    expect(sw).toBeInTheDocument();
+    expect(sw).toBeChecked();
+  });
+
+  it("calls onCheckedChange when toggled", async () => {
+    const onCheckedChange = vi.fn();
+    render(
+      <Switch
+        checked={false}
+        aria-label="Haptics"
+        onCheckedChange={onCheckedChange}
+      />,
+    );
+    await userEvent.click(screen.getByRole("switch", { name: "Haptics" }));
+    expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,26 @@
+import * as SwitchPrimitive from "@radix-ui/react-switch";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block h-4 w-4 rounded-full bg-background shadow-sm ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/hooks/use-android-back-button.test.ts
+++ b/src/hooks/use-android-back-button.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/lib/pwa", () => ({
 vi.mock("@/components/ui/toaster", () => ({ toast: vi.fn() }));
 
 import { toast } from "@/components/ui/toaster";
+import { haptics } from "@/lib/haptics";
 import { isIOS, isStandalone } from "@/lib/pwa";
 import { useAppStore, useBackStack } from "@/stores";
 import { useAndroidBackButton } from "./use-android-back-button";
@@ -114,5 +115,29 @@ describe("useAndroidBackButton", () => {
     expect(toast).toHaveBeenCalledTimes(2);
     expect(window.history.back).not.toHaveBeenCalled();
     vi.useRealTimers();
+  });
+
+  it("fires haptics.back() when dismissing the top overlay", () => {
+    const back = vi.spyOn(haptics, "back").mockImplementation(() => {});
+    useBackStack.getState().register(vi.fn());
+    renderHook(() => useAndroidBackButton(true));
+    popstate();
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires haptics.back() when stepping up to Home", () => {
+    const back = vi.spyOn(haptics, "back").mockImplementation(() => {});
+    useAppStore.setState({ activeModule: "lists" });
+    renderHook(() => useAndroidBackButton(true));
+    popstate();
+    expect(back).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire haptics.back() on the exit-hint branch (Home root)", () => {
+    const back = vi.spyOn(haptics, "back").mockImplementation(() => {});
+    useAppStore.setState({ activeModule: null });
+    renderHook(() => useAndroidBackButton(true));
+    popstate(); // first press at Home → hint toast, not a dismiss
+    expect(back).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-android-back-button.ts
+++ b/src/hooks/use-android-back-button.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { toast } from "@/components/ui/toaster";
+import { haptics } from "@/lib/haptics";
 import { isIOS, isStandalone } from "@/lib/pwa";
 import { useAppStore, useBackStack } from "@/stores";
 
@@ -32,6 +33,7 @@ export function useAndroidBackButton(enabled: boolean): void {
       //    itself via its own useBackHandler effect; we only peek.
       const top = useBackStack.getState().peek();
       if (top) {
+        haptics.back();
         top.handler();
         rebuffer();
         return;
@@ -39,6 +41,7 @@ export function useAndroidBackButton(enabled: boolean): void {
       // 2. Module layer (single-root): step up to Home.
       const { activeModule, setActiveModule } = useAppStore.getState();
       if (activeModule !== null) {
+        haptics.back();
         setActiveModule(null);
         rebuffer();
         return;

--- a/src/hooks/use-pressable.test.ts
+++ b/src/hooks/use-pressable.test.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { haptics } from "@/lib/haptics";
 import { PRESSABLE, usePressable } from "./use-pressable";
 
 describe("usePressable", () => {
@@ -13,5 +14,11 @@ describe("usePressable", () => {
     const { result } = renderHook(() => usePressable());
     expect(result.current.className).toBe(PRESSABLE);
     expect(() => result.current.onPointerDown({} as never)).not.toThrow();
+  });
+  it("fires haptics.tap() on pointer down", () => {
+    const tap = vi.spyOn(haptics, "tap").mockImplementation(() => {});
+    const { result } = renderHook(() => usePressable());
+    result.current.onPointerDown({} as never);
+    expect(tap).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/use-pressable.ts
+++ b/src/hooks/use-pressable.ts
@@ -1,5 +1,6 @@
 import type { PointerEvent } from "react";
 import { useCallback } from "react";
+import { haptics } from "@/lib/haptics";
 
 /**
  * Press-feedback visual. The scale is motion-gated (reduced-motion drops it);
@@ -20,7 +21,7 @@ export interface Pressable {
 /** Single integration point for press visuals and (later) haptics. */
 export function usePressable(): Pressable {
   const onPointerDown = useCallback((_event: PointerEvent) => {
-    // Haptic seam: the optional-haptics story adds `useHaptics().tap()` here.
+    haptics.tap();
   }, []);
   return { className: PRESSABLE, onPointerDown };
 }

--- a/src/hooks/use-pressable.ts
+++ b/src/hooks/use-pressable.ts
@@ -18,7 +18,7 @@ export interface Pressable {
   onPointerDown: (event: PointerEvent) => void;
 }
 
-/** Single integration point for press visuals and (later) haptics. */
+/** Single integration point for press visuals and haptics. */
 export function usePressable(): Pressable {
   const onPointerDown = useCallback((_event: PointerEvent) => {
     haptics.tap();

--- a/src/lib/haptics.test.ts
+++ b/src/lib/haptics.test.ts
@@ -106,4 +106,17 @@ describe("haptics", () => {
     haptics.tap();
     expect(vibrate).toHaveBeenCalledTimes(2);
   });
+
+  it("coalesces a success that follows a tap on the same gesture — why completion controls must stay raw <button>", () => {
+    // A usePressable control fires tap() on pointerdown, then success() on the
+    // same click — within THROTTLE_MS, so the shared throttle would swallow the
+    // success double-pulse. The list/chore complete controls stay raw <button>
+    // precisely to avoid this; if that ever regresses, this test changes color.
+    const vibrate = navigator.vibrate as ReturnType<typeof vi.fn>;
+    haptics.tap(); // pointerdown → 10
+    haptics.success(); // same gesture, inside the window → suppressed
+    expect(vibrate).toHaveBeenCalledTimes(1);
+    expect(vibrate).toHaveBeenCalledWith(10);
+    expect(vibrate).not.toHaveBeenCalledWith([12, 40, 12]);
+  });
 });

--- a/src/lib/haptics.test.ts
+++ b/src/lib/haptics.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useHapticsPreference } from "@/stores";
+import { canVibrate, haptics, resetHapticsThrottle } from "./haptics";
+
+function setVibrate(fn: ((p: number | number[]) => boolean) | undefined) {
+  if (fn) {
+    Object.defineProperty(navigator, "vibrate", {
+      value: fn,
+      configurable: true,
+      writable: true,
+    });
+  } else {
+    // biome-ignore lint/performance/noDelete: capability removal for the test
+    delete (navigator as { vibrate?: unknown }).vibrate;
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers(); // controls the throttle clock (Date.now)
+  resetHapticsThrottle(); // reset the module throttle clock between tests
+  setVibrate(vi.fn(() => true)); // capable baseline; tests override
+  useHapticsPreference.setState({
+    enabled: true,
+    categories: { taps: true, completions: true, back: true },
+  });
+});
+afterEach(() => {
+  vi.useRealTimers();
+  setVibrate(undefined);
+});
+
+describe("canVibrate", () => {
+  it("is true when navigator.vibrate exists, false when absent", () => {
+    expect(canVibrate()).toBe(true);
+    setVibrate(undefined);
+    expect(canVibrate()).toBe(false);
+  });
+});
+
+describe("haptics", () => {
+  it("fires the right pattern per category when capable + opted-in", () => {
+    const vibrate = navigator.vibrate as ReturnType<typeof vi.fn>;
+    haptics.tap();
+    expect(vibrate).toHaveBeenLastCalledWith(10);
+    vi.advanceTimersByTime(100);
+    haptics.success();
+    expect(vibrate).toHaveBeenLastCalledWith([12, 40, 12]);
+    vi.advanceTimersByTime(100);
+    haptics.back();
+    expect(vibrate).toHaveBeenLastCalledWith(8);
+  });
+
+  it("is a silent no-op when navigator.vibrate is absent", () => {
+    setVibrate(undefined);
+    expect(() => haptics.tap()).not.toThrow();
+  });
+
+  it("is a no-op when the master toggle is off", () => {
+    useHapticsPreference.setState({ enabled: false });
+    haptics.tap();
+    expect(navigator.vibrate).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the specific category is off", () => {
+    useHapticsPreference.setState({
+      enabled: true,
+      categories: { taps: false, completions: true, back: true },
+    });
+    haptics.tap();
+    expect(navigator.vibrate).not.toHaveBeenCalled();
+  });
+
+  it("throttles repeats inside the window and re-fires after it", () => {
+    const vibrate = navigator.vibrate as ReturnType<typeof vi.fn>;
+    haptics.tap();
+    haptics.tap(); // within THROTTLE_MS → suppressed
+    expect(vibrate).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(100); // past the window
+    haptics.tap();
+    expect(vibrate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/haptics.test.ts
+++ b/src/lib/haptics.test.ts
@@ -10,7 +10,6 @@ function setVibrate(fn: ((p: number | number[]) => boolean) | undefined) {
       writable: true,
     });
   } else {
-    // biome-ignore lint/performance/noDelete: capability removal for the test
     delete (navigator as { vibrate?: unknown }).vibrate;
   }
 }

--- a/src/lib/haptics.test.ts
+++ b/src/lib/haptics.test.ts
@@ -14,10 +14,29 @@ function setVibrate(fn: ((p: number | number[]) => boolean) | undefined) {
   }
 }
 
+/**
+ * Drive `(pointer: coarse)` — a touch-primary device is `true`, a mouse-primary
+ * desktop is `false`. canVibrate() requires this in addition to the Vibration
+ * API, because desktop Chrome/Edge/Firefox define a no-op `navigator.vibrate`.
+ */
+function setCoarsePointer(coarse: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches: query.includes("coarse") ? coarse : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
 beforeEach(() => {
   vi.useFakeTimers(); // controls the throttle clock (Date.now)
   resetHapticsThrottle(); // reset the module throttle clock between tests
   setVibrate(vi.fn(() => true)); // capable baseline; tests override
+  setCoarsePointer(true); // touch-primary baseline (Android PWA); tests override
   useHapticsPreference.setState({
     enabled: true,
     categories: { taps: true, completions: true, back: true },
@@ -32,6 +51,15 @@ describe("canVibrate", () => {
   it("is true when navigator.vibrate exists, false when absent", () => {
     expect(canVibrate()).toBe(true);
     setVibrate(undefined);
+    expect(canVibrate()).toBe(false);
+  });
+
+  it("is false on a fine-pointer (desktop) device even when navigator.vibrate exists", () => {
+    // Desktop Chrome/Edge/Firefox define a silent no-op navigator.vibrate, so
+    // the function's presence alone is NOT a touch-device gate; the coarse
+    // pointer is what excludes mouse-primary desktops.
+    setCoarsePointer(false);
+    setVibrate(vi.fn(() => true));
     expect(canVibrate()).toBe(false);
   });
 });

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -17,11 +17,22 @@ const PATTERNS: Record<HapticCategory, number | number[]> = {
 const THROTTLE_MS = 40; // guard against pointerdown storms / rapid repeats
 let lastFireAt = Number.NEGATIVE_INFINITY;
 
-/** Feature-detect the Vibration API. Android Chrome → true; iOS Safari + desktop → false. */
+/**
+ * Detect a device that can actually deliver haptics: the Vibration API AND a
+ * touch-primary (coarse) pointer. Android Chrome PWA → true; iOS Safari → false
+ * (no `navigator.vibrate`); desktop Chrome/Edge/Firefox → false too, because
+ * they define a *no-op* `navigator.vibrate` on mouse-primary hardware — so the
+ * function's presence alone is not a touch-device gate. Mirrors the
+ * `(pointer: coarse)` check in `use-android-back-button.ts`.
+ */
 export function canVibrate(): boolean {
-  return (
-    typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
-  );
+  if (
+    typeof navigator === "undefined" ||
+    typeof navigator.vibrate !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia?.("(pointer: coarse)").matches === true;
 }
 
 function fire(category: keyof typeof PATTERNS): void {

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,11 +1,18 @@
-import { useHapticsPreference } from "@/stores/haptics-store";
+import {
+  type HapticCategory,
+  useHapticsPreference,
+} from "@/stores/haptics-store";
 
-/** Short, subtle patterns (ms). Single pulses for tap/back; a brief double for success. */
-const PATTERNS = {
+/**
+ * Short, subtle patterns (ms). Single pulses for tap/back; a brief double for
+ * success. Typed as `number | number[]` (not `as const`) so each value is
+ * assignable to `navigator.vibrate`'s mutable `VibratePattern`.
+ */
+const PATTERNS: Record<HapticCategory, number | number[]> = {
   taps: 10,
   completions: [12, 40, 12],
   back: 8,
-} as const;
+};
 
 const THROTTLE_MS = 40; // guard against pointerdown storms / rapid repeats
 let lastFireAt = Number.NEGATIVE_INFINITY;

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,0 +1,40 @@
+import { useHapticsPreference } from "@/stores/haptics-store";
+
+/** Short, subtle patterns (ms). Single pulses for tap/back; a brief double for success. */
+const PATTERNS = {
+  taps: 10,
+  completions: [12, 40, 12],
+  back: 8,
+} as const;
+
+const THROTTLE_MS = 40; // guard against pointerdown storms / rapid repeats
+let lastFireAt = Number.NEGATIVE_INFINITY;
+
+/** Feature-detect the Vibration API. Android Chrome → true; iOS Safari + desktop → false. */
+export function canVibrate(): boolean {
+  return (
+    typeof navigator !== "undefined" && typeof navigator.vibrate === "function"
+  );
+}
+
+function fire(category: keyof typeof PATTERNS): void {
+  if (!canVibrate()) return;
+  const { enabled, categories } = useHapticsPreference.getState();
+  if (!enabled || !categories[category]) return;
+  const now = Date.now();
+  if (now - lastFireAt < THROTTLE_MS) return; // coalesce rapid repeats
+  lastFireAt = now;
+  navigator.vibrate(PATTERNS[category]);
+}
+
+/** @internal Test-only: reset the shared throttle clock between test runs. */
+export function resetHapticsThrottle(): void {
+  lastFireAt = Number.NEGATIVE_INFINITY;
+}
+
+/** The only sanctioned way to vibrate. Each method no-ops unless capable + opted-in. */
+export const haptics = {
+  tap: () => fire("taps"),
+  success: () => fire("completions"),
+  back: () => fire("back"),
+};

--- a/src/stores/haptics-store.test.ts
+++ b/src/stores/haptics-store.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { HAPTICS_STORAGE_KEY, useHapticsPreference } from "./haptics-store";
+
+beforeEach(() => {
+  localStorage.clear();
+  useHapticsPreference.setState({
+    enabled: false,
+    categories: { taps: true, completions: true, back: true },
+  });
+});
+
+describe("useHapticsPreference", () => {
+  it("defaults to master off with every category on", () => {
+    const s = useHapticsPreference.getState();
+    expect(s.enabled).toBe(false);
+    expect(s.categories).toEqual({ taps: true, completions: true, back: true });
+  });
+
+  it("setEnabled toggles the master flag", () => {
+    useHapticsPreference.getState().setEnabled(true);
+    expect(useHapticsPreference.getState().enabled).toBe(true);
+  });
+
+  it("setCategory toggles one category without touching the others", () => {
+    useHapticsPreference.getState().setCategory("taps", false);
+    expect(useHapticsPreference.getState().categories).toEqual({
+      taps: false,
+      completions: true,
+      back: true,
+    });
+  });
+
+  it("persists enabled + categories to localStorage[family-hub-haptics]", () => {
+    useHapticsPreference.getState().setEnabled(true);
+    useHapticsPreference.getState().setCategory("back", false);
+    const persisted = JSON.parse(
+      localStorage.getItem(HAPTICS_STORAGE_KEY) ?? "{}",
+    );
+    expect(persisted.state.enabled).toBe(true);
+    expect(persisted.state.categories.back).toBe(false);
+  });
+});

--- a/src/stores/haptics-store.ts
+++ b/src/stores/haptics-store.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type HapticCategory = "taps" | "completions" | "back";
+
+interface HapticsPreferenceState {
+  enabled: boolean; // master, default false
+  categories: Record<HapticCategory, boolean>; // each default true
+  setEnabled: (on: boolean) => void;
+  setCategory: (category: HapticCategory, on: boolean) => void;
+}
+
+/** localStorage key; also consumed by the test-harness store reset. */
+export const HAPTICS_STORAGE_KEY = "family-hub-haptics";
+
+export const useHapticsPreference = create<HapticsPreferenceState>()(
+  persist(
+    (set) => ({
+      enabled: false,
+      categories: { taps: true, completions: true, back: true },
+      setEnabled: (on) => set({ enabled: on }),
+      setCategory: (category, on) =>
+        set((s) => ({ categories: { ...s.categories, [category]: on } })),
+    }),
+    {
+      name: HAPTICS_STORAGE_KEY,
+      partialize: (s) => ({ enabled: s.enabled, categories: s.categories }),
+    },
+  ),
+);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -27,4 +27,10 @@ export {
 } from "./calendar-store";
 // Family Store - Hydration only (data selectors moved to @/api)
 export { useFamilyStore, useHasHydrated } from "./family-store";
+// Haptics Store
+export {
+  HAPTICS_STORAGE_KEY,
+  type HapticCategory,
+  useHapticsPreference,
+} from "./haptics-store";
 export { type Photo, usePhotosStore } from "./photos-store";

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -56,6 +56,7 @@ Element.prototype.animate = vi.fn();
 
 // Import stores directly to reset them (avoid circular deps with test-utils)
 import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
+import { resetHapticsThrottle } from "@/lib/haptics";
 import { useAppStore } from "@/stores/app-store";
 import { useAuthStore } from "@/stores/auth-store";
 import { useBackStack } from "@/stores/back-stack-store";
@@ -118,6 +119,9 @@ function resetAllStores(): void {
     categories: { taps: true, completions: true, back: true },
   });
   localStorage.removeItem(HAPTICS_STORAGE_KEY);
+  // Reset the module-level throttle clock so a test that exercises the real
+  // fire() (capable + opted-in) cannot leak a recent lastFireAt into the next.
+  resetHapticsThrottle();
 }
 
 // =============================================================================

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -61,6 +61,10 @@ import { useAuthStore } from "@/stores/auth-store";
 import { useBackStack } from "@/stores/back-stack-store";
 import { useCalendarStore } from "@/stores/calendar-store";
 import { useFamilyStore } from "@/stores/family-store";
+import {
+  HAPTICS_STORAGE_KEY,
+  useHapticsPreference,
+} from "@/stores/haptics-store";
 import { resetTestQueryClient } from "@/test/test-utils";
 
 /**
@@ -107,6 +111,13 @@ function resetAllStores(): void {
 
   // Reset back stack store
   useBackStack.setState({ stack: [] });
+
+  // Reset haptics preference store
+  useHapticsPreference.setState({
+    enabled: false,
+    categories: { taps: true, completions: true, back: true },
+  });
+  localStorage.removeItem(HAPTICS_STORAGE_KEY);
 }
 
 // =============================================================================


### PR DESCRIPTION
Implements optional, opt-in haptic feedback for the installed Android PWA. **Closes #235.**

- **Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/optional-haptics.md
- **Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-18-optional-haptics-design.md
- **Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-18-optional-haptics.md

## What this does

A subtle vibration fires on a per-device-configurable set of touch interactions in the installed Android PWA — primary-action **taps**, list/chore **completions**, and hardware **back**-dismiss — routed through a single helper, opt-in (master default **off**), and a silent no-op everywhere `navigator.vibrate` is absent (iOS Safari, desktop). Built entirely on the existing PR #230 (`usePressable().onPointerDown`) and PR #234 (`useAndroidBackButton` `onPop`) seams — **no new motion/press/back infrastructure and no new dependency** (`@radix-ui/react-switch` was already installed).

## Contract checklist (each non-negotiable → code + tests)

| # | Requirement | Code | Tests |
|---|---|---|---|
| 1 | **Single helper** is the *only* `navigator.vibrate` caller | `src/lib/haptics.ts` (`haptics.tap/success/back`, `fire()`) | `haptics.test.ts`; `grep` confirms no other caller |
| 2 | **Capability-only gate + opt-in** — cap→master→category→throttle (one shared 40 ms); no `isStandalone`/`isIOS` in helper; patterns tap `10`, success `[12,40,12]`, back `8` | `haptics.ts` `fire()` / `canVibrate()` | `haptics.test.ts` (pattern per category; no-op when incapable / master-off / category-off; throttle suppress-then-refire) |
| 3 | **Persisted per-device store** (key `family-hub-haptics`, master default off, 3 categories default on, localStorage only) | `src/stores/haptics-store.ts` + `@/stores` barrel | `haptics-store.test.ts` (defaults, setters, persistence) |
| 4 | **Reuse seams, no double-pulse** — tap seam; success only on the **completing transition**; back only on the **two handled** `onPop` branches (not exit-hint) | `use-pressable.ts`, `list-item-row.tsx`, `chore-row.tsx`, `use-android-back-button.ts` | `use-pressable.test.ts`, `list-item-row.test.tsx`, `chore-row.test.tsx`, `use-android-back-button.test.ts` (fires/does-NOT-fire both directions) |
| 5 | **Capability-gated Preferences UI** — section only when `canVibrate()`; master + 3 sub-switches; thin `Switch` over already-installed radix | `preferences-sheet.tsx`, `src/components/ui/switch.tsx` | `preferences-sheet.test.tsx` (absent when unsupported; master reveals sub-switches; toggles write store), `switch.test.tsx` |
| 6 | **Test harness** — `useHapticsPreference` reset **by name** in `resetAllStores()` + key cleared; fire-site tests use `vi.spyOn(haptics,…)`, **never** `vi.mock("@/lib/haptics")` | `src/test/setup.ts` | all fire-site tests use `vi.spyOn`; `grep` confirms no `vi.mock` of haptics |
| 7 | **Green gate** | — | see Verification below |

## Verification

- `npm run lint` → **exit 0** (the 1 remaining warning is pre-existing in `meals-view.tsx`, untouched by this branch)
- `npm test -- --run` → **110 files, 1050 tests passing** (1028 baseline + 22 new)
- `npm run build` → `tsc -b` + Vite + PWA build **clean** (this gate caught and we fixed a real `VibratePattern` type issue the test runner's esbuild does not type-check)

## ⚠️ Manual device pass NOT run — needs human verification

The plan's **Task 8 manual Galaxy-S10 (installed PWA) pass is the real acceptance gate** and **could not be run in this environment** (no physical Android device). Please verify on a Galaxy S10 / Android Chrome **installed** PWA:

- Preferences shows a **Haptics** section, master **off** by default; flipping it on reveals **Taps / Completions / Back** sub-switches.
- Feel a subtle **tap** on buttons / bottom-nav / sidebar rows / list & recipe cards; a brief **double** on completing a list item or chore; a **pulse** on a hardware back that dismisses an overlay or steps up to Home (**no** pulse on the "press back again to exit" hint).
- Turning off an individual category silences just that category; master off silences everything.
- **iOS Safari + desktop:** confirm **no** Haptics section appears and nothing vibrates.

## Commits

Regular merge requested (not squash) so the individual `feat:` commits remain visible for release-please: store → helper + `canVibrate` → `Switch` primitive → capability-gated preferences section → tap / success / back fire-sites, plus a lint-suppression cleanup (`chore`) and the `VibratePattern` type fix (`fix`).


---

## Review follow-up (coarse-pointer gate + throttle-coupling guard)

Three commits address review feedback on this branch:

- **`fix(haptics): gate canVibrate on a coarse pointer`** — `canVibrate()` previously tested only `typeof navigator.vibrate === "function"`, which is **true on desktop Chrome/Edge/Firefox** (they define a silent no-op `vibrate`). The Haptics section therefore rendered on the most common desktop browsers, contradicting the capability-gated contract and the "desktop shows no Haptics section" acceptance step. It now also requires `window.matchMedia("(pointer: coarse)").matches`, reusing the exact pattern in `use-android-back-button.ts`. iOS Safari and **all** desktop browsers now hide the section; Android (coarse pointer) is unchanged. JSDoc + the in-file comment are reconciled to match.
- **`test(haptics): guard the no-double-pulse throttle coupling`** — documents on both raw complete `<button>`s why they must not become `<Button>`/`usePressable` (a pointerdown `tap()` would let the shared 40ms throttle swallow the `success()` pulse), plus a unit test (`tap→success` within window suppresses success) and a component regression test (real, capable + opted-in completion vibrates `[12,40,12]`; turns red if a preceding `tap()` is ever introduced).
- **`test(haptics): reset the fire throttle clock in resetAllStores`** — defense-in-depth so a real-`fire()` test can't leak `lastFireAt` into the next test.

**Manual-test note:** the "iOS Safari + desktop: confirm no Haptics section appears" step is now accurate for desktop Chrome/Firefox too (previously it would have failed there). On Android, the coarse-pointer requirement matches the installed-PWA target — no change to the device pass.

**Gate:** `npm run lint` exit 0 (lone pre-existing `meals-view.tsx` warning), `npm test -- --run` **110 files / 1053 passing** (1050 baseline + 3 new), `npm run build` clean (`tsc -b` + Vite + PWA).

> Cross-repo doc note: spec **D3** (`docs/superpowers/specs/2026-06-18-optional-haptics-design.md`, root `joe-bor/family-hub`) still states the helper "does not check pointer-coarseness" and that "on desktop `navigator.vibrate` is absent". That premise was the root of this bug and should be reconciled in the root docs repo (out of scope for this FE PR).
