### PR TITLE
test(e2e): fix mobile-sheet off-viewport and preferences-reload flakes

### DIFF
--- a/e2e/helpers/test-helpers.ts
+++ b/e2e/helpers/test-helpers.ts
@@ -144,6 +144,81 @@ export async function waitForOfflineCachePersisted(
 }
 
 /**
+ * Read the dehydrated data for a single query from the persisted offline read
+ * cache (IndexedDB), or undefined if the cache, store, key, or query is absent.
+ *
+ * Lets a test gate a reload on a specific value becoming durable. On reload the
+ * query cache rehydrates from this IndexedDB snapshot *before* useFamily's
+ * localStorage `initialData` seed can apply, and useFamily's 5-minute staleTime
+ * then suppresses the corrective background refetch — so reloading before a
+ * just-written value is persisted here resurfaces the stale pre-change snapshot.
+ */
+export async function readPersistedQueryData<T = unknown>(
+  page: Page,
+  queryKey: readonly unknown[],
+): Promise<T | undefined> {
+  return page.evaluate(
+    ({ dbName, storeName, key, targetKey }) =>
+      new Promise<T | undefined>((resolve) => {
+        if (!indexedDB.databases) {
+          resolve(undefined);
+          return;
+        }
+        indexedDB
+          .databases()
+          .then((dbs) => {
+            if (!dbs.some((d) => d.name === dbName)) {
+              resolve(undefined);
+              return;
+            }
+            const req = indexedDB.open(dbName);
+            req.onerror = () => resolve(undefined);
+            req.onsuccess = () => {
+              const db = req.result;
+              if (!db.objectStoreNames.contains(storeName)) {
+                db.close();
+                resolve(undefined);
+                return;
+              }
+              const getReq = db
+                .transaction(storeName, "readonly")
+                .objectStore(storeName)
+                .get(key);
+              getReq.onsuccess = () => {
+                const client = getReq.result as
+                  | {
+                      clientState?: {
+                        queries?: Array<{
+                          queryKey?: unknown;
+                          state?: { data?: unknown };
+                        }>;
+                      };
+                    }
+                  | undefined;
+                const match = client?.clientState?.queries?.find(
+                  (q) => JSON.stringify(q.queryKey) === targetKey,
+                );
+                resolve(match?.state?.data as T | undefined);
+                db.close();
+              };
+              getReq.onerror = () => {
+                resolve(undefined);
+                db.close();
+              };
+            };
+          })
+          .catch(() => resolve(undefined));
+      }),
+    {
+      dbName: OFFLINE_CACHE_DB_NAME,
+      storeName: OFFLINE_CACHE_STORE_NAME,
+      key: OFFLINE_CACHE_KEY,
+      targetKey: JSON.stringify(queryKey),
+    },
+  );
+}
+
+/**
  * Create default test members for seeding
  */
 export function createTestMembers(): FamilyMember[] {

--- a/e2e/mobile-bottom-nav.spec.ts
+++ b/e2e/mobile-bottom-nav.spec.ts
@@ -6,6 +6,7 @@ import {
   switchCalendarView,
   waitForCalendarReady,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 test.describe("Mobile Bottom Navigation", () => {
@@ -63,7 +64,7 @@ test.describe("Mobile Bottom Navigation", () => {
 
     await nav.getByRole("button", { name: "More" }).click();
     const moreSheet = page.getByRole("dialog", { name: "More" });
-    await expect(moreSheet).toBeVisible();
+    await waitForSheetSettled(moreSheet);
     await moreSheet.getByRole("button", { name: "Meals" }).click();
     await expect(moreSheet).toBeHidden();
     await expect(

--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -4,6 +4,7 @@ import {
   clearStorage,
   safeClick,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 test.describe("Mobile Meals", () => {
@@ -32,7 +33,7 @@ test.describe("Mobile Meals", () => {
     const nav = page.getByRole("navigation", { name: /primary/i });
     await safeClick(nav.getByRole("button", { name: "More" }));
     const mealsMoreSheet = page.getByRole("dialog", { name: "More" });
-    await expect(mealsMoreSheet).toBeVisible();
+    await waitForSheetSettled(mealsMoreSheet);
     await safeClick(mealsMoreSheet.getByRole("button", { name: "Meals" }));
     await expect(mealsMoreSheet).toBeHidden();
 
@@ -44,7 +45,7 @@ test.describe("Mobile Meals", () => {
     );
 
     const quickMealSheet = page.getByRole("dialog", { name: "Plan Dinner" });
-    await expect(quickMealSheet).toBeVisible();
+    await waitForSheetSettled(quickMealSheet);
     await quickMealSheet.getByLabel("Meal name").fill("Leftovers");
     await quickMealSheet
       .getByRole("button", { name: "Create quick meal" })
@@ -57,7 +58,7 @@ test.describe("Mobile Meals", () => {
 
     await safeClick(nav.getByRole("button", { name: "More" }));
     const recipesMoreSheet = page.getByRole("dialog", { name: "More" });
-    await expect(recipesMoreSheet).toBeVisible();
+    await waitForSheetSettled(recipesMoreSheet);
     await safeClick(recipesMoreSheet.getByRole("button", { name: "Recipes" }));
     await expect(recipesMoreSheet).toBeHidden();
     await expect(
@@ -66,7 +67,7 @@ test.describe("Mobile Meals", () => {
 
     await page.getByRole("button", { name: "Add recipe" }).click();
     const addRecipeSheet = page.getByRole("dialog", { name: "Add Recipe" });
-    await expect(addRecipeSheet).toBeVisible();
+    await waitForSheetSettled(addRecipeSheet);
     await addRecipeSheet
       .getByRole("button", { name: "Create manually" })
       .click();
@@ -74,7 +75,7 @@ test.describe("Mobile Meals", () => {
     const createRecipeSheet = page.getByRole("dialog", {
       name: "Create Recipe",
     });
-    await expect(createRecipeSheet).toBeVisible();
+    await waitForSheetSettled(createRecipeSheet);
     await createRecipeSheet.getByLabel("Title").fill("Sunday Pancakes");
     await createRecipeSheet
       .getByRole("textbox", { name: "Ingredient 1" })
@@ -106,7 +107,7 @@ test.describe("Mobile Meals", () => {
       page.getByRole("button", { name: "Add recipe to lunch" }).first(),
     );
     const recipeMealSheet = page.getByRole("dialog", { name: "Plan Lunch" });
-    await expect(recipeMealSheet).toBeVisible();
+    await waitForSheetSettled(recipeMealSheet);
     await recipeMealSheet
       .getByRole("button", { name: "Add recipe to slot" })
       .click();

--- a/e2e/mobile-recipes.spec.ts
+++ b/e2e/mobile-recipes.spec.ts
@@ -4,6 +4,7 @@ import {
   clearStorage,
   safeClick,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 test.describe("Mobile Recipes", () => {
@@ -35,7 +36,7 @@ test.describe("Mobile Recipes", () => {
     const nav = page.getByRole("navigation", { name: /primary/i });
     await safeClick(nav.getByRole("button", { name: "More" }));
     const moreSheet = page.getByRole("dialog", { name: "More" });
-    await expect(moreSheet).toBeVisible();
+    await waitForSheetSettled(moreSheet);
     await safeClick(moreSheet.getByRole("button", { name: "Recipes" }));
     await expect(moreSheet).toBeHidden();
 
@@ -48,11 +49,11 @@ test.describe("Mobile Recipes", () => {
 
     await page.getByRole("button", { name: "Add recipe" }).click();
     const addDialog = page.getByRole("dialog", { name: "Add Recipe" });
-    await expect(addDialog).toBeVisible();
+    await waitForSheetSettled(addDialog);
     await addDialog.getByRole("button", { name: "Create manually" }).click();
 
     const createDialog = page.getByRole("dialog", { name: "Create Recipe" });
-    await expect(createDialog).toBeVisible();
+    await waitForSheetSettled(createDialog);
     await createDialog.getByLabel("Title").fill("Sunday Pancakes");
     await createDialog
       .getByRole("textbox", { name: "Ingredient 1" })
@@ -102,13 +103,13 @@ test.describe("Mobile Recipes", () => {
     await page.getByLabel("Search recipes").clear();
     await page.getByRole("button", { name: "Add recipe" }).click();
     const secondAddDialog = page.getByRole("dialog", { name: "Add Recipe" });
-    await expect(secondAddDialog).toBeVisible();
+    await waitForSheetSettled(secondAddDialog);
     await secondAddDialog
       .getByRole("button", { name: "Import from URL" })
       .click();
 
     const importDialog = page.getByRole("dialog", { name: "Import Recipe" });
-    await expect(importDialog).toBeVisible();
+    await waitForSheetSettled(importDialog);
     await importDialog.getByLabel("Recipe URL").fill("not-a-url");
     await importDialog.getByRole("button", { name: "Import recipe" }).click();
     await expect(importDialog.getByText("Enter a valid URL")).toBeVisible();

--- a/e2e/mobile-settings-sidebar.spec.ts
+++ b/e2e/mobile-settings-sidebar.spec.ts
@@ -4,6 +4,7 @@ import {
   clearStorage,
   safeClick,
   waitForHydration,
+  waitForSheetSettled,
 } from "./helpers/test-helpers";
 
 test.describe("Mobile menu + More overflow", () => {
@@ -33,7 +34,7 @@ test.describe("Mobile menu + More overflow", () => {
     await safeClick(nav.getByRole("button", { name: /^more$/i }));
 
     const moreSheet = page.getByRole("dialog", { name: /more/i });
-    await expect(moreSheet).toBeVisible();
+    await waitForSheetSettled(moreSheet);
 
     await safeClick(moreSheet.getByRole("button", { name: /^recipes$/i }));
 

--- a/e2e/preferences.spec.ts
+++ b/e2e/preferences.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
+  readPersistedQueryData,
   safeClick,
   waitForHydration,
   waitForSheetSettled,
@@ -69,7 +70,24 @@ test.describe("Preferences sheet", () => {
     const family = await familyResponse.json();
     expect(family.data.timezone).toBe("America/New_York");
 
-    // Survives a full reload.
+    // Survives a full reload. The reload rehydrates the family query from the
+    // offline read cache (IndexedDB), which takes precedence over useFamily's
+    // localStorage initialData seed; its 5-minute staleTime then suppresses a
+    // corrective refetch. Wait for the new zone to be durable there first,
+    // otherwise the reload can resurface the stale pre-change zone (flaky).
+    await expect
+      .poll(
+        async () =>
+          (
+            await readPersistedQueryData<{ data?: { timezone?: string } }>(
+              page,
+              ["family", "data"], // familyKeys.family()
+            )
+          )?.data?.timezone,
+        { timeout: 10000 },
+      )
+      .toBe("America/New_York");
+
     await page.reload();
     await waitForHydration(page);
     const reopened = await openPreferences(page);


### PR DESCRIPTION
## Problem

Main CI went red on `chore(main): release family-hub 0.3.18` — a release-please commit with **zero app/test code changes**. The same E2E suite was green on the prior commit, confirming flaky tests. Failing run: https://github.com/joe-bor/FamilyHub/actions/runs/27852051722

Two distinct flakes surfaced in that run:

1. **Build-failing** — `[Mobile Chrome] mobile-meals.spec.ts:61` failed all 3 attempts: `Error: locator.click: Element is outside of the viewport`.
2. **Flaky-but-recovered** — `[firefox] preferences.spec.ts:76` (timezone: got `America/Los_Angeles`, passed on retry).

## Root causes

**① vaul off-viewport sheet (caused the red build).** The mobile specs interact with freshly-opened vaul `MobileSheet`s (the "More" overflow sheet, meal/recipe sheets) after only `expect(sheet).toBeVisible()`. `toBeVisible()` passes while the sheet is still translated fully off-viewport — vaul positions snap-point drawers from JS after mount, and reduced-motion makes the transition instant but not the positioning. On a loaded runner, `safeClick`'s `force:true` then fires into the off-screen sheet → "Element is outside of the viewport". The repo already had `waitForSheetSettled` for exactly this, but it was only wired into `preferences` and `mobile-settings-sheets`; `mobile-meals`, `mobile-recipes`, `mobile-bottom-nav`, and `mobile-settings-sidebar` shared the same latent gap, so fixing only the failing spec would relocate the flake.

**② preferences reload race (different cause).** After `page.reload()` the family query rehydrates from the IndexedDB offline read cache, which takes precedence over `useFamily`'s localStorage `initialData` seed; its 5-minute `staleTime` then suppresses the corrective refetch. When the offline persist lagged the timezone PUT, the reload resurfaced the stale pre-change zone.

## Fixes

- **`1a4b39f`** — apply the existing `waitForSheetSettled` gate before interacting with each opened sheet in the four mobile specs.
- **`cafe4ed`** — add `readPersistedQueryData()` and poll the offline cache for the new zone before reloading, so the reload rehydrates the just-written value.

## Validation (local, real BE image `1.6.0`)

- **Deterministic repro** — CSS-pinned the drawer off-viewport: `safeClick` alone throws "outside of the viewport"; `waitForSheetSettled` gates until on-screen, then the click succeeds. ✓
- 4 fixed mobile specs (Mobile Chrome): **8 passed** ✓
- preferences (firefox + Mobile Chrome): **4 passed** ✓
- Stress ×3 on the two previously-failing tests: **9 passed** ✓

Test-only changes — no production code, no version bump.