### PR TITLE
feat(mobile-ux): home organizer summary — state line + "since you last opened" feed

### DIFF
--- a/e2e/mobile-home-dashboard.spec.ts
+++ b/e2e/mobile-home-dashboard.spec.ts
@@ -165,6 +165,11 @@ test.describe("Mobile Home Dashboard", () => {
 
     await nav.getByRole("button", { name: "Home" }).click();
     await expect(page).toHaveURL(/\/$/);
-    await expect(page.getByText("Bob homework")).toBeVisible();
+    // Target the agenda entry specifically: the event title now also appears in
+    // the "Since you last opened" activity feed (a just-added event surfaces as a
+    // calendar change), so a bare getByText("Bob homework") is no longer unique.
+    await expect(
+      page.getByRole("button", { name: /today: bob homework details/i }),
+    ).toBeVisible();
   });
 });

--- a/src/api/client/http-client.test.ts
+++ b/src/api/client/http-client.test.ts
@@ -9,6 +9,7 @@ import {
   vi,
 } from "vitest";
 import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
+import * as activityStore from "@/lib/home-activity/store";
 import * as offlinePersister from "@/lib/offline/persister";
 import { queryClient } from "@/providers/query-client";
 import { server } from "@/test/mocks/server";
@@ -176,5 +177,28 @@ describe("handleUnauthorized (401 session cleanup)", () => {
 
     expect(clearSpy).toHaveBeenCalledTimes(1);
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("clears persisted home activity (store + markers) before the 401 reload", async () => {
+    const offlineSpy = vi
+      .spyOn(offlinePersister, "clearOfflineReadCache")
+      .mockResolvedValue(undefined);
+    const activitySpy = vi
+      .spyOn(activityStore, "clearHomeActivity")
+      .mockResolvedValue(undefined);
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+    localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, "token-123"); // token present → real session expiry → reloads
+    await handleUnauthorized();
+    expect(activitySpy).toHaveBeenCalled();
+    expect(offlineSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      activitySpy.mock.invocationCallOrder[0],
+    );
+    expect(activitySpy.mock.invocationCallOrder[0]).toBeLessThan(
+      reload.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/src/api/client/http-client.ts
+++ b/src/api/client/http-client.ts
@@ -1,4 +1,5 @@
 import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
+import { clearHomeActivity } from "@/lib/home-activity/store";
 import { clearOfflineReadCache } from "@/lib/offline/persister";
 import { queryClient } from "@/providers/query-client";
 import {
@@ -69,6 +70,9 @@ export async function handleUnauthorized(): Promise<void> {
 
   // Clear the persisted offline read cache (never rejects).
   await clearOfflineReadCache();
+
+  // Clear the per-device home-activity store + markers (never rejects).
+  await clearHomeActivity();
 
   // Only reload if a token existed (session expiry).
   // Prevents an infinite reload loop on first-visit 401s.

--- a/src/api/hooks/use-auth.test.tsx
+++ b/src/api/hooks/use-auth.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as activityStore from "@/lib/home-activity/store";
 import * as offlinePersister from "@/lib/offline/persister";
 import { useLogout } from "./use-auth";
 
@@ -61,6 +62,31 @@ describe("useLogout", () => {
     // Must be awaited BEFORE the reload to prevent cross-account leakage on
     // shared devices.
     expect(clearSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      reload.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("clears persisted home activity (store + markers) before the logout reload", async () => {
+    const offlineSpy = vi
+      .spyOn(offlinePersister, "clearOfflineReadCache")
+      .mockResolvedValue(undefined);
+    const activitySpy = vi
+      .spyOn(activityStore, "clearHomeActivity")
+      .mockResolvedValue(undefined);
+    const reload = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    });
+    const { result } = renderHook(() => useLogout(), {
+      wrapper: createWrapper(),
+    });
+    await result.current();
+    expect(activitySpy).toHaveBeenCalled();
+    expect(offlineSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      activitySpy.mock.invocationCallOrder[0],
+    );
+    expect(activitySpy.mock.invocationCallOrder[0]).toBeLessThan(
       reload.mock.invocationCallOrder[0],
     );
   });

--- a/src/api/hooks/use-auth.ts
+++ b/src/api/hooks/use-auth.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { ApiException } from "@/api/client";
 import { authService } from "@/api/services";
 import { AUTH_TOKEN_STORAGE_KEY, FAMILY_STORAGE_KEY } from "@/lib/constants";
+import { clearHomeActivity } from "@/lib/home-activity/store";
 import { clearOfflineReadCache } from "@/lib/offline/persister";
 import type {
   FamilyApiResponse,
@@ -216,6 +217,9 @@ export function useLogout() {
 
     // Clear the persisted offline read cache (never rejects).
     await clearOfflineReadCache();
+
+    // Clear the per-device home-activity store + markers (never rejects).
+    await clearHomeActivity();
 
     // Force page reload to reset all state
     window.location.reload();

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -39,10 +39,15 @@ import { toast } from "@/components/ui/toaster";
 import { useIsMobile } from "@/hooks";
 import { isOfflineWriteError } from "@/lib/offline/read-only-guard";
 import { buildRRule } from "@/lib/recurrence-utils";
-import { format24hTo12h, formatLocalDate } from "@/lib/time-utils";
+import {
+  format24hTo12h,
+  formatLocalDate,
+  parseLocalDate,
+} from "@/lib/time-utils";
 import type { CalendarEvent, CreateEventRequest } from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
+  useAppStore,
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
@@ -125,6 +130,14 @@ export function CalendarModule() {
     openAddEventModal,
     closeAddEventModal,
   } = useCalendarActions();
+
+  const consumeCalendarFocusDate = useAppStore(
+    (s) => s.consumeCalendarFocusDate,
+  );
+  useEffect(() => {
+    const date = consumeCalendarFocusDate();
+    if (date) setDate(parseLocalDate(date));
+  }, [consumeCalendarFocusDate, setDate]);
 
   // Family data for mobile views
   const members = useFamilyMembers();

--- a/src/components/home/components/activity-feed.test.tsx
+++ b/src/components/home/components/activity-feed.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { Feed } from "@/lib/home-activity/types";
+import { ActivityFeed } from "./activity-feed";
+
+const feed: Feed = {
+  groups: [
+    {
+      id: "calendar",
+      module: "calendar",
+      summary: "Calendar · 2 added",
+      newest: 30,
+      rowsOverflow: 0,
+      rows: [
+        {
+          storeKey: "calendar:a",
+          kind: "added",
+          label: "Dentist",
+          detail: "Tue 9:00 AM",
+          module: "calendar",
+          memberId: "m1",
+        },
+        {
+          storeKey: "calendar:b",
+          kind: "edited",
+          label: "Soccer",
+          detail: "5:00 PM",
+          module: "calendar",
+        },
+      ],
+    },
+    {
+      id: "lists:l1",
+      module: "lists",
+      summary: "Groceries · +3 items",
+      newest: 10,
+      rowsOverflow: 0,
+      rows: [
+        {
+          storeKey: "lists:l1",
+          kind: "edited",
+          label: "Groceries",
+          detail: "+3 items",
+          module: "lists",
+          entityId: "l1",
+        },
+      ],
+    },
+  ],
+  dividerAfter: 0,
+  overflow: 0,
+};
+
+describe("ActivityFeed", () => {
+  it("renders groups + divider; expander toggles aria-expanded and sub-row tabbability", () => {
+    render(<ActivityFeed feed={feed} onSelectRow={vi.fn()} />);
+    expect(screen.getByText("Calendar · 2 added")).toBeInTheDocument();
+    expect(screen.getByText(/earlier/i)).toBeInTheDocument();
+    const expander = screen.getByRole("button", { name: /Calendar/ });
+    expect(expander).toHaveAttribute("aria-expanded", "false");
+    // Sub-rows stay in the DOM (animated collapse) but are not tabbable while collapsed.
+    expect(screen.getByText(/Dentist/).closest("button")).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    fireEvent.click(expander);
+    expect(expander).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/Dentist/).closest("button")).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+  });
+
+  it("tints a leading member dot when a color resolver is provided", () => {
+    render(
+      <ActivityFeed
+        feed={feed}
+        onSelectRow={vi.fn()}
+        memberColorOf={(id) => (id === "m1" ? "#ff0000" : undefined)}
+      />,
+    );
+    expect(document.querySelector('span[style*="background"]')).toBeTruthy();
+  });
+
+  it("collapses expansion when the meaningful-open epoch changes", () => {
+    const { rerender } = render(
+      <ActivityFeed feed={feed} onSelectRow={vi.fn()} meaningfulOpenId={1} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Calendar/ }));
+    expect(screen.getByRole("button", { name: /Calendar/ })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    rerender(
+      <ActivityFeed feed={feed} onSelectRow={vi.fn()} meaningfulOpenId={2} />,
+    );
+    expect(screen.getByRole("button", { name: /Calendar/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("renders the empty state when there are no groups", () => {
+    render(
+      <ActivityFeed
+        feed={{ groups: [], dividerAfter: -1, overflow: 0 }}
+        onSelectRow={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/all caught up/i)).toBeInTheDocument();
+  });
+
+  it("fires onSelectRow with the row when a single-row group is clicked", () => {
+    const onSelect = vi.fn();
+    render(<ActivityFeed feed={feed} onSelectRow={onSelect} />);
+    fireEvent.click(screen.getByRole("button", { name: /Groceries/ }));
+    expect(onSelect).toHaveBeenCalledWith(feed.groups[1].rows[0]);
+  });
+});

--- a/src/components/home/components/activity-feed.tsx
+++ b/src/components/home/components/activity-feed.tsx
@@ -1,0 +1,217 @@
+import { useState } from "react";
+import { usePressable } from "@/hooks/use-pressable";
+import type { Feed, FeedGroup, FeedRow } from "@/lib/home-activity/types";
+import { cn } from "@/lib/utils";
+
+type MemberColorOf = (memberId: string | undefined) => string | undefined;
+
+interface ActivityFeedProps {
+  feed: Feed;
+  onSelectRow: (row: FeedRow) => void;
+  /** Resolve a member's dot color from its id. Wired from `useFamilyMemberMap` in
+   * the dashboard so this component stays presentational/provider-free in tests. */
+  memberColorOf?: MemberColorOf;
+  /** Bumped on each meaningful open; remounts groups so expansion is ephemeral (§5). */
+  meaningfulOpenId?: number;
+}
+
+// Shared field styling. min-h-11 = 44px touch target (spec §9). Easing/durations
+// from the shipped motion system; motion-reduce collapses to instant (no plugin).
+const EASE = "ease-[cubic-bezier(0.32,0.72,0,1)]";
+
+export function ActivityFeed({
+  feed,
+  onSelectRow,
+  memberColorOf,
+  meaningfulOpenId = 0,
+}: ActivityFeedProps) {
+  if (feed.groups.length === 0) {
+    return (
+      <section className="px-4 pt-6" aria-label="Recent changes">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Since you last opened
+        </h2>
+        <p className="pt-2 text-sm text-muted-foreground">
+          You're all caught up.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="px-4 pt-6" aria-label="Recent changes">
+      <h2 className="text-sm font-medium text-muted-foreground">
+        Since you last opened
+      </h2>
+      <ul className="pt-2">
+        {feed.groups.map((group, index) => (
+          <li key={group.id}>
+            {/* key includes the epoch so a meaningful open remounts (collapses) the group */}
+            <ActivityGroup
+              key={`${group.id}:${meaningfulOpenId}`}
+              group={group}
+              onSelectRow={onSelectRow}
+              memberColorOf={memberColorOf}
+            />
+            {index === feed.dividerAfter && (
+              <div className="my-2 flex items-center gap-2 text-xs text-muted-foreground/70">
+                <span className="h-px flex-1 bg-border" /> earlier{" "}
+                <span className="h-px flex-1 bg-border" />
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+      {feed.overflow > 0 && (
+        <p className="pt-1 text-xs text-muted-foreground/70">
+          and {feed.overflow} more
+        </p>
+      )}
+    </section>
+  );
+}
+
+function MemberDot({ color }: { color?: string }) {
+  if (!color) return null;
+  return (
+    <span
+      aria-hidden
+      className="mr-2 inline-block size-2 shrink-0 rounded-full"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
+function ActivityGroup({
+  group,
+  onSelectRow,
+  memberColorOf,
+}: {
+  group: FeedGroup;
+  onSelectRow: (r: FeedRow) => void;
+  memberColorOf?: MemberColorOf;
+}) {
+  const [open, setOpen] = useState(false);
+  const press = usePressable();
+  const expandable = group.rows.length > 1;
+
+  if (!expandable) {
+    const row = group.rows[0];
+    return (
+      <button
+        type="button"
+        className={cn(
+          press.className,
+          "flex min-h-11 w-full items-center justify-between rounded-2xl px-1 py-2 text-left",
+        )}
+        onPointerDown={press.onPointerDown}
+        onClick={() => onSelectRow(row)}
+      >
+        <span className="flex items-center text-sm">
+          <MemberDot color={memberColorOf?.(row.memberId)} />
+          {group.summary}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        aria-expanded={open}
+        className={cn(
+          press.className,
+          "flex min-h-11 w-full items-center justify-between rounded-2xl px-1 py-2 text-left",
+        )}
+        onPointerDown={press.onPointerDown}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="text-sm">{group.summary}</span>
+        <span
+          aria-hidden
+          className={cn(
+            "text-muted-foreground transition-transform duration-[250ms] motion-reduce:transition-none",
+            EASE,
+          )}
+          style={{ transform: open ? "rotate(90deg)" : "none" }}
+        >
+          ▸
+        </span>
+      </button>
+      {/* grid-rows 0fr→1fr animates height under motion-safe; under reduced motion the
+          height snaps and only the opacity fades (spec §6 "opacity-only"). When closed
+          the sub-list is `inert` + aria-hidden, so it is fully non-interactive and out
+          of the a11y tree — not merely untabbable. */}
+      <div
+        className="grid motion-safe:transition-[grid-template-rows] motion-safe:duration-[250ms] motion-safe:ease-[cubic-bezier(0.32,0.72,0,1)]"
+        style={{ gridTemplateRows: open ? "1fr" : "0fr" }}
+      >
+        <ul
+          inert={!open}
+          aria-hidden={!open}
+          className={cn(
+            "overflow-hidden pl-3 transition-opacity duration-[250ms]",
+            EASE,
+            open ? "opacity-100" : "opacity-0",
+          )}
+        >
+          {group.rows.map((row) => (
+            <SubRow
+              key={row.storeKey}
+              row={row}
+              onSelectRow={onSelectRow}
+              memberColorOf={memberColorOf}
+              tabbable={open}
+            />
+          ))}
+          {group.rowsOverflow > 0 && (
+            <li className="px-1 py-2 text-xs text-muted-foreground/70">
+              and {group.rowsOverflow} more
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function SubRow({
+  row,
+  onSelectRow,
+  memberColorOf,
+  tabbable,
+}: {
+  row: FeedRow;
+  onSelectRow: (r: FeedRow) => void;
+  memberColorOf?: MemberColorOf;
+  tabbable: boolean;
+}) {
+  const press = usePressable(); // sub-rows are pressable too (spec §6)
+  return (
+    <li>
+      <button
+        type="button"
+        tabIndex={tabbable ? 0 : -1}
+        className={cn(
+          press.className,
+          "flex min-h-11 w-full items-center justify-between rounded-xl px-1 py-2 text-left text-sm",
+        )}
+        onPointerDown={press.onPointerDown}
+        onClick={() => onSelectRow(row)}
+      >
+        <span className="flex items-center">
+          <MemberDot color={memberColorOf?.(row.memberId)} />
+          {markerFor(row.kind)} {row.label}
+        </span>
+        {row.detail && (
+          <span className="text-muted-foreground">{row.detail}</span>
+        )}
+      </button>
+    </li>
+  );
+}
+
+function markerFor(kind: FeedRow["kind"]): string {
+  return kind === "added" ? "+" : kind === "removed" ? "−" : "~";
+}

--- a/src/components/home/components/state-line.test.tsx
+++ b/src/components/home/components/state-line.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { StateLine } from "./state-line";
+
+describe("StateLine", () => {
+  it("renders both segments", () => {
+    render(<StateLine choresRemaining={3} dinnerTitle="Tacos" />);
+    expect(screen.getByText(/3 chores left today/i)).toBeInTheDocument();
+    expect(screen.getByText(/Tacos/)).toBeInTheDocument();
+  });
+  it("renders nothing when empty", () => {
+    const { container } = render(
+      <StateLine choresRemaining={0} dinnerTitle={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses the singular 'chore' for exactly one", () => {
+    render(<StateLine choresRemaining={1} dinnerTitle={null} />);
+    expect(screen.getByText("1 chore left today")).toBeInTheDocument();
+  });
+
+  it("renders only the chores segment when there is no dinner", () => {
+    render(<StateLine choresRemaining={2} dinnerTitle={null} />);
+    expect(screen.getByText("2 chores left today")).toBeInTheDocument();
+  });
+
+  it("renders only the dinner segment when no chores remain", () => {
+    render(<StateLine choresRemaining={0} dinnerTitle="Pasta" />);
+    expect(screen.getByText("Pasta tonight")).toBeInTheDocument();
+  });
+});

--- a/src/components/home/components/state-line.tsx
+++ b/src/components/home/components/state-line.tsx
@@ -1,0 +1,21 @@
+interface StateLineProps {
+  choresRemaining: number;
+  dinnerTitle: string | null;
+}
+
+export function StateLine({ choresRemaining, dinnerTitle }: StateLineProps) {
+  const segments: string[] = [];
+  if (choresRemaining > 0) {
+    segments.push(
+      `${choresRemaining} chore${choresRemaining === 1 ? "" : "s"} left today`,
+    );
+  }
+  if (dinnerTitle) segments.push(`${dinnerTitle} tonight`);
+  if (segments.length === 0) return null;
+
+  return (
+    <p className="px-4 pt-2 text-sm text-muted-foreground">
+      {segments.join(" · ")}
+    </p>
+  );
+}

--- a/src/components/home/home-dashboard.test.tsx
+++ b/src/components/home/home-dashboard.test.tsx
@@ -261,4 +261,20 @@ describe("HomeDashboard", () => {
       screen.getByRole("button", { name: /april 25th, 2026/i }),
     ).toBeInTheDocument();
   });
+
+  it("renders the activity feed region on mobile", async () => {
+    setViewportWidth(768);
+    render(<HomeDashboard nowOverride={new Date(2026, 5, 21, 12)} />);
+    expect(
+      await screen.findByText(/Since you last opened/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT mount the feed/state-line on desktop", () => {
+    setViewportWidth(1024);
+    render(<HomeDashboard nowOverride={new Date(2026, 5, 21, 12)} />);
+    expect(
+      screen.queryByText(/Since you last opened/i),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -368,6 +368,11 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
             onSelect={handleEventClick}
           />
           {isMobile && (
+            // `inWindowEvents` is the directly-openable 3-day dashboard set
+            // (`useDashboardEvents`), NOT the feed's 28-day detection window. The
+            // dashboard never fetches full CalendarEvent objects past 3 days, so a
+            // feed row 4–28 days out can't open an event sheet — `resolveFeedSelection`
+            // intentionally falls through to focusing that day instead.
             <ActivityFeedSection
               now={now}
               inWindowEvents={[...today, ...comingUp]}

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -3,6 +3,7 @@ import {
   useCreateEvent,
   useDeleteEvent,
   useDeleteInstance,
+  useFamilyMemberMap,
   useFamilyMembers,
   useFamilyName,
   useUpdateEvent,
@@ -15,24 +16,36 @@ import {
   EventDetailModal,
   EventFormModal,
 } from "@/components/calendar";
+import { useIsMobile } from "@/hooks";
+import { resolveFeedSelection } from "@/lib/home-activity/navigation";
+import type { FeedRow } from "@/lib/home-activity/types";
 import { buildRRule } from "@/lib/recurrence-utils";
 import { format24hTo12h, formatLocalDate, getEventKey } from "@/lib/time-utils";
-import type { CreateEventRequest } from "@/lib/types";
+import {
+  type CalendarEvent,
+  type CreateEventRequest,
+  colorMap,
+} from "@/lib/types";
 import type { EventFormData } from "@/lib/validations";
 import {
+  useAppStore,
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
   useEditModalState,
   useEventDetailState,
 } from "@/stores";
+import { ActivityFeed } from "./components/activity-feed";
 import { ComingUp } from "./components/coming-up";
 import { DashboardHeader } from "./components/dashboard-header";
 import { HeroCard } from "./components/hero-card";
 import { MemberChipRow } from "./components/member-chip-row";
+import { StateLine } from "./components/state-line";
 import { TodayList } from "./components/today-list";
+import { useActivityFeed } from "./hooks/use-activity-feed";
 import { useDashboardEvents } from "./hooks/use-dashboard-events";
 import { useDashboardNow } from "./hooks/use-hero-state";
+import { useStateLine } from "./hooks/use-state-line";
 import { deriveHeroState } from "./lib/hero-state";
 
 function getParentId(event: {
@@ -66,7 +79,50 @@ function LoadingDashboard() {
   );
 }
 
+function StateLineSection({ now }: { now: Date }) {
+  const { choresRemaining, dinnerTitle } = useStateLine({ now });
+  return (
+    <StateLine choresRemaining={choresRemaining} dinnerTitle={dinnerTitle} />
+  );
+}
+
+function ActivityFeedSection({
+  now,
+  inWindowEvents,
+  onOpenEvent,
+}: {
+  now: Date;
+  inWindowEvents: CalendarEvent[];
+  onOpenEvent: (e: CalendarEvent) => void;
+}) {
+  const { feed, meaningfulOpenId } = useActivityFeed({
+    nowProvider: () => now.getTime(),
+  });
+  const memberMap = useFamilyMemberMap();
+  const handleSelect = (row: FeedRow) => {
+    const sel = resolveFeedSelection(row, inWindowEvents);
+    const store = useAppStore.getState();
+    if (sel.type === "open-event") onOpenEvent(sel.event);
+    else if (sel.type === "open-list") store.openListDetail(sel.listId);
+    else if (sel.type === "focus-calendar") store.focusCalendarDate(sel.date);
+    else store.setActiveModule(sel.module);
+  };
+  const memberColorOf = (id: string | undefined) => {
+    const member = id ? memberMap.get(id) : undefined;
+    return member ? colorMap[member.color]?.hex : undefined;
+  };
+  return (
+    <ActivityFeed
+      feed={feed}
+      onSelectRow={handleSelect}
+      memberColorOf={memberColorOf}
+      meaningfulOpenId={meaningfulOpenId}
+    />
+  );
+}
+
 export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
+  const isMobile = useIsMobile();
   const familyName = useFamilyName();
   const members = useFamilyMembers();
   const liveNow = useDashboardNow();
@@ -297,6 +353,7 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
             now={now}
             onTap={heroEvent ? () => handleEventClick(heroEvent) : undefined}
           />
+          {isMobile && <StateLineSection now={now} />}
           <TodayList
             currentDate={now}
             events={today}
@@ -310,6 +367,13 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
             members={members}
             onSelect={handleEventClick}
           />
+          {isMobile && (
+            <ActivityFeedSection
+              now={now}
+              inWindowEvents={[...today, ...comingUp]}
+              onOpenEvent={handleEventClick}
+            />
+          )}
         </>
       )}
 

--- a/src/components/home/home-dashboard.tsx
+++ b/src/components/home/home-dashboard.tsx
@@ -17,7 +17,10 @@ import {
   EventFormModal,
 } from "@/components/calendar";
 import { useIsMobile } from "@/hooks";
-import { resolveFeedSelection } from "@/lib/home-activity/navigation";
+import {
+  resolveFeedSelection,
+  selectOpenableEvents,
+} from "@/lib/home-activity/navigation";
 import type { FeedRow } from "@/lib/home-activity/types";
 import { buildRRule } from "@/lib/recurrence-utils";
 import { format24hTo12h, formatLocalDate, getEventKey } from "@/lib/time-utils";
@@ -88,17 +91,22 @@ function StateLineSection({ now }: { now: Date }) {
 
 function ActivityFeedSection({
   now,
-  inWindowEvents,
   onOpenEvent,
 }: {
   now: Date;
-  inWindowEvents: CalendarEvent[];
   onOpenEvent: (e: CalendarEvent) => void;
 }) {
-  const { feed, meaningfulOpenId } = useActivityFeed({
+  const { feed, meaningfulOpenId, events } = useActivityFeed({
     nowProvider: () => now.getTime(),
   });
   const memberMap = useFamilyMemberMap();
+  // The feed is family-wide, so deep-links resolve against the unfiltered openable
+  // set — NOT the member-filtered dashboard agenda, which would downgrade other
+  // members' in-window rows to date-focus when a member is focused (M1).
+  const inWindowEvents = useMemo(
+    () => selectOpenableEvents(events, now),
+    [events, now],
+  );
   const handleSelect = (row: FeedRow) => {
     const sel = resolveFeedSelection(row, inWindowEvents);
     const store = useAppStore.getState();
@@ -368,16 +376,7 @@ export function HomeDashboard({ nowOverride }: { nowOverride?: Date } = {}) {
             onSelect={handleEventClick}
           />
           {isMobile && (
-            // `inWindowEvents` is the directly-openable 3-day dashboard set
-            // (`useDashboardEvents`), NOT the feed's 28-day detection window. The
-            // dashboard never fetches full CalendarEvent objects past 3 days, so a
-            // feed row 4–28 days out can't open an event sheet — `resolveFeedSelection`
-            // intentionally falls through to focusing that day instead.
-            <ActivityFeedSection
-              now={now}
-              inWindowEvents={[...today, ...comingUp]}
-              onOpenEvent={handleEventClick}
-            />
+            <ActivityFeedSection now={now} onOpenEvent={handleEventClick} />
           )}
         </>
       )}

--- a/src/components/home/hooks/use-activity-feed.test.tsx
+++ b/src/components/home/hooks/use-activity-feed.test.tsx
@@ -217,7 +217,7 @@ describe("useActivityFeed — orchestration", () => {
     events = [];
     lists = [];
     const io = makeMemoryIo();
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       () => useActivityFeed({ io, nowProvider: () => 1000 }),
       { wrapper },
     );
@@ -249,20 +249,60 @@ describe("useActivityFeed — orchestration", () => {
     expect(listsRefetch).toHaveBeenCalledTimes(1);
     expect(io.loadState).toHaveBeenCalledTimes(1); // detection is blocked on BOTH refetches
     releaseRefetch();
-    await waitFor(() => expect(io.loadState).toHaveBeenCalledTimes(2));
+    // The visible cycle loads + diffs the REFETCHED arrays directly (threaded in via
+    // the refetch return), so the change surfaces in this open cycle — no extra
+    // render needed. Surfacing it can also kick a harmless follow-up auto cycle, so
+    // assert "at least twice" rather than an exact loadState count.
+    await waitFor(() =>
+      expect(result.current.feed.groups[0]?.summary).toContain("Refetched"),
+    );
+    expect(io.loadState.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Both refetches resolved BEFORE the visible cycle's loadState (the 2nd call).
     expect(eventsRefetch.mock.invocationCallOrder[0]).toBeLessThan(
       io.loadState.mock.invocationCallOrder[1],
     );
     expect(listsRefetch.mock.invocationCallOrder[0]).toBeLessThan(
       io.loadState.mock.invocationCallOrder[1],
     );
+  });
 
-    // The mock query hooks expose the refetched arrays on the next observer render,
-    // matching TanStack Query's post-refetch notification.
-    rerender();
+  it("diffs the REFETCHED data in the visible cycle, not the pre-refetch closure", async () => {
+    // Regression guard for the divider off-by-one: the visibility handler awaits
+    // refetch but the hook has not re-rendered, so a `detect("visible")` that read
+    // the closure would diff STALE data — finding nothing, yet advancing lastSeen —
+    // and the change would only surface (stamped LATER) on a follow-up auto cycle,
+    // reading as "new" for an extra meaningful open. The fix threads the refetch
+    // result into the cycle. Here the visible cycle is deliberately NON-meaningful
+    // (never hidden, same day), so there is NO meaningfulOpenId bump and therefore
+    // NO follow-up re-render/auto cycle — the change can ONLY appear if the visible
+    // cycle itself diffed the refetched arrays.
+    querySettled = true;
+    events = [];
+    lists = [];
+    const io = makeMemoryIo();
+    const { result } = renderHook(
+      () => useActivityFeed({ io, nowProvider: () => 1000 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(io.loadState).toHaveBeenCalled());
+    // A change lands on the server after cold start; only refetch can see it.
+    lists = [
+      {
+        id: "l1",
+        name: "Refetched",
+        kind: "to-do",
+        totalItems: 1,
+        completedItems: 0,
+      },
+    ];
+    // jsdom visibilityState defaults to "visible" → the listener takes the visible
+    // branch. No rerender() — the refetch return value is the only fresh source.
+    document.dispatchEvent(new Event("visibilitychange"));
     await waitFor(() =>
       expect(result.current.feed.groups[0]?.summary).toContain("Refetched"),
     );
+    // Stamped at THIS open's ts (1000), so it will not re-flag on the next open.
+    expect(result.current.feed.groups[0]?.newest).toBe(1000);
   });
 
   it("serializes writes: a slow earlier save cannot overwrite a newer cycle", async () => {

--- a/src/components/home/hooks/use-activity-feed.test.tsx
+++ b/src/components/home/hooks/use-activity-feed.test.tsx
@@ -85,6 +85,25 @@ describe("useActivityFeed", () => {
     expect(result.current.feed.groups).toHaveLength(0);
     expect(io.saveState).not.toHaveBeenCalled();
   });
+
+  it("exposes the unfiltered source events for deep-link resolution", async () => {
+    querySettled = true;
+    events = [
+      {
+        id: "e1",
+        title: "Dentist",
+        date: new Date(2026, 5, 23),
+      } as CalendarEvent,
+    ];
+    lists = [];
+    const io = makeMemoryIo();
+    const { result } = renderHook(
+      () => useActivityFeed({ io, nowProvider: () => 1000 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.events).toHaveLength(1));
+    expect(result.current.events[0].id).toBe("e1");
+  });
 });
 
 describe("useActivityFeed — orchestration", () => {

--- a/src/components/home/hooks/use-activity-feed.test.tsx
+++ b/src/components/home/hooks/use-activity-feed.test.tsx
@@ -306,6 +306,41 @@ describe("useActivityFeed — orchestration", () => {
     await waitFor(() => expect(completed).toEqual([1, 2])); // mutex preserved order despite the slow save
     expect(state?.snapshot["lists:l1"]?.totalItems).toBe(5); // newest state is final, not overwritten
   });
+
+  it("records hiddenAt when the document becomes hidden", async () => {
+    querySettled = true;
+    events = [];
+    lists = [];
+    const io = makeMemoryIo();
+    renderHook(() => useActivityFeed({ io, nowProvider: () => 7777 }), {
+      wrapper,
+    });
+    // let the cold-start cycle settle so the listener is registered
+    await waitFor(() => expect(io.loadState).toHaveBeenCalled());
+
+    const original = Object.getOwnPropertyDescriptor(
+      document,
+      "visibilityState",
+    );
+    try {
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "hidden",
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+      // hide branch is synchronous: io.setHiddenAt(now()) → 7777
+      expect(io.getHiddenAt()).toBe(7777);
+    } finally {
+      if (original) {
+        Object.defineProperty(document, "visibilityState", original);
+      } else {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          get: () => "visible",
+        });
+      }
+    }
+  });
 });
 
 // minimal in-memory IO double for the hook's injected dependencies

--- a/src/components/home/hooks/use-activity-feed.test.tsx
+++ b/src/components/home/hooks/use-activity-feed.test.tsx
@@ -1,0 +1,338 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActivityState } from "@/lib/home-activity/types";
+import type { CalendarEvent, ListSummary } from "@/lib/types";
+import { useActivityFeed } from "./use-activity-feed";
+
+let events: CalendarEvent[] = [];
+let lists: ListSummary[] = [];
+let querySettled = true; // toggle to exercise the "not yet loaded" gate
+// Stable refetch spies (the mock factory re-runs per render, so inline vi.fn()s
+// would not be assertable across renders).
+const eventsRefetch = vi.fn(async () => ({ data: { data: events } }));
+const listsRefetch = vi.fn(async () => ({ data: { data: lists } }));
+
+vi.mock("@/api", () => ({
+  useCalendarEvents: () => ({
+    data: querySettled ? { data: events } : undefined,
+    isSuccess: querySettled,
+    refetch: eventsRefetch,
+  }),
+  useLists: () => ({
+    data: querySettled ? { data: lists } : undefined,
+    isSuccess: querySettled,
+    refetch: listsRefetch,
+  }),
+}));
+
+beforeEach(() => {
+  eventsRefetch.mockClear();
+  listsRefetch.mockClear();
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useActivityFeed", () => {
+  it("surfaces a newly-seen list change as a feed group", async () => {
+    querySettled = true;
+    events = [];
+    lists = [
+      {
+        id: "l1",
+        name: "Groceries",
+        kind: "grocery",
+        totalItems: 0,
+        completedItems: 0,
+      },
+    ];
+    const io = makeMemoryIo(); // seeds an empty prior snapshot so the list reads as 'added'
+    const { result } = renderHook(
+      () => useActivityFeed({ io, nowProvider: () => 1000 }),
+      { wrapper },
+    );
+    await waitFor(() =>
+      expect(result.current.feed.groups.length).toBeGreaterThan(0),
+    );
+    expect(result.current.feed.groups[0].summary).toContain("Groceries");
+  });
+
+  it("does not snapshot or diff while a source query is unsettled", async () => {
+    querySettled = false; // queries still loading
+    events = [];
+    lists = [
+      {
+        id: "l1",
+        name: "Groceries",
+        kind: "grocery",
+        totalItems: 0,
+        completedItems: 0,
+      },
+    ];
+    const io = makeMemoryIo();
+    const { result } = renderHook(
+      () => useActivityFeed({ io, nowProvider: () => 1000 }),
+      { wrapper },
+    );
+    // No "added" dump from partial data; saveState is never called with a fresh snapshot.
+    await waitFor(() => expect(io.loadState).toHaveBeenCalled());
+    expect(result.current.feed.groups).toHaveLength(0);
+    expect(io.saveState).not.toHaveBeenCalled();
+  });
+});
+
+describe("useActivityFeed — orchestration", () => {
+  it("does NOT advance the divider on a background data-change cycle", async () => {
+    querySettled = true;
+    events = [];
+    lists = [
+      {
+        id: "l1",
+        name: "Groceries",
+        kind: "grocery",
+        totalItems: 0,
+        completedItems: 0,
+      },
+    ];
+    const io = makeMemoryIo();
+    const now = vi.fn(() => 1000);
+    const { rerender } = renderHook(
+      () => useActivityFeed({ io, nowProvider: now }),
+      { wrapper },
+    );
+    await waitFor(() => expect(io.saveState).toHaveBeenCalledTimes(1)); // cold-start open
+    const seenAfterOpen = io.getLastSeen(); // advanced to 1000 by the open
+    // A later data change (auto cycle) must refresh the log but not advance the marker.
+    now.mockReturnValue(5000);
+    lists = [
+      ...lists,
+      {
+        id: "l2",
+        name: "Camping",
+        kind: "to-do",
+        totalItems: 1,
+        completedItems: 0,
+      },
+    ];
+    rerender();
+    await waitFor(() => expect(io.saveState).toHaveBeenCalledTimes(2));
+    expect(io.getLastSeen()).toBe(seenAfterOpen); // divider baseline did not move
+  });
+
+  it("keeps the rendered divider baseline frozen across background cycles", async () => {
+    querySettled = true;
+    events = [];
+    lists = [
+      {
+        id: "l1",
+        name: "Earlier",
+        kind: "to-do",
+        totalItems: 0,
+        completedItems: 0,
+      },
+      {
+        id: "l2",
+        name: "New",
+        kind: "to-do",
+        totalItems: 0,
+        completedItems: 0,
+      },
+    ];
+    const initial: ActivityState = {
+      snapshot: {
+        "lists:l1": {
+          storeKey: "lists:l1",
+          module: "lists",
+          title: "Earlier",
+          totalItems: 0,
+          completedItems: 0,
+          entityId: "l1",
+        },
+        "lists:l2": {
+          storeKey: "lists:l2",
+          module: "lists",
+          title: "New",
+          totalItems: 0,
+          completedItems: 0,
+          entityId: "l2",
+        },
+      },
+      log: [
+        {
+          storeKey: "lists:l1",
+          module: "lists",
+          kind: "edited",
+          title: "Earlier",
+          detail: "+1 items",
+          detectedAt: 100,
+          entityId: "l1",
+        },
+        {
+          storeKey: "lists:l2",
+          module: "lists",
+          kind: "edited",
+          title: "New",
+          detail: "+1 items",
+          detectedAt: 300,
+          entityId: "l2",
+        },
+      ],
+      snapshotSavedAt: 500,
+      eventWindow: { start: "2000-01-01", end: "2100-01-01" },
+    };
+    const io = makeMemoryIo(initial, 200);
+    const now = vi.fn(() => 1000);
+    const { result, rerender } = renderHook(
+      () => useActivityFeed({ io, nowProvider: now }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.feed.dividerAfter).toBe(0));
+
+    // Add another new group on an automatic cycle. The original "New" row must
+    // remain above the divider; rereading the advanced lastSeen would move it below.
+    now.mockReturnValue(2000);
+    lists = [
+      ...lists,
+      {
+        id: "l3",
+        name: "Newest",
+        kind: "to-do",
+        totalItems: 1,
+        completedItems: 0,
+      },
+    ];
+    rerender();
+    await waitFor(() => expect(result.current.feed.groups).toHaveLength(3));
+    expect(result.current.feed.dividerAfter).toBe(1);
+  });
+
+  it("refetches BOTH sources before detecting and incorporates refreshed data", async () => {
+    querySettled = true;
+    events = [];
+    lists = [];
+    const io = makeMemoryIo();
+    const { result, rerender } = renderHook(
+      () => useActivityFeed({ io, nowProvider: () => 1000 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(io.loadState).toHaveBeenCalled());
+    lists = [
+      {
+        id: "l1",
+        name: "Refetched",
+        kind: "to-do",
+        totalItems: 1,
+        completedItems: 0,
+      },
+    ];
+    let releaseRefetch = () => {};
+    const refetchGate = new Promise<void>((resolve) => {
+      releaseRefetch = resolve;
+    });
+    eventsRefetch.mockImplementationOnce(async () => {
+      await refetchGate;
+      return { data: { data: events } };
+    });
+    listsRefetch.mockImplementationOnce(async () => {
+      await refetchGate;
+      return { data: { data: lists } };
+    });
+    // jsdom visibilityState defaults to "visible" → the listener takes the visible branch.
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(eventsRefetch).toHaveBeenCalledTimes(1));
+    expect(listsRefetch).toHaveBeenCalledTimes(1);
+    expect(io.loadState).toHaveBeenCalledTimes(1); // detection is blocked on BOTH refetches
+    releaseRefetch();
+    await waitFor(() => expect(io.loadState).toHaveBeenCalledTimes(2));
+    expect(eventsRefetch.mock.invocationCallOrder[0]).toBeLessThan(
+      io.loadState.mock.invocationCallOrder[1],
+    );
+    expect(listsRefetch.mock.invocationCallOrder[0]).toBeLessThan(
+      io.loadState.mock.invocationCallOrder[1],
+    );
+
+    // The mock query hooks expose the refetched arrays on the next observer render,
+    // matching TanStack Query's post-refetch notification.
+    rerender();
+    await waitFor(() =>
+      expect(result.current.feed.groups[0]?.summary).toContain("Refetched"),
+    );
+  });
+
+  it("serializes writes: a slow earlier save cannot overwrite a newer cycle", async () => {
+    querySettled = true;
+    events = [];
+    lists = [
+      { id: "l1", name: "A", kind: "to-do", totalItems: 0, completedItems: 0 },
+    ];
+    let state: ActivityState | null = {
+      snapshot: {},
+      log: [],
+      snapshotSavedAt: 0,
+      eventWindow: { start: "2000-01-01", end: "2100-01-01" },
+    };
+    const completed: number[] = [];
+    let call = 0;
+    const io = {
+      loadState: vi.fn(async () => state),
+      saveState: vi.fn(async (s: ActivityState) => {
+        const n = ++call;
+        if (n === 1) await new Promise((r) => setTimeout(r, 50)); // make the FIRST save slow
+        state = s;
+        completed.push(n);
+      }),
+      getLastSeen: () => 0,
+      setLastSeen: () => {},
+      getHiddenAt: () => 0,
+      setHiddenAt: () => {},
+    };
+    const now = vi.fn(() => 1000);
+    const { rerender } = renderHook(
+      () => useActivityFeed({ io, nowProvider: now }),
+      { wrapper },
+    );
+    // Queue a second cycle with newer data while the first save is still pending.
+    now.mockReturnValue(2000);
+    lists = [
+      { id: "l1", name: "A", kind: "to-do", totalItems: 5, completedItems: 0 },
+    ];
+    rerender();
+    await waitFor(() => expect(completed).toEqual([1, 2])); // mutex preserved order despite the slow save
+    expect(state?.snapshot["lists:l1"]?.totalItems).toBe(5); // newest state is final, not overwritten
+  });
+});
+
+// minimal in-memory IO double for the hook's injected dependencies
+function makeMemoryIo(
+  initialState: ActivityState | null = {
+    snapshot: {},
+    log: [],
+    snapshotSavedAt: 0,
+    eventWindow: { start: "2000-01-01", end: "2100-01-01" },
+  },
+  initialLastSeen = 0,
+) {
+  let state = initialState;
+  let lastSeen = initialLastSeen;
+  let hiddenAt = 0;
+  return {
+    loadState: vi.fn(async () => state),
+    saveState: vi.fn(async (s: ActivityState) => {
+      state = s;
+    }),
+    getLastSeen: () => lastSeen,
+    setLastSeen: (v: number) => {
+      lastSeen = v;
+    },
+    getHiddenAt: () => hiddenAt,
+    setHiddenAt: (v: number) => {
+      hiddenAt = v;
+    },
+  };
+}

--- a/src/components/home/hooks/use-activity-feed.ts
+++ b/src/components/home/hooks/use-activity-feed.ts
@@ -59,6 +59,13 @@ const EMPTY_FEED: Feed = { groups: [], dividerAfter: -1, overflow: 0 };
 const EMPTY_EVENTS: CalendarEvent[] = [];
 const EMPTY_LISTS: ListSummary[] = [];
 
+/** Freshly-refetched arrays threaded into a return-to-visible cycle so it diffs the
+ * refreshed data directly, rather than the pre-refetch render's closure. */
+interface FreshData {
+  events: CalendarEvent[];
+  lists: ListSummary[];
+}
+
 /** Overlap of the previous and current detection windows (yyyy-MM-dd strings). */
 function overlapOf(prev: EventWindow, curr: EventWindow): EventWindow {
   return {
@@ -157,9 +164,15 @@ export function useActivityFeed({
   }, []);
 
   // One cycle's critical section. Serialized by `queueRef`, so no other cycle's
-  // load/save can interleave with this one.
+  // load/save can interleave with this one. `override` carries the just-refetched
+  // arrays for a return-to-visible cycle: the visibility handler `await`s the
+  // refetch, but the hook has not re-rendered yet, so the closure's `events`/`lists`
+  // are still pre-refetch. Diffing those would surface nothing while still advancing
+  // `lastSeen`, leaving the real change to be stamped LATER by the follow-up auto
+  // cycle — reading as "new" for an extra open. Threading the refetch result in
+  // makes the open diff fresh data (spec §4: "refetch … then detect").
   const runCycle = useCallback(
-    async (trigger: "auto" | "visible") => {
+    async (trigger: "auto" | "visible", override?: FreshData) => {
       const prior = await io.loadState();
 
       // Gate: never diff partial data. Render whatever is persisted and wait.
@@ -173,7 +186,10 @@ export function useActivityFeed({
       }
 
       const ts = now();
-      const fresh = buildSnapshot(events, lists);
+      const fresh = buildSnapshot(
+        override?.events ?? events,
+        override?.lists ?? lists,
+      );
 
       // First run / long absence → reseed silently (no "added" dump).
       if (!prior || ts - prior.snapshotSavedAt > STALE_RESEED_MS) {
@@ -234,8 +250,8 @@ export function useActivityFeed({
   // gen-skip): cycles are cheap in-memory diffs, and a meaningful-open cycle must
   // never be skipped because a data-change cycle queued right after it.
   const detect = useCallback(
-    (trigger: "auto" | "visible") => {
-      const run = queueRef.current.then(() => runCycle(trigger));
+    (trigger: "auto" | "visible", override?: FreshData) => {
+      const run = queueRef.current.then(() => runCycle(trigger, override));
       queueRef.current = run.catch(() => {}); // keep the chain alive across errors
       return run;
     },
@@ -245,9 +261,20 @@ export function useActivityFeed({
   // Stable handles for the visibility listener so it never re-registers on data change.
   const detectRef = useRef(detect);
   detectRef.current = detect;
-  const refetchRef = useRef<() => Promise<void>>(async () => {});
+  // Returns the refreshed arrays so the return-to-visible cycle can diff them
+  // directly (the hook has not re-rendered post-refetch, so the closure is stale).
+  // Null when either refetch yielded no data — the cycle then falls back to the
+  // closure rather than diffing a half-refreshed pair.
+  const refetchRef = useRef<() => Promise<FreshData | null>>(async () => null);
   refetchRef.current = async () => {
-    await Promise.all([eventsQuery.refetch(), listsQuery.refetch()]);
+    const [e, l] = await Promise.all([
+      eventsQuery.refetch(),
+      listsQuery.refetch(),
+    ]);
+    const freshEvents = e.data?.data;
+    const freshLists = l.data?.data;
+    if (!freshEvents || !freshLists) return null;
+    return { events: freshEvents, lists: freshLists };
   };
 
   // Cold-start + data-change cycles. `detect` changes identity when events/lists/
@@ -263,12 +290,14 @@ export function useActivityFeed({
       if (document.visibilityState === "hidden") {
         io.setHiddenAt(now());
       } else {
-        // Refetch both sources so the NEXT data-change cycle diffs fresh data.
-        // The refreshed arrays surface on the following render (TanStack notifies
-        // the observer); this "visible" cycle still diffs the pre-refetch snapshot,
-        // which matches the plan's freshness model.
-        await refetchRef.current();
-        void detectRef.current("visible");
+        // Refetch both sources, THEN diff the refreshed arrays in this same open
+        // cycle (threaded in via `override`). The hook has not re-rendered yet, so
+        // the closure is still pre-refetch — diffing it would surface nothing while
+        // advancing `lastSeen`, leaving the change to be stamped later and read as
+        // "new" for an extra open. Passing the refetch result keeps the open's diff
+        // and its `lastSeen` advance on the same data (spec §4).
+        const fresh = await refetchRef.current();
+        void detectRef.current("visible", fresh ?? undefined);
       }
     }
     document.addEventListener("visibilitychange", onVisibility);

--- a/src/components/home/hooks/use-activity-feed.ts
+++ b/src/components/home/hooks/use-activity-feed.ts
@@ -304,5 +304,7 @@ export function useActivityFeed({
     return () => document.removeEventListener("visibilitychange", onVisibility);
   }, [io, now]);
 
-  return { feed, meaningfulOpenId };
+  // `events` is the unfiltered 28-day source the feed is built from; the dashboard
+  // narrows it to the openable horizon (selectOpenableEvents) for deep-linking.
+  return { feed, meaningfulOpenId, events };
 }

--- a/src/components/home/hooks/use-activity-feed.ts
+++ b/src/components/home/hooks/use-activity-feed.ts
@@ -1,0 +1,279 @@
+import { addDays, startOfDay } from "date-fns";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCalendarEvents, useLists } from "@/api";
+import {
+  ACTIVITY_WINDOW_MS,
+  CALENDAR_SUBROW_CAP,
+  FEED_ENTRY_CAP,
+  FEED_EVENT_WINDOW_DAYS,
+  STALE_RESEED_MS,
+} from "@/lib/home-activity/constants";
+import {
+  diffSnapshots,
+  mergeLog,
+  pruneLog,
+  reconcileLog,
+} from "@/lib/home-activity/diff";
+import { buildFeed } from "@/lib/home-activity/group";
+import {
+  getHiddenAt,
+  getLastSeen,
+  isMeaningfulOpen,
+  setHiddenAt,
+  setLastSeen,
+} from "@/lib/home-activity/markers";
+import { buildSnapshot } from "@/lib/home-activity/normalize";
+import {
+  loadActivityState,
+  saveActivityState,
+} from "@/lib/home-activity/store";
+import type {
+  ActivityState,
+  EventWindow,
+  Feed,
+} from "@/lib/home-activity/types";
+import { formatLocalDate } from "@/lib/time-utils";
+import type { CalendarEvent, ListSummary } from "@/lib/types";
+
+interface ActivityIo {
+  loadState: () => Promise<ActivityState | null>;
+  saveState: (s: ActivityState) => Promise<void>;
+  getLastSeen: () => number;
+  setLastSeen: (v: number) => void;
+  getHiddenAt: () => number;
+  setHiddenAt: (v: number) => void;
+}
+
+const defaultIo: ActivityIo = {
+  loadState: loadActivityState,
+  saveState: saveActivityState,
+  getLastSeen,
+  setLastSeen,
+  getHiddenAt,
+  setHiddenAt,
+};
+
+const EMPTY_FEED: Feed = { groups: [], dividerAfter: -1, overflow: 0 };
+// Stable identities so the detection effect does not re-fire every render while a
+// query is still loading (a fresh `?? []` would be a new reference each time).
+const EMPTY_EVENTS: CalendarEvent[] = [];
+const EMPTY_LISTS: ListSummary[] = [];
+
+/** Overlap of the previous and current detection windows (yyyy-MM-dd strings). */
+function overlapOf(prev: EventWindow, curr: EventWindow): EventWindow {
+  return {
+    start: prev.start > curr.start ? prev.start : curr.start,
+    end: prev.end < curr.end ? prev.end : curr.end,
+  };
+}
+
+export function useActivityFeed({
+  io = defaultIo,
+  nowProvider,
+}: {
+  io?: ActivityIo;
+  nowProvider?: () => number;
+} = {}) {
+  // Stabilize nowProvider so the visibility listener is not torn down each render.
+  const nowRef = useRef(nowProvider ?? (() => Date.now()));
+  nowRef.current = nowProvider ?? nowRef.current;
+  const now = useCallback(() => nowRef.current(), []);
+
+  // Memoize the query range by a local-date STRING — startOfDay(new Date()) is a
+  // new reference every render, which would churn the query key and effects.
+  const todayStr = formatLocalDate(new Date(now()));
+  // `now` is a stable useCallback ref that never changes identity, so without
+  // `todayStr` the memo would never recompute when the calendar date rolls over.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: todayStr is intentional
+  const range = useMemo<EventWindow>(() => {
+    const today = startOfDay(new Date(now()));
+    return {
+      start: formatLocalDate(today),
+      end: formatLocalDate(addDays(today, FEED_EVENT_WINDOW_DAYS)),
+    };
+  }, [todayStr, now]);
+
+  const eventsQuery = useCalendarEvents({
+    startDate: range.start,
+    endDate: range.end,
+  });
+  const listsQuery = useLists();
+  const settled = eventsQuery.isSuccess && listsQuery.isSuccess;
+  const events = eventsQuery.data?.data ?? EMPTY_EVENTS;
+  const lists = listsQuery.data?.data ?? EMPTY_LISTS;
+
+  const [feed, setFeed] = useState<Feed>(EMPTY_FEED);
+  const [meaningfulOpenId, setMeaningfulOpenId] = useState(0); // bump → reset ephemeral expansion
+  const coldStartRef = useRef(true);
+  // Mutex: every cycle (cold start, data change, return-to-visible) is chained
+  // through this promise so a cycle's load→diff→save runs to completion before the
+  // next begins. The newest-queued cycle therefore writes LAST and wins — a slow
+  // earlier save can never land after a newer one (the generation guard alone did
+  // not prevent this: two saves already in flight could resolve out of order).
+  const queueRef = useRef<Promise<void>>(Promise.resolve());
+  // The divider baseline is frozen at the `lastSeen` of the most recent meaningful
+  // OPEN and reused by every cycle in between. A background data-change cycle or a
+  // quick peek must NOT move the divider, so renders never reread the advanced
+  // marker — they read this ref.
+  const displayBaselineRef = useRef<number | null>(null);
+  // Last feed committed to state. `render` skips setFeed when a cycle produces a
+  // structurally identical feed, so a no-op cycle (e.g. a return-to-visible that
+  // found nothing new) does not mint a new Feed object. A new `feed` identity
+  // would force a re-render and churn the cycle count the orchestration tests
+  // assert. This is primarily render-count stability — not a correctness gate:
+  // `newest` (max detectedAt) advances on any real change, so genuine updates
+  // always render.
+  const lastRenderedFeedRef = useRef<Feed>(EMPTY_FEED);
+
+  const render = useCallback((log: ActivityState["log"]) => {
+    const next = buildFeed(
+      log,
+      displayBaselineRef.current ?? 0,
+      FEED_ENTRY_CAP,
+      CALENDAR_SUBROW_CAP,
+    );
+    const prev = lastRenderedFeedRef.current;
+    // Skip setFeed entirely when the feed is structurally unchanged: minting a new
+    // Feed object on a no-op cycle would re-render needlessly and churn the
+    // orchestration tests' cycle count. `newest`, `summary`, `dividerAfter`, and
+    // `overflow` together version the feed, so any real change is still rendered.
+    if (
+      prev.groups.length === next.groups.length &&
+      prev.dividerAfter === next.dividerAfter &&
+      prev.overflow === next.overflow &&
+      // length already confirmed equal above, so next.groups[i] is always defined
+      prev.groups.every(
+        (g, i) =>
+          g.id === next.groups[i].id &&
+          g.newest === next.groups[i].newest &&
+          g.summary === next.groups[i].summary &&
+          g.rows.length === next.groups[i].rows.length,
+      )
+    ) {
+      return;
+    }
+    lastRenderedFeedRef.current = next;
+    setFeed(next);
+  }, []);
+
+  // One cycle's critical section. Serialized by `queueRef`, so no other cycle's
+  // load/save can interleave with this one.
+  const runCycle = useCallback(
+    async (trigger: "auto" | "visible") => {
+      const prior = await io.loadState();
+
+      // Gate: never diff partial data. Render whatever is persisted and wait.
+      if (!settled) {
+        if (prior) {
+          if (displayBaselineRef.current === null)
+            displayBaselineRef.current = io.getLastSeen();
+          render(prior.log);
+        }
+        return;
+      }
+
+      const ts = now();
+      const fresh = buildSnapshot(events, lists);
+
+      // First run / long absence → reseed silently (no "added" dump).
+      if (!prior || ts - prior.snapshotSavedAt > STALE_RESEED_MS) {
+        await io.saveState({
+          snapshot: fresh,
+          log: [],
+          snapshotSavedAt: ts,
+          eventWindow: range,
+        });
+        io.setLastSeen(ts);
+        displayBaselineRef.current = ts; // nothing is "new" yet
+        coldStartRef.current = false;
+        setFeed(EMPTY_FEED);
+        return;
+      }
+
+      // Window-bounds-aware diff AND reconcile: an event that merely aged out of the
+      // sliding window must be neither reported (diff) nor dropped/demoted (reconcile)
+      // — it is preserved until normal 48h pruning (§4.4).
+      const overlap = overlapOf(prior.eventWindow, range);
+      const deltas = diffSnapshots(fresh, prior.snapshot, ts, overlap);
+      let log = mergeLog(prior.log, deltas); // merge BEFORE reconcile so add+remove net-cancels
+      log = reconcileLog(log, new Set(Object.keys(fresh)), range); // preserve out-of-window entries
+      log = pruneLog(log, ts, ACTIVITY_WINDOW_MS);
+      await io.saveState({
+        snapshot: fresh,
+        log,
+        snapshotSavedAt: ts,
+        eventWindow: range,
+      });
+
+      // Classify the OPEN, not the data change. Only a real open advances the divider.
+      const isOpenEvent = trigger === "visible" || coldStartRef.current;
+      const meaningful =
+        isOpenEvent &&
+        isMeaningfulOpen({
+          coldStart: coldStartRef.current,
+          now: ts,
+          hiddenAt: io.getHiddenAt(),
+          lastSeen: io.getLastSeen(),
+        });
+      // Freeze the baseline at THIS open's pre-advance lastSeen; later non-open
+      // cycles reuse it, so the divider holds until the next real open.
+      if (meaningful || displayBaselineRef.current === null) {
+        displayBaselineRef.current = io.getLastSeen();
+      }
+      render(log);
+      if (meaningful) {
+        io.setLastSeen(ts); // advance the persisted marker AFTER capturing the baseline
+        setMeaningfulOpenId((n) => n + 1); // reset ephemeral expansion on a real open
+      }
+      coldStartRef.current = false;
+    },
+    [io, now, settled, events, lists, range, render],
+  );
+
+  // Enqueue a cycle behind the mutex. We deliberately run every queued cycle (no
+  // gen-skip): cycles are cheap in-memory diffs, and a meaningful-open cycle must
+  // never be skipped because a data-change cycle queued right after it.
+  const detect = useCallback(
+    (trigger: "auto" | "visible") => {
+      const run = queueRef.current.then(() => runCycle(trigger));
+      queueRef.current = run.catch(() => {}); // keep the chain alive across errors
+      return run;
+    },
+    [runCycle],
+  );
+
+  // Stable handles for the visibility listener so it never re-registers on data change.
+  const detectRef = useRef(detect);
+  detectRef.current = detect;
+  const refetchRef = useRef<() => Promise<void>>(async () => {});
+  refetchRef.current = async () => {
+    await Promise.all([eventsQuery.refetch(), listsQuery.refetch()]);
+  };
+
+  // Cold-start + data-change cycles. `detect` changes identity when events/lists/
+  // range/settled change, which is the data-change trigger.
+  useEffect(() => {
+    void detect("auto");
+  }, [detect]);
+
+  // Hide → record hiddenAt. Visible → refetch (focus refetch is off app-wide),
+  // THEN detect as an open. Registered once; reads the latest detect/refetch via refs.
+  useEffect(() => {
+    async function onVisibility() {
+      if (document.visibilityState === "hidden") {
+        io.setHiddenAt(now());
+      } else {
+        // Refetch both sources so the NEXT data-change cycle diffs fresh data.
+        // The refreshed arrays surface on the following render (TanStack notifies
+        // the observer); this "visible" cycle still diffs the pre-refetch snapshot,
+        // which matches the plan's freshness model.
+        await refetchRef.current();
+        void detectRef.current("visible");
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [io, now]);
+
+  return { feed, meaningfulOpenId };
+}

--- a/src/components/home/hooks/use-state-line.test.tsx
+++ b/src/components/home/hooks/use-state-line.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useStateLine } from "./use-state-line";
+
+// Module-level mutables feed the mocked query hooks (the factory closes over them),
+// so each test sets the chores/meals data it needs before rendering.
+let choresResult: unknown;
+let mealsResult: unknown;
+
+vi.mock("@/api", () => ({
+  useChoresBoard: () => choresResult,
+  useMealsBoard: () => mealsResult,
+}));
+
+const choresWith = (remaining: number) => ({
+  data: { data: { today: { summary: { remaining } } } },
+});
+const mealsWithDinner = (date: string, title: string | null) => ({
+  data: {
+    data: {
+      days: [
+        {
+          date,
+          slots: [{ mealType: "dinner", primary: title ? { title } : null }],
+        },
+      ],
+    },
+  },
+});
+const emptyMeals = { data: { data: { days: [] } } };
+
+describe("useStateLine", () => {
+  it("reports chores remaining and tonight's dinner for the local day", () => {
+    choresResult = choresWith(3);
+    mealsResult = mealsWithDinner("2026-06-21", "Tacos"); // June 21 — month index is 0-based
+    const { result } = renderHook(() =>
+      useStateLine({ now: new Date(2026, 5, 21) }),
+    );
+    expect(result.current.choresRemaining).toBe(3);
+    expect(result.current.dinnerTitle).toBe("Tacos");
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it("is empty when no chores remain and no dinner is planned", () => {
+    choresResult = choresWith(0);
+    mealsResult = emptyMeals;
+    const { result } = renderHook(() =>
+      useStateLine({ now: new Date(2026, 5, 21) }),
+    );
+    expect(result.current.choresRemaining).toBe(0);
+    expect(result.current.dinnerTitle).toBeNull();
+    expect(result.current.isEmpty).toBe(true);
+  });
+
+  it("is not empty with chores remaining but no dinner", () => {
+    choresResult = choresWith(2);
+    mealsResult = emptyMeals;
+    const { result } = renderHook(() =>
+      useStateLine({ now: new Date(2026, 5, 21) }),
+    );
+    expect(result.current.dinnerTitle).toBeNull();
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it("is not empty with a dinner but zero chores remaining", () => {
+    choresResult = choresWith(0);
+    mealsResult = mealsWithDinner("2026-06-21", "Pasta");
+    const { result } = renderHook(() =>
+      useStateLine({ now: new Date(2026, 5, 21) }),
+    );
+    expect(result.current.choresRemaining).toBe(0);
+    expect(result.current.dinnerTitle).toBe("Pasta");
+    expect(result.current.isEmpty).toBe(false);
+  });
+
+  it("treats pending queries (undefined data) as empty", () => {
+    choresResult = { data: undefined };
+    mealsResult = { data: undefined };
+    const { result } = renderHook(() =>
+      useStateLine({ now: new Date(2026, 5, 21) }),
+    );
+    expect(result.current.choresRemaining).toBe(0);
+    expect(result.current.dinnerTitle).toBeNull();
+    expect(result.current.isEmpty).toBe(true);
+  });
+});

--- a/src/components/home/hooks/use-state-line.ts
+++ b/src/components/home/hooks/use-state-line.ts
@@ -1,0 +1,18 @@
+import { useChoresBoard, useMealsBoard } from "@/api";
+import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
+
+export function useStateLine({ now = new Date() }: { now?: Date } = {}) {
+  const weekStart = formatLocalDate(getWeekStartSunday(now));
+  const todayStr = formatLocalDate(now);
+  const { data: chores } = useChoresBoard();
+  const { data: meals } = useMealsBoard(weekStart);
+
+  const choresRemaining = chores?.data?.today.summary.remaining ?? 0;
+
+  const day = meals?.data?.days.find((d) => d.date === todayStr);
+  const dinnerTitle =
+    day?.slots.find((s) => s.mealType === "dinner")?.primary?.title ?? null;
+
+  const isEmpty = choresRemaining === 0 && !dinnerTitle;
+  return { choresRemaining, dinnerTitle, isEmpty };
+}

--- a/src/components/lists-view.tsx
+++ b/src/components/lists-view.tsx
@@ -1,9 +1,10 @@
 import { Plus } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useListPreferences, useLists } from "@/api";
 import { OfflineUnavailable, ScreenTransition } from "@/components/shared";
 import { useBackHandler, useIsMobile } from "@/hooks";
 import { cn } from "@/lib/utils";
+import { useAppStore } from "@/stores";
 import { ListCard } from "./lists/list-card";
 import { ListCreateSheet } from "./lists/list-create-sheet";
 import { ListDetailView } from "./lists/list-detail-view";
@@ -13,6 +14,11 @@ export function ListsView() {
   const isMobile = useIsMobile();
   const [selectedListId, setSelectedListId] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const consumeListDetailIntent = useAppStore((s) => s.consumeListDetailIntent);
+  useEffect(() => {
+    const id = consumeListDetailIntent();
+    if (id) setSelectedListId(id);
+  }, [consumeListDetailIntent]);
   const lists = useLists();
   const preferences = useListPreferences();
   useBackHandler(selectedListId !== null, () => setSelectedListId(null));

--- a/src/lib/home-activity/constants.ts
+++ b/src/lib/home-activity/constants.ts
@@ -1,0 +1,8 @@
+export const ACTIVITY_WINDOW_MS = 1000 * 60 * 60 * 48; // 48h rolling window
+export const MEANINGFUL_GAP_MS = 1000 * 60 * 60 * 4; // 4h hidden → next open is "meaningful"
+export const STALE_RESEED_MS = ACTIVITY_WINDOW_MS; // away longer than the window → silent reseed
+export const FEED_ENTRY_CAP = 20; // max top-level entries (calendar group counts as one) — bounds length
+export const CALENDAR_SUBROW_CAP = 10; // max sub-rows inside the expanded calendar group
+export const FEED_EVENT_WINDOW_DAYS = 28; // calendar detection window
+export const LAST_SEEN_KEY = "family-hub-activity-last-seen";
+export const HIDDEN_AT_KEY = "family-hub-activity-hidden-at";

--- a/src/lib/home-activity/constants.ts
+++ b/src/lib/home-activity/constants.ts
@@ -6,3 +6,13 @@ export const CALENDAR_SUBROW_CAP = 10; // max sub-rows inside the expanded calen
 export const FEED_EVENT_WINDOW_DAYS = 28; // calendar detection window
 export const LAST_SEEN_KEY = "family-hub-activity-last-seen";
 export const HIDDEN_AT_KEY = "family-hub-activity-hidden-at";
+
+// A DEDICATED database — NOT the offline cache's `family-hub-offline`.
+// `idb-keyval.createStore` calls `indexedDB.open(dbName)` with no version, so it
+// can only create its object store during the DB's initial `onupgradeneeded`. The
+// offline cache already created `family-hub-offline` at v1 with `query-cache`, so
+// adding a second store to that DB would never fire an upgrade and every
+// transaction would throw (silently swallowed). A separate DB avoids that entirely.
+export const ACTIVITY_DB_NAME = "family-hub-home-activity";
+export const ACTIVITY_STORE_NAME = "home-activity";
+export const ACTIVITY_STATE_KEY = "activity-state";

--- a/src/lib/home-activity/constants.ts
+++ b/src/lib/home-activity/constants.ts
@@ -4,6 +4,10 @@ export const STALE_RESEED_MS = ACTIVITY_WINDOW_MS; // away longer than the windo
 export const FEED_ENTRY_CAP = 20; // max top-level entries (calendar group counts as one) — bounds length
 export const CALENDAR_SUBROW_CAP = 10; // max sub-rows inside the expanded calendar group
 export const FEED_EVENT_WINDOW_DAYS = 28; // calendar detection window
+// Openable horizon for deep-linking a feed calendar row to its detail sheet:
+// today + the next 2 days (a 3-day inclusive window, matching the dashboard
+// agenda's "today + coming up"). Rows beyond it focus the day instead.
+export const OPENABLE_WINDOW_DAYS = 2;
 export const LAST_SEEN_KEY = "family-hub-activity-last-seen";
 export const HIDDEN_AT_KEY = "family-hub-activity-hidden-at";
 

--- a/src/lib/home-activity/diff.test.ts
+++ b/src/lib/home-activity/diff.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent, ListSummary } from "@/lib/types";
+import { diffSnapshots } from "./diff";
+import { buildSnapshot } from "./normalize";
+
+const ev = (over: Partial<CalendarEvent>): CalendarEvent => ({
+  id: "e1",
+  title: "Dentist",
+  startTime: "9:00 AM",
+  endTime: "10:00 AM",
+  date: new Date(2026, 5, 23),
+  memberId: "m1",
+  isAllDay: false,
+  ...over,
+});
+const list = (over: Partial<ListSummary>): ListSummary => ({
+  id: "l1",
+  name: "Groceries",
+  kind: "grocery",
+  totalItems: 3,
+  completedItems: 1,
+  ...over,
+});
+const T = 1_000;
+
+describe("diffSnapshots", () => {
+  it("reports an added calendar event with a date/time detail", () => {
+    const fresh = buildSnapshot([ev({})], []);
+    const items = diffSnapshots(fresh, {}, T);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "added",
+      module: "calendar",
+      title: "Dentist",
+      detectedAt: T,
+    });
+    expect(items[0].detail).toContain("9:00 AM");
+  });
+
+  it("reports an edited event when a watched field changes", () => {
+    const prev = buildSnapshot([ev({})], []);
+    const fresh = buildSnapshot([ev({ startTime: "5:00 PM" })], []);
+    const items = diffSnapshots(fresh, prev, T);
+    expect(items[0]).toMatchObject({ kind: "edited" });
+  });
+
+  it("reports a removed event using the previous title", () => {
+    const prev = buildSnapshot([ev({})], []);
+    const items = diffSnapshots({}, prev, T);
+    expect(items[0]).toMatchObject({ kind: "removed", title: "Dentist" });
+  });
+
+  it("ignores unchanged entities", () => {
+    const prev = buildSnapshot([ev({})], []);
+    const fresh = buildSnapshot([ev({})], []);
+    expect(diffSnapshots(fresh, prev, T)).toHaveLength(0);
+  });
+
+  it("summarizes list item additions and completions", () => {
+    const prev = buildSnapshot(
+      [],
+      [list({ totalItems: 3, completedItems: 1 })],
+    );
+    const added = diffSnapshots(
+      buildSnapshot([], [list({ totalItems: 6, completedItems: 1 })]),
+      prev,
+      T,
+    );
+    expect(added[0].detail).toBe("+3 items");
+    const done = diffSnapshots(
+      buildSnapshot([], [list({ totalItems: 3, completedItems: 3 })]),
+      prev,
+      T,
+    );
+    expect(done[0].detail).toBe("2 checked off");
+  });
+
+  it("labels a created list 'New list' (not the doubled title)", () => {
+    const items = diffSnapshots(
+      buildSnapshot([], [list({ name: "Party" })]),
+      {},
+      T,
+    );
+    expect(items[0]).toMatchObject({
+      kind: "added",
+      title: "Party",
+      detail: "New list",
+    });
+  });
+
+  it("suppresses a bare un-check (completedItems decrease, no other change)", () => {
+    const prev = buildSnapshot(
+      [],
+      [list({ totalItems: 3, completedItems: 2 })],
+    );
+    const fresh = buildSnapshot(
+      [],
+      [list({ totalItems: 3, completedItems: 1 })],
+    );
+    expect(diffSnapshots(fresh, prev, T)).toHaveLength(0);
+  });
+
+  it("ignores window-edge churn: an event only outside the overlap is neither added nor removed", () => {
+    const overlap = { start: "2026-06-22", end: "2026-07-10" };
+    // prev had an event on the 21st (now below the new window's start); fresh has one on the 23rd.
+    const prev = buildSnapshot(
+      [ev({ id: "old", date: new Date(2026, 5, 21) })],
+      [],
+    );
+    const fresh = buildSnapshot(
+      [ev({ id: "new", date: new Date(2026, 5, 23) })],
+      [],
+    );
+    const items = diffSnapshots(fresh, prev, T, overlap);
+    // "old" aged out below start → not removed; "new" is inside overlap → added.
+    expect(items.map((i) => i.kind)).toEqual(["added"]);
+    expect(items[0].title).toBe("Dentist");
+  });
+
+  it("detail for an all-day event is 'all day' regardless of startTime", () => {
+    const items = diffSnapshots(
+      buildSnapshot([ev({ isAllDay: true })], []),
+      {},
+      T,
+    );
+    expect(items[0].detail).toBe("all day");
+  });
+
+  it("summarizes a list item removal as 'N removed'", () => {
+    const prev = buildSnapshot(
+      [],
+      [list({ totalItems: 3, completedItems: 1 })],
+    );
+    const fresh = buildSnapshot(
+      [],
+      [list({ totalItems: 1, completedItems: 1 })],
+    );
+    expect(diffSnapshots(fresh, prev, T)[0].detail).toBe("2 removed");
+  });
+});

--- a/src/lib/home-activity/diff.ts
+++ b/src/lib/home-activity/diff.ts
@@ -136,3 +136,84 @@ export function diffSnapshots(
 
   return out;
 }
+
+export function mergeLog(
+  log: ActivityItem[],
+  deltas: ActivityItem[],
+): ActivityItem[] {
+  const byKey = new Map(log.map((i) => [i.storeKey, i]));
+  for (const d of deltas) {
+    const existing = byKey.get(d.storeKey);
+    if (!existing) {
+      byKey.set(d.storeKey, d);
+      continue;
+    }
+    if (d.kind === "removed") {
+      // An add then a remove within the window net-cancels — no lingering row
+      // (spec §4.4 / §9 AC). Otherwise the removal wins.
+      if (existing.kind === "added") {
+        byKey.delete(d.storeKey);
+        continue;
+      }
+      byKey.set(d.storeKey, {
+        ...d,
+        kind: "removed",
+        detectedAt: Math.max(existing.detectedAt, d.detectedAt),
+      });
+      continue;
+    }
+    // d is added/edited: a prior "added" stays "added"; otherwise take the delta's kind.
+    // (A prior "removed" re-appearing is emitted by diffSnapshots as "added", so this resolves to "added".)
+    const kind = existing.kind === "added" ? "added" : d.kind;
+    byKey.set(d.storeKey, {
+      ...d,
+      kind,
+      detectedAt: Math.max(existing.detectedAt, d.detectedAt),
+    });
+  }
+  return [...byKey.values()];
+}
+
+export function reconcileLog(
+  log: ActivityItem[],
+  freshKeys: Set<string>,
+  window?: { start: string; end: string },
+): ActivityItem[] {
+  const out: ActivityItem[] = [];
+  for (const i of log) {
+    if (freshKeys.has(i.storeKey)) {
+      out.push(i);
+      continue;
+    }
+    // Absent from `fresh`. A calendar entry whose date is OUTSIDE the current query
+    // window merely aged out of the fetch — it was NOT deleted. Preserve it as-is
+    // (do not drop an `added`, do not demote an `edited`) until normal 48h pruning.
+    // Without this, the window-aware diff's suppression is undone here (§4.4).
+    if (
+      window &&
+      i.module === "calendar" &&
+      i.date &&
+      (i.date < window.start || i.date > window.end)
+    ) {
+      out.push(i);
+      continue;
+    }
+    if (i.kind === "added") {
+      // genuinely absent within the window → drop the phantom
+    } else if (i.kind === "edited") {
+      out.push({ ...i, kind: "removed" });
+    } else {
+      out.push(i); // already removed
+    }
+  }
+  return out;
+}
+
+export function pruneLog(
+  log: ActivityItem[],
+  now: number,
+  maxAgeMs: number,
+): ActivityItem[] {
+  // Inclusive boundary: an entry exactly maxAgeMs old is kept (drops only when strictly older).
+  return log.filter((i) => now - i.detectedAt <= maxAgeMs);
+}

--- a/src/lib/home-activity/diff.ts
+++ b/src/lib/home-activity/diff.ts
@@ -1,0 +1,138 @@
+import { parseLocalDate } from "@/lib/time-utils";
+import type {
+  ActivityItem,
+  ActivityKind,
+  Snapshot,
+  SnapshotEntry,
+} from "./types";
+
+const CALENDAR_FIELDS: (keyof SnapshotEntry)[] = [
+  "title",
+  "date",
+  "startTime",
+  "endTime",
+  "endDate",
+  "isAllDay",
+  "location",
+  "memberId",
+];
+
+function calendarChanged(a: SnapshotEntry, b: SnapshotEntry): boolean {
+  return CALENDAR_FIELDS.some((f) => a[f] !== b[f]);
+}
+
+function listChanged(fresh: SnapshotEntry, prev: SnapshotEntry): boolean {
+  if (fresh.title !== prev.title) return true;
+  if (fresh.totalItems !== prev.totalItems) return true;
+  // completedItems: only an INCREASE (checked off) is surfaced. An un-check
+  // (decrease) with no other change is suppressed — there is no "updated"
+  // signal (spec §4.2).
+  return (fresh.completedItems ?? 0) > (prev.completedItems ?? 0);
+}
+
+function calendarDetail(e: SnapshotEntry): string {
+  if (e.isAllDay) return "all day";
+  return e.startTime
+    ? `${affixDay(e.date)} ${e.startTime}`.trim()
+    : (e.date ?? "");
+}
+
+function affixDay(date?: string): string {
+  if (!date) return "";
+  // parseLocalDate (not raw `new Date("yyyy-MM-dd")`) per the repo's TZ convention.
+  return parseLocalDate(date).toLocaleDateString(undefined, {
+    weekday: "short",
+  }); // "Tue"
+}
+
+function listDetail(fresh: SnapshotEntry, prev?: SnapshotEntry): string {
+  if (!prev) return "New list"; // created → summary "<name> · New list" (§5)
+  // Single summary signal per list: a rename takes precedence — if the title also
+  // changed, the item-count delta is intentionally not surfaced this cycle.
+  if (fresh.title !== prev.title) return "renamed";
+  const totalDelta = (fresh.totalItems ?? 0) - (prev.totalItems ?? 0);
+  if (totalDelta > 0) return `+${totalDelta} items`;
+  if (totalDelta < 0) return `${-totalDelta} removed`;
+  // Only reachable when completedItems increased — listChanged() gates out the
+  // title/total/uncheck cases, so there is no unspecified "updated" fallback.
+  const doneDelta = (fresh.completedItems ?? 0) - (prev.completedItems ?? 0);
+  return `${doneDelta} checked off`;
+}
+
+/** Calendar entities outside the overlap of the previous and current detection
+ * windows are sliding-edge churn, not real adds/removes (spec §4.4). Lists are
+ * unwindowed and always pass. yyyy-MM-dd strings compare chronologically. */
+function inWindow(
+  e: SnapshotEntry,
+  overlap?: { start: string; end: string },
+): boolean {
+  if (!overlap || e.module !== "calendar" || !e.date) return true;
+  return e.date >= overlap.start && e.date <= overlap.end;
+}
+
+function item(
+  entry: SnapshotEntry,
+  kind: ActivityKind,
+  detail: string,
+  detectedAt: number,
+): ActivityItem {
+  return {
+    storeKey: entry.storeKey,
+    module: entry.module,
+    kind,
+    title: entry.title,
+    detail,
+    memberId: entry.memberId,
+    recurringEventId: entry.recurringEventId,
+    date: entry.date,
+    entityId: entry.entityId,
+    detectedAt,
+  };
+}
+
+export function diffSnapshots(
+  fresh: Snapshot,
+  prev: Snapshot,
+  detectedAt: number,
+  overlap?: { start: string; end: string },
+): ActivityItem[] {
+  const out: ActivityItem[] = [];
+
+  for (const key of Object.keys(fresh)) {
+    const f = fresh[key];
+    const p = prev[key];
+    if (!p) {
+      if (!inWindow(f, overlap)) continue; // entered at the sliding top edge — not a real add
+      out.push(
+        item(
+          f,
+          "added",
+          f.module === "calendar" ? calendarDetail(f) : listDetail(f),
+          detectedAt,
+        ),
+      );
+      continue;
+    }
+    const changed =
+      f.module === "calendar" ? calendarChanged(f, p) : listChanged(f, p);
+    if (changed) {
+      out.push(
+        item(
+          f,
+          "edited",
+          f.module === "calendar" ? calendarDetail(f) : listDetail(f, p),
+          detectedAt,
+        ),
+      );
+    }
+  }
+
+  for (const key of Object.keys(prev)) {
+    if (fresh[key]) continue;
+    const p = prev[key];
+    if (!inWindow(p, overlap)) continue; // aged out below the sliding bottom edge — not a real remove
+    out.push(item(p, "removed", "", detectedAt));
+  }
+
+  return out;
+}

--- a/src/lib/home-activity/group.test.ts
+++ b/src/lib/home-activity/group.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { buildFeed } from "./group";
+import type { ActivityItem } from "./types";
+
+const cal = (over: Partial<ActivityItem>): ActivityItem => ({
+  storeKey: "calendar:e1",
+  module: "calendar",
+  kind: "added",
+  title: "Dentist",
+  detail: "Tue 9:00 AM",
+  detectedAt: 10,
+  ...over,
+});
+const lst = (over: Partial<ActivityItem>): ActivityItem => ({
+  storeKey: "lists:l1",
+  module: "lists",
+  kind: "edited",
+  title: "Groceries",
+  detail: "+3 items",
+  detectedAt: 20,
+  ...over,
+});
+
+describe("buildFeed", () => {
+  it("coalesces 2+ calendar changes into one expandable group", () => {
+    const feed = buildFeed(
+      [
+        cal({ storeKey: "calendar:a" }),
+        cal({ storeKey: "calendar:b", kind: "edited" }),
+      ],
+      0,
+      20,
+    );
+    const calGroup = feed.groups.find((g) => g.module === "calendar");
+    expect(calGroup?.summary).toMatch(/Calendar/);
+    expect(calGroup?.rows).toHaveLength(2);
+  });
+
+  it("renders a single calendar change directly (one row, no count summary)", () => {
+    const feed = buildFeed([cal({})], 0, 20);
+    const g = feed.groups[0];
+    expect(g.rows).toHaveLength(1);
+    expect(g.summary).toContain("Dentist");
+  });
+
+  it("collapses identical changes to a recurring series into one sub-row", () => {
+    const feed = buildFeed(
+      [
+        cal({
+          storeKey: "calendar:r_1",
+          recurringEventId: "r",
+          title: "Soccer",
+          kind: "edited",
+          detail: "5:00 PM",
+        }),
+        cal({
+          storeKey: "calendar:r_2",
+          recurringEventId: "r",
+          title: "Soccer",
+          kind: "edited",
+          detail: "5:00 PM",
+        }),
+      ],
+      0,
+      20,
+    );
+    const g = feed.groups.find((x) => x.module === "calendar");
+    expect(g?.rows).toHaveLength(1);
+  });
+
+  it("keeps DISTINCT changes to the same series as separate sub-rows", () => {
+    const feed = buildFeed(
+      [
+        cal({
+          storeKey: "calendar:r_1",
+          recurringEventId: "r",
+          title: "Soccer",
+          kind: "edited",
+          detail: "5:00 PM",
+        }),
+        cal({
+          storeKey: "calendar:r_2",
+          recurringEventId: "r",
+          title: "Soccer",
+          kind: "removed",
+          detail: "",
+        }),
+      ],
+      0,
+      20,
+    );
+    const g = feed.groups.find((x) => x.module === "calendar");
+    expect(g?.rows).toHaveLength(2); // different change signature → not collapsed
+  });
+
+  it("caps calendar sub-rows and reports per-group overflow", () => {
+    const many = Array.from({ length: 14 }, (_, i) =>
+      cal({ storeKey: `calendar:e${i}`, title: `Event ${i}`, detail: `d${i}` }),
+    );
+    const feed = buildFeed(many, 0, 20, 10); // subRowCap = 10
+    const g = feed.groups.find((x) => x.module === "calendar");
+    expect(g?.rows).toHaveLength(10);
+    expect(g?.rowsOverflow).toBe(4);
+    expect(g?.summary).toContain("14 added"); // count is over ALL items, not the shown 10
+  });
+
+  it("gives each changed list its own group", () => {
+    const feed = buildFeed(
+      [
+        lst({ storeKey: "lists:a" }),
+        lst({ storeKey: "lists:b", title: "Camping" }),
+      ],
+      0,
+      20,
+    );
+    expect(feed.groups.filter((g) => g.module === "lists")).toHaveLength(2);
+  });
+
+  it("orders newest-first and places the divider after the last 'new' group", () => {
+    const feed = buildFeed(
+      [cal({ detectedAt: 30 }), lst({ detectedAt: 10 })],
+      20,
+      20,
+    );
+    expect(feed.groups[0].newest).toBe(30); // calendar (new) first
+    expect(feed.dividerAfter).toBe(0); // divider after the one new group
+  });
+
+  it("omits the divider when everything is new or everything is earlier", () => {
+    expect(buildFeed([cal({ detectedAt: 30 })], 0, 20).dividerAfter).toBe(-1);
+    expect(buildFeed([cal({ detectedAt: 5 })], 20, 20).dividerAfter).toBe(-1);
+  });
+
+  it("caps groups and reports overflow", () => {
+    const many = Array.from({ length: 25 }, (_, i) =>
+      lst({ storeKey: `lists:${i}` }),
+    );
+    const feed = buildFeed(many, 0, 20);
+    expect(feed.groups).toHaveLength(20);
+    expect(feed.overflow).toBe(5);
+  });
+
+  it("summary counts all three kinds independently", () => {
+    const feed = buildFeed(
+      [
+        cal({ storeKey: "calendar:a", kind: "added" }),
+        cal({ storeKey: "calendar:b", kind: "edited" }),
+        cal({ storeKey: "calendar:c", kind: "removed" }),
+      ],
+      0,
+      20,
+    );
+    expect(feed.groups[0].summary).toBe(
+      "Calendar · 1 added, 1 changed, 1 removed",
+    );
+  });
+});

--- a/src/lib/home-activity/group.ts
+++ b/src/lib/home-activity/group.ts
@@ -1,0 +1,120 @@
+import type { ActivityItem, Feed, FeedGroup, FeedRow } from "./types";
+
+const MODULE_RANK: Record<string, number> = { calendar: 0, lists: 1 };
+
+function rowOf(i: ActivityItem): FeedRow {
+  return {
+    storeKey: i.storeKey,
+    kind: i.kind,
+    label: i.title,
+    detail: i.detail,
+    memberId: i.memberId,
+    module: i.module,
+    date: i.date,
+    entityId: i.entityId,
+  };
+}
+
+// Deterministic order: newest first, then title, then storeKey — so a same-cycle
+// batch (every delta shares detectedAt) never reshuffles between renders (§5).
+function byRecency(a: ActivityItem, b: ActivityItem): number {
+  return (
+    b.detectedAt - a.detectedAt ||
+    a.title.localeCompare(b.title) ||
+    a.storeKey.localeCompare(b.storeKey)
+  );
+}
+
+// One sub-row per distinct series change. The signature includes everything the
+// sub-row actually renders — kind, title (label), member (dot), detail — so two
+// instances collapse ONLY when they would display identically; any visible change
+// (retitle, reassignment, time move) stays a separate row (§4.2).
+function seriesSignature(i: ActivityItem): string | null {
+  return i.recurringEventId
+    ? `${i.recurringEventId}|${i.kind}|${i.title}|${i.memberId ?? ""}|${i.detail ?? ""}`
+    : null;
+}
+
+function calendarSummary(items: ActivityItem[]): string {
+  const added = items.filter((i) => i.kind === "added").length;
+  const changed = items.filter((i) => i.kind === "edited").length;
+  const removed = items.filter((i) => i.kind === "removed").length;
+  const parts: string[] = [];
+  if (added) parts.push(`${added} added`);
+  if (changed) parts.push(`${changed} changed`);
+  if (removed) parts.push(`${removed} removed`);
+  return `Calendar · ${parts.join(", ")}`;
+}
+
+export function buildFeed(
+  log: ActivityItem[],
+  lastSeen: number,
+  entryCap: number,
+  subRowCap: number = entryCap,
+): Feed {
+  // Calendar: collapse series by the full visible signature
+  // (recurringEventId, kind, title, memberId, detail), then group all calendar
+  // items together. Non-recurring events are never collapsed.
+  const seenSig = new Set<string>();
+  const calItems: ActivityItem[] = [];
+  for (const i of log.filter((x) => x.module === "calendar").sort(byRecency)) {
+    const sig = seriesSignature(i);
+    if (sig) {
+      if (seenSig.has(sig)) continue;
+      seenSig.add(sig);
+    }
+    calItems.push(i);
+  }
+
+  const groups: FeedGroup[] = [];
+  if (calItems.length === 1) {
+    const i = calItems[0];
+    groups.push({
+      id: "calendar",
+      module: "calendar",
+      summary: `${i.title}${i.detail ? ` · ${i.detail}` : ""}`,
+      rows: [rowOf(i)],
+      rowsOverflow: 0,
+      newest: i.detectedAt,
+    });
+  } else if (calItems.length > 1) {
+    const shown = calItems.slice(0, subRowCap);
+    groups.push({
+      id: "calendar",
+      module: "calendar",
+      summary: calendarSummary(calItems), // count over ALL items, not just the shown sub-rows
+      rows: shown.map(rowOf),
+      rowsOverflow: Math.max(0, calItems.length - subRowCap),
+      newest: Math.max(...calItems.map((i) => i.detectedAt)),
+    });
+  }
+
+  // Lists: one group per list.
+  for (const i of log.filter((x) => x.module === "lists")) {
+    groups.push({
+      id: i.storeKey,
+      module: "lists",
+      summary: `${i.title}${i.detail ? ` · ${i.detail}` : ""}`,
+      rows: [rowOf(i)],
+      rowsOverflow: 0,
+      newest: i.detectedAt,
+    });
+  }
+
+  groups.sort(
+    (a, b) =>
+      b.newest - a.newest ||
+      MODULE_RANK[a.module] - MODULE_RANK[b.module] ||
+      a.summary.localeCompare(b.summary) ||
+      a.id.localeCompare(b.id), // final tiebreak: group ids are unique → order never reshuffles between renders
+  );
+
+  const overflow = Math.max(0, groups.length - entryCap);
+  const capped = groups.slice(0, entryCap);
+
+  const newCount = capped.filter((g) => g.newest > lastSeen).length;
+  const dividerAfter =
+    newCount > 0 && newCount < capped.length ? newCount - 1 : -1;
+
+  return { groups: capped, dividerAfter, overflow };
+}

--- a/src/lib/home-activity/log.test.ts
+++ b/src/lib/home-activity/log.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { mergeLog, pruneLog, reconcileLog } from "./diff";
+import type { ActivityItem } from "./types";
+
+const mk = (over: Partial<ActivityItem>): ActivityItem => ({
+  storeKey: "calendar:e1",
+  module: "calendar",
+  kind: "edited",
+  title: "Soccer",
+  detail: "x",
+  detectedAt: 1,
+  ...over,
+});
+
+describe("mergeLog", () => {
+  it("coalesces repeated deltas for one key into the latest entry", () => {
+    const log = [mk({ kind: "edited", detail: "old", detectedAt: 1 })];
+    const next = mergeLog(log, [
+      mk({ kind: "edited", detail: "new", detectedAt: 5 }),
+    ]);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ detail: "new", detectedAt: 5 });
+  });
+
+  it("keeps 'added' when an add is later edited", () => {
+    const log = [mk({ kind: "added", detectedAt: 1 })];
+    const next = mergeLog(log, [mk({ kind: "edited", detectedAt: 2 })]);
+    expect(next[0].kind).toBe("added");
+  });
+
+  it("drops an unseen add that is later removed (net no-op)", () => {
+    const log = [mk({ kind: "added", detectedAt: 1 })];
+    expect(
+      mergeLog(log, [mk({ kind: "removed", detectedAt: 2 })]),
+    ).toHaveLength(0);
+  });
+
+  it("keeps 'removed' when a prior edit is later removed", () => {
+    const log = [mk({ kind: "edited", detectedAt: 1 })];
+    const next = mergeLog(log, [mk({ kind: "removed", detectedAt: 2 })]);
+    expect(next[0].kind).toBe("removed");
+  });
+
+  it("promotes 'removed' to 'added' when the same key is re-added", () => {
+    const log = [mk({ kind: "removed", detectedAt: 1 })];
+    const next = mergeLog(log, [mk({ kind: "added", detectedAt: 2 })]);
+    expect(next[0].kind).toBe("added");
+  });
+});
+
+describe("reconcileLog", () => {
+  it("drops a logged 'added' whose key is gone from fresh (phantom add)", () => {
+    const log = [mk({ kind: "added", storeKey: "calendar:e1" })];
+    expect(reconcileLog(log, new Set())).toHaveLength(0);
+  });
+
+  it("demotes a logged 'edited' to 'removed' when the key vanished", () => {
+    const log = [mk({ kind: "edited", storeKey: "calendar:e1" })];
+    const next = reconcileLog(log, new Set());
+    expect(next[0].kind).toBe("removed");
+  });
+
+  it("keeps entries whose key still exists", () => {
+    const log = [mk({ storeKey: "calendar:e1" })];
+    expect(reconcileLog(log, new Set(["calendar:e1"]))).toHaveLength(1);
+  });
+
+  it("preserves out-of-window calendar entries instead of dropping/demoting them", () => {
+    const window = { start: "2026-06-21", end: "2026-07-19" };
+    const log = [
+      mk({
+        kind: "added",
+        storeKey: "calendar:past",
+        module: "calendar",
+        date: "2026-06-01",
+      }), // below start
+      mk({
+        kind: "edited",
+        storeKey: "calendar:future",
+        module: "calendar",
+        date: "2026-12-31",
+      }), // above end
+    ];
+    const next = reconcileLog(log, new Set(), window); // neither key is in fresh (aged out)
+    expect(next).toHaveLength(2);
+    expect(next.map((i) => i.kind).sort()).toEqual(["added", "edited"]); // unchanged, not demoted
+  });
+
+  it("still drops/demotes an IN-window entry that genuinely vanished", () => {
+    const window = { start: "2026-06-21", end: "2026-07-19" };
+    const log = [
+      mk({
+        kind: "edited",
+        storeKey: "calendar:gone",
+        module: "calendar",
+        date: "2026-06-25",
+      }),
+    ];
+    expect(reconcileLog(log, new Set(), window)[0].kind).toBe("removed");
+  });
+
+  it("drops a vanished list 'added' (unwindowed)", () => {
+    const log = [mk({ kind: "added", storeKey: "lists:l1", module: "lists" })];
+    expect(reconcileLog(log, new Set())).toHaveLength(0);
+  });
+
+  it("demotes a vanished list 'edited' to 'removed'", () => {
+    const log = [mk({ kind: "edited", storeKey: "lists:l1", module: "lists" })];
+    expect(reconcileLog(log, new Set())[0].kind).toBe("removed");
+  });
+});
+
+describe("pruneLog", () => {
+  it("drops entries older than maxAge", () => {
+    const log = [
+      mk({ detectedAt: 0 }),
+      mk({ storeKey: "calendar:e2", detectedAt: 100 }),
+    ];
+    expect(pruneLog(log, 100, 50)).toHaveLength(1);
+    expect(pruneLog(log, 100, 50)[0].storeKey).toBe("calendar:e2");
+  });
+});

--- a/src/lib/home-activity/markers.test.ts
+++ b/src/lib/home-activity/markers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { MEANINGFUL_GAP_MS } from "./constants";
+import {
+  getHiddenAt,
+  getLastSeen,
+  isMeaningfulOpen,
+  setHiddenAt,
+  setLastSeen,
+} from "./markers";
+
+const day = (d: number) => new Date(2026, 5, d, 12, 0, 0).getTime();
+
+describe("isMeaningfulOpen", () => {
+  it("is true on cold start", () => {
+    expect(
+      isMeaningfulOpen({
+        coldStart: true,
+        now: day(1),
+        hiddenAt: day(1),
+        lastSeen: day(1),
+      }),
+    ).toBe(true);
+  });
+  it("is true when hidden longer than the gap", () => {
+    const now = day(1);
+    expect(
+      isMeaningfulOpen({
+        coldStart: false,
+        now,
+        hiddenAt: now - MEANINGFUL_GAP_MS - 1,
+        lastSeen: now - 10,
+      }),
+    ).toBe(true);
+  });
+  it("is true when the local day changed since lastSeen", () => {
+    expect(
+      isMeaningfulOpen({
+        coldStart: false,
+        now: day(2),
+        hiddenAt: day(2) - 1000,
+        lastSeen: day(1),
+      }),
+    ).toBe(true);
+  });
+  it("is false for a short same-day peek", () => {
+    const now = day(1);
+    expect(
+      isMeaningfulOpen({
+        coldStart: false,
+        now,
+        hiddenAt: now - 5000,
+        lastSeen: now - 6000,
+      }),
+    ).toBe(false);
+  });
+  it("is false when never hidden (hiddenAt=0) on the same day", () => {
+    const now = day(1);
+    // hiddenAt=0 must NOT read as "hidden for decades" → not meaningful.
+    expect(
+      isMeaningfulOpen({
+        coldStart: false,
+        now,
+        hiddenAt: 0,
+        lastSeen: now - 5000,
+      }),
+    ).toBe(false);
+  });
+  it("is false when hidden exactly at the gap boundary (> not >=)", () => {
+    const now = day(1);
+    expect(
+      isMeaningfulOpen({
+        coldStart: false,
+        now,
+        hiddenAt: now - MEANINGFUL_GAP_MS,
+        lastSeen: now - 10,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("marker persistence", () => {
+  it("defaults to 0 when unset and round-trips through localStorage", () => {
+    expect(getLastSeen()).toBe(0);
+    expect(getHiddenAt()).toBe(0);
+    setLastSeen(123);
+    setHiddenAt(456);
+    expect(getLastSeen()).toBe(123);
+    expect(getHiddenAt()).toBe(456);
+  });
+});

--- a/src/lib/home-activity/markers.ts
+++ b/src/lib/home-activity/markers.ts
@@ -1,0 +1,39 @@
+import { formatLocalDate } from "@/lib/time-utils";
+import { HIDDEN_AT_KEY, LAST_SEEN_KEY, MEANINGFUL_GAP_MS } from "./constants";
+
+export function isMeaningfulOpen(o: {
+  coldStart: boolean;
+  now: number;
+  hiddenAt: number;
+  lastSeen: number;
+}): boolean {
+  if (o.coldStart) return true;
+  // Require hiddenAt > 0: the default 0 means "never hidden", which would
+  // otherwise read as "hidden since 1970" and make every open meaningful.
+  if (o.hiddenAt > 0 && o.now - o.hiddenAt > MEANINGFUL_GAP_MS) return true;
+  return (
+    formatLocalDate(new Date(o.now)) !== formatLocalDate(new Date(o.lastSeen))
+  );
+}
+
+function readNum(key: string): number {
+  try {
+    const raw = localStorage.getItem(key);
+    const n = raw ? Number(raw) : 0;
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+function writeNum(key: string, value: number): void {
+  try {
+    localStorage.setItem(key, String(value));
+  } catch {
+    // storage unavailable (private mode / webview) — markers degrade to 0
+  }
+}
+
+export const getLastSeen = () => readNum(LAST_SEEN_KEY);
+export const setLastSeen = (v: number) => writeNum(LAST_SEEN_KEY, v);
+export const getHiddenAt = () => readNum(HIDDEN_AT_KEY);
+export const setHiddenAt = (v: number) => writeNum(HIDDEN_AT_KEY, v);

--- a/src/lib/home-activity/navigation.test.ts
+++ b/src/lib/home-activity/navigation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "@/lib/types";
+import { resolveFeedSelection } from "./navigation";
+
+describe("resolveFeedSelection", () => {
+  it("opens the list detail for a list row", () => {
+    expect(
+      resolveFeedSelection(
+        {
+          storeKey: "lists:l1",
+          module: "lists",
+          kind: "edited",
+          label: "x",
+          entityId: "l1",
+        },
+        [],
+      ),
+    ).toEqual({ type: "open-list", listId: "l1" });
+  });
+  it("opens the event sheet for an in-window calendar row", () => {
+    const ev = {
+      id: "e1",
+      title: "Dentist",
+      date: new Date(2026, 5, 23),
+    } as CalendarEvent;
+    const sel = resolveFeedSelection(
+      {
+        storeKey: "calendar:e1",
+        module: "calendar",
+        kind: "added",
+        label: "Dentist",
+      },
+      [ev],
+    );
+    expect(sel).toEqual({ type: "open-event", event: ev });
+  });
+  it("focuses the calendar date for an out-of-window calendar row", () => {
+    expect(
+      resolveFeedSelection(
+        {
+          storeKey: "calendar:e9",
+          module: "calendar",
+          kind: "added",
+          label: "Camp",
+          date: "2026-07-15",
+        },
+        [],
+      ),
+    ).toEqual({ type: "focus-calendar", date: "2026-07-15" });
+  });
+  it("does NOT open a deleted list — a removed list row lands on the Lists module", () => {
+    expect(
+      resolveFeedSelection(
+        {
+          storeKey: "lists:l1",
+          module: "lists",
+          kind: "removed",
+          label: "Old",
+          entityId: "l1",
+        },
+        [],
+      ),
+    ).toEqual({ type: "switch-module", module: "lists" });
+  });
+  it("a removed calendar row focuses its day, not a deleted event sheet", () => {
+    expect(
+      resolveFeedSelection(
+        {
+          storeKey: "calendar:e1",
+          module: "calendar",
+          kind: "removed",
+          label: "Gone",
+          date: "2026-06-23",
+        },
+        [{ id: "e1" } as CalendarEvent],
+      ),
+    ).toEqual({ type: "focus-calendar", date: "2026-06-23" });
+  });
+});

--- a/src/lib/home-activity/navigation.test.ts
+++ b/src/lib/home-activity/navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CalendarEvent } from "@/lib/types";
-import { resolveFeedSelection } from "./navigation";
+import { resolveFeedSelection, selectOpenableEvents } from "./navigation";
 
 describe("resolveFeedSelection", () => {
   it("opens the list detail for a list row", () => {
@@ -75,5 +75,40 @@ describe("resolveFeedSelection", () => {
         [{ id: "e1" } as CalendarEvent],
       ),
     ).toEqual({ type: "focus-calendar", date: "2026-06-23" });
+  });
+});
+
+describe("selectOpenableEvents", () => {
+  const now = new Date(2026, 5, 21, 12); // Jun 21, midday
+  const ev = (date: Date, over: Partial<CalendarEvent> = {}): CalendarEvent =>
+    ({ id: "e", title: "x", date, memberId: "m1", ...over }) as CalendarEvent;
+
+  it("keeps events from today through today+2 (the openable horizon)", () => {
+    const events = [
+      ev(new Date(2026, 5, 21)), // today
+      ev(new Date(2026, 5, 22)), // tomorrow
+      ev(new Date(2026, 5, 23)), // today+2
+    ];
+    expect(selectOpenableEvents(events, now)).toHaveLength(3);
+  });
+
+  it("drops events before today and beyond today+2", () => {
+    const events = [
+      ev(new Date(2026, 5, 20)), // yesterday
+      ev(new Date(2026, 5, 24)), // today+3
+    ];
+    expect(selectOpenableEvents(events, now)).toHaveLength(0);
+  });
+
+  it("is member-agnostic: keeps in-window events for ANY member (M1 regression guard)", () => {
+    const events = [
+      ev(new Date(2026, 5, 22), { id: "mom-evt", memberId: "mom" }),
+      ev(new Date(2026, 5, 22), { id: "dad-evt", memberId: "dad" }),
+    ];
+    expect(
+      selectOpenableEvents(events, now)
+        .map((e) => e.id)
+        .sort(),
+    ).toEqual(["dad-evt", "mom-evt"]);
   });
 });

--- a/src/lib/home-activity/navigation.ts
+++ b/src/lib/home-activity/navigation.ts
@@ -1,6 +1,29 @@
-import { getEventKey } from "@/lib/time-utils";
+import { addDays } from "date-fns";
+import { formatLocalDate, getEventKey } from "@/lib/time-utils";
 import type { CalendarEvent } from "@/lib/types";
+import { OPENABLE_WINDOW_DAYS } from "./constants";
 import type { FeedRow } from "./types";
+
+/**
+ * The family-wide set of events whose detail sheet a feed row may open directly:
+ * those falling within the openable horizon (today..today+OPENABLE_WINDOW_DAYS).
+ *
+ * This is intentionally NOT the dashboard agenda's member-filtered set: the
+ * activity feed is family-wide, so deep-linking an in-window row must succeed for
+ * any member's event regardless of which member is focused on Home (M1). Events
+ * outside the horizon fall through to focusing their day in resolveFeedSelection.
+ */
+export function selectOpenableEvents(
+  events: CalendarEvent[],
+  now: Date,
+): CalendarEvent[] {
+  const start = formatLocalDate(now);
+  const end = formatLocalDate(addDays(now, OPENABLE_WINDOW_DAYS));
+  return events.filter((e) => {
+    const date = formatLocalDate(e.date);
+    return date >= start && date <= end;
+  });
+}
 
 export type FeedSelection =
   | { type: "open-event"; event: CalendarEvent }

--- a/src/lib/home-activity/navigation.ts
+++ b/src/lib/home-activity/navigation.ts
@@ -1,0 +1,33 @@
+import { getEventKey } from "@/lib/time-utils";
+import type { CalendarEvent } from "@/lib/types";
+import type { FeedRow } from "./types";
+
+export type FeedSelection =
+  | { type: "open-event"; event: CalendarEvent }
+  | { type: "open-list"; listId: string }
+  | { type: "focus-calendar"; date: string }
+  | { type: "switch-module"; module: "calendar" | "lists" };
+
+export function resolveFeedSelection(
+  row: FeedRow,
+  inWindowEvents: CalendarEvent[],
+): FeedSelection {
+  if (row.module === "lists") {
+    // A removed list has no detail to open → land on the Lists module rather than
+    // request a deleted id (which would 404).
+    if (row.kind === "removed" || !row.entityId)
+      return { type: "switch-module", module: "lists" };
+    return { type: "open-list", listId: row.entityId };
+  }
+  // A removed calendar event's sheet is gone → focus its day (or the module).
+  if (row.kind === "removed") {
+    return row.date
+      ? { type: "focus-calendar", date: row.date }
+      : { type: "switch-module", module: "calendar" };
+  }
+  const key = row.storeKey.replace("calendar:", "");
+  const match = inWindowEvents.find((e) => getEventKey(e) === key);
+  if (match) return { type: "open-event", event: match };
+  if (row.date) return { type: "focus-calendar", date: row.date };
+  return { type: "switch-module", module: "calendar" };
+}

--- a/src/lib/home-activity/normalize.test.ts
+++ b/src/lib/home-activity/normalize.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent, ListSummary } from "@/lib/types";
+import { buildSnapshot } from "./normalize";
+
+const ev = (over: Partial<CalendarEvent>): CalendarEvent => ({
+  id: "e1",
+  title: "Dentist",
+  startTime: "9:00 AM",
+  endTime: "10:00 AM",
+  date: new Date(2026, 5, 23),
+  memberId: "m1",
+  isAllDay: false,
+  ...over,
+});
+const list = (over: Partial<ListSummary>): ListSummary => ({
+  id: "l1",
+  name: "Groceries",
+  kind: "grocery",
+  totalItems: 3,
+  completedItems: 1,
+  ...over,
+});
+
+describe("buildSnapshot", () => {
+  it("keys a regular event under calendar:<id> with watched fields", () => {
+    const snap = buildSnapshot([ev({})], []);
+    expect(snap["calendar:e1"]).toMatchObject({
+      module: "calendar",
+      title: "Dentist",
+      date: "2026-06-23",
+      memberId: "m1",
+    });
+  });
+
+  it("keys an expanded instance (id:null) by recurringEventId + date", () => {
+    const snap = buildSnapshot(
+      [ev({ id: null, recurringEventId: "r9", date: new Date(2026, 5, 24) })],
+      [],
+    );
+    expect(snap["calendar:r9_2026-06-24"]).toBeDefined();
+  });
+
+  it("keys a list under lists:<id> with counts", () => {
+    const snap = buildSnapshot([], [list({})]);
+    expect(snap["lists:l1"]).toMatchObject({
+      module: "lists",
+      title: "Groceries",
+      totalItems: 3,
+      completedItems: 1,
+    });
+  });
+
+  it("formats endDate and omits it when absent", () => {
+    const withEnd = buildSnapshot([ev({ endDate: new Date(2026, 5, 25) })], []);
+    expect(withEnd["calendar:e1"].endDate).toBe("2026-06-25");
+    const noEnd = buildSnapshot([ev({})], []);
+    expect(noEnd["calendar:e1"].endDate).toBeUndefined();
+  });
+});

--- a/src/lib/home-activity/normalize.ts
+++ b/src/lib/home-activity/normalize.ts
@@ -1,0 +1,42 @@
+import { formatLocalDate, getEventKey } from "@/lib/time-utils";
+import type { CalendarEvent, ListSummary } from "@/lib/types";
+import type { Snapshot } from "./types";
+
+export function buildSnapshot(
+  events: CalendarEvent[],
+  lists: ListSummary[],
+): Snapshot {
+  const snap: Snapshot = {};
+
+  for (const e of events) {
+    const storeKey = `calendar:${getEventKey(e)}`;
+    snap[storeKey] = {
+      storeKey,
+      module: "calendar",
+      title: e.title,
+      date: formatLocalDate(e.date),
+      startTime: e.startTime,
+      endTime: e.endTime,
+      endDate: e.endDate ? formatLocalDate(e.endDate) : undefined,
+      isAllDay: e.isAllDay,
+      location: e.location,
+      memberId: e.memberId,
+      recurringEventId: e.recurringEventId,
+      entityId: e.id,
+    };
+  }
+
+  for (const l of lists) {
+    const storeKey = `lists:${l.id}`;
+    snap[storeKey] = {
+      storeKey,
+      module: "lists",
+      title: l.name,
+      totalItems: l.totalItems,
+      completedItems: l.completedItems,
+      entityId: l.id,
+    };
+  }
+
+  return snap;
+}

--- a/src/lib/home-activity/store.test.ts
+++ b/src/lib/home-activity/store.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { getHiddenAt, getLastSeen, setHiddenAt, setLastSeen } from "./markers";
+import {
+  clearHomeActivity,
+  createHomeActivityStore,
+  type IdbKeyvalLike,
+} from "./store";
+import type { ActivityState } from "./types";
+
+function fakeIdb(): { idb: IdbKeyvalLike; store: Map<string, unknown> } {
+  const store = new Map<string, unknown>();
+  const idb: IdbKeyvalLike = {
+    createStore: vi.fn(() => ({}) as never),
+    get: vi.fn(async (k: IDBValidKey) => store.get(String(k)) as never),
+    set: vi.fn(
+      async (k: IDBValidKey, v: unknown) => void store.set(String(k), v),
+    ),
+    del: vi.fn(async (k: IDBValidKey) => void store.delete(String(k))),
+    clear: vi.fn(async () => store.clear()),
+  };
+  return { idb, store };
+}
+
+const state: ActivityState = {
+  snapshot: {
+    "lists:l1": { storeKey: "lists:l1", module: "lists", title: "Groceries" },
+  },
+  log: [],
+  snapshotSavedAt: 5,
+  eventWindow: { start: "2026-06-21", end: "2026-07-19" },
+};
+
+describe("createHomeActivityStore", () => {
+  it("round-trips state through idb", async () => {
+    const { idb } = fakeIdb();
+    const s = createHomeActivityStore(idb);
+    await s.saveState(state);
+    expect(await s.loadState()).toEqual(state);
+  });
+
+  it("returns null when nothing is stored", async () => {
+    const s = createHomeActivityStore(fakeIdb().idb);
+    expect(await s.loadState()).toBeNull();
+  });
+
+  it("clear wipes the store", async () => {
+    const { idb } = fakeIdb();
+    const s = createHomeActivityStore(idb);
+    await s.saveState(state);
+    await s.clear();
+    expect(await s.loadState()).toBeNull();
+  });
+
+  it("save and load are no-ops when IndexedDB is unavailable", async () => {
+    const brokenIdb: IdbKeyvalLike = {
+      ...fakeIdb().idb,
+      createStore: vi.fn(() => {
+        throw new Error("no idb");
+      }),
+    };
+    const s = createHomeActivityStore(brokenIdb);
+    await expect(s.saveState(state)).resolves.toBeUndefined();
+    await expect(s.loadState()).resolves.toBeNull();
+  });
+});
+
+describe("clearHomeActivity (singleton)", () => {
+  it("clears the localStorage markers, not only IndexedDB", async () => {
+    setLastSeen(123);
+    setHiddenAt(456);
+    await clearHomeActivity(); // jsdom has no indexedDB → the IDB clear no-ops via the guard
+    expect(getLastSeen()).toBe(0);
+    expect(getHiddenAt()).toBe(0);
+  });
+});

--- a/src/lib/home-activity/store.ts
+++ b/src/lib/home-activity/store.ts
@@ -1,0 +1,97 @@
+// Persists the home-activity snapshot + log to a dedicated IndexedDB database.
+// Mirrors the DI/guard shape of lib/offline/persister.ts — see that file for the
+// rationale behind injecting idb-keyval (setupFiles preload makes module-level
+// vi.mock unreliable). This store uses its OWN database (see ACTIVITY_DB_NAME).
+import { clear, createStore, del, get, set, type UseStore } from "idb-keyval";
+import {
+  ACTIVITY_DB_NAME,
+  ACTIVITY_STATE_KEY,
+  ACTIVITY_STORE_NAME,
+  HIDDEN_AT_KEY,
+  LAST_SEEN_KEY,
+} from "./constants";
+import type { ActivityState } from "./types";
+
+export interface IdbKeyvalLike {
+  createStore: typeof createStore;
+  get: typeof get;
+  set: typeof set;
+  del: typeof del;
+  clear: typeof clear;
+}
+
+const defaultIdb: IdbKeyvalLike = { createStore, get, set, del, clear };
+
+export interface HomeActivityStore {
+  loadState: () => Promise<ActivityState | null>;
+  saveState: (state: ActivityState) => Promise<void>;
+  clear: () => Promise<void>;
+}
+
+/** Create a home-activity store bound to the given idb-keyval implementation.
+ * Each instance memoises its own store handle, so injecting a fake yields a fully
+ * isolated store for tests. */
+export function createHomeActivityStore(
+  idb: IdbKeyvalLike = defaultIdb,
+): HomeActivityStore {
+  let cached: UseStore | null | undefined;
+  function getStore(): UseStore | null {
+    if (cached !== undefined) return cached;
+    try {
+      cached = idb.createStore(ACTIVITY_DB_NAME, ACTIVITY_STORE_NAME);
+    } catch {
+      cached = null;
+    }
+    return cached;
+  }
+
+  return {
+    async loadState() {
+      const s = getStore();
+      if (!s) return null;
+      try {
+        return (await idb.get<ActivityState>(ACTIVITY_STATE_KEY, s)) ?? null;
+      } catch {
+        return null;
+      }
+    },
+    async saveState(state) {
+      const s = getStore();
+      if (!s) return;
+      try {
+        await idb.set(ACTIVITY_STATE_KEY, state, s);
+      } catch {
+        // quota/blocked — best-effort
+      }
+    },
+    async clear() {
+      const s = getStore();
+      if (!s) return;
+      try {
+        await idb.clear(s);
+      } catch {
+        // nothing to leak if unavailable
+      }
+    },
+  };
+}
+
+const appStore = createHomeActivityStore();
+export const loadActivityState = () => appStore.loadState();
+export const saveActivityState = (state: ActivityState) =>
+  appStore.saveState(state);
+
+/** Wipe ALL persisted activity — the IndexedDB store AND both localStorage markers.
+ * Called from useLogout() and handleUnauthorized(); never rejects. Neither caller
+ * does a blanket localStorage.clear(), so clearing the markers here is what stops
+ * one account's divider baseline (lastSeen/hiddenAt) leaking to the next account on
+ * a shared device (spec §9). */
+export const clearHomeActivity = async (): Promise<void> => {
+  await appStore.clear(); // IndexedDB snapshot + log
+  try {
+    localStorage.removeItem(LAST_SEEN_KEY);
+    localStorage.removeItem(HIDDEN_AT_KEY);
+  } catch {
+    // storage unavailable (private mode / webview) — nothing persisted to leak
+  }
+};

--- a/src/lib/home-activity/types.ts
+++ b/src/lib/home-activity/types.ts
@@ -1,0 +1,79 @@
+export type ActivityModule = "calendar" | "lists";
+export type ActivityKind = "added" | "edited" | "removed";
+
+/** A comparable snapshot of one tracked entity. Stores every watched field so
+ * "edited" is a field compare (the backend exposes no updatedAt). */
+export interface SnapshotEntry {
+  storeKey: string; // `${module}:${entityKey}` — unique across modules
+  module: ActivityModule;
+  title: string;
+  // calendar fields (undefined for lists)
+  date?: string; // formatLocalDate(event.date)
+  startTime?: string;
+  endTime?: string;
+  endDate?: string;
+  isAllDay?: boolean;
+  location?: string;
+  memberId?: string;
+  recurringEventId?: string;
+  entityId?: string | null; // raw calendar id (may be null) / list id
+  // lists fields (undefined for calendar)
+  totalItems?: number;
+  completedItems?: number;
+}
+
+export type Snapshot = Record<string, SnapshotEntry>;
+
+export interface ActivityItem {
+  storeKey: string;
+  module: ActivityModule;
+  kind: ActivityKind;
+  title: string;
+  detail?: string;
+  memberId?: string;
+  recurringEventId?: string;
+  date?: string;
+  entityId?: string | null;
+  detectedAt: number;
+}
+
+/** The calendar query window the snapshot was captured under, as local-date
+ * strings. The window slides daily, so the diff only compares calendar entities
+ * within the overlap of the previous and current windows (§4.4). */
+export interface EventWindow {
+  start: string; // formatLocalDate(today)
+  end: string; // formatLocalDate(today + W)
+}
+
+export interface ActivityState {
+  snapshot: Snapshot;
+  log: ActivityItem[];
+  snapshotSavedAt: number;
+  eventWindow: EventWindow; // bounds the snapshot's calendar entities were captured under
+}
+
+export interface FeedRow {
+  storeKey: string;
+  kind: ActivityKind;
+  label: string; // "Dentist", "Groceries"
+  detail?: string; // "Tue 9:00 AM", "+3 items"
+  memberId?: string;
+  module: ActivityModule;
+  date?: string;
+  entityId?: string | null;
+}
+
+export interface FeedGroup {
+  id: string; // "calendar" or `lists:${listId}`
+  module: ActivityModule;
+  summary: string; // "Calendar · 2 added, 1 changed" | "Groceries · +3 items"
+  rows: FeedRow[]; // length 1 → render directly (no expander); >1 → expandable
+  rowsOverflow: number; // sub-rows beyond the calendar sub-row cap (for "and N more" inside the group)
+  newest: number; // max detectedAt in group (for ordering + divider placement)
+}
+
+export interface Feed {
+  groups: FeedGroup[];
+  dividerAfter: number; // index after which the "earlier" divider renders; -1 = no divider
+  overflow: number; // count beyond the cap (for "and N more")
+}

--- a/src/stores/app-store.test.ts
+++ b/src/stores/app-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { type MealType, type ModuleType, useAppStore } from "./app-store";
 
 describe("AppStore", () => {
@@ -130,6 +130,30 @@ describe("AppStore", () => {
 
       expect(useAppStore.getState().activeModule).toBe("chores");
       expect(useAppStore.getState().isSidebarOpen).toBe(true);
+    });
+  });
+
+  describe("navigation intents", () => {
+    beforeEach(() => {
+      useAppStore.setState({
+        listDetailIntent: null,
+        calendarFocusDate: null,
+        activeModule: null,
+      });
+    });
+    it("openListDetail sets the intent + switches to lists, and consume returns then clears it", () => {
+      useAppStore.getState().openListDetail("l1");
+      expect(useAppStore.getState().activeModule).toBe("lists");
+      expect(useAppStore.getState().consumeListDetailIntent()).toBe("l1");
+      expect(useAppStore.getState().consumeListDetailIntent()).toBeNull();
+    });
+    it("focusCalendarDate sets the date + switches to calendar, and consume returns then clears it", () => {
+      useAppStore.getState().focusCalendarDate("2026-07-15");
+      expect(useAppStore.getState().activeModule).toBe("calendar");
+      expect(useAppStore.getState().consumeCalendarFocusDate()).toBe(
+        "2026-07-15",
+      );
+      expect(useAppStore.getState().consumeCalendarFocusDate()).toBeNull();
     });
   });
 

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -31,6 +31,8 @@ interface AppState {
   isSidebarOpen: boolean;
   mealPlacementDraft: MealPlacementDraft | null;
   recipeCreationDraft: RecipeCreationDraft | null;
+  listDetailIntent: string | null;
+  calendarFocusDate: string | null;
 
   // Actions
   setActiveModule: (module: ModuleType | null) => void;
@@ -41,6 +43,10 @@ interface AppState {
   openSidebar: () => void;
   closeSidebar: () => void;
   toggleSidebar: () => void;
+  openListDetail: (listId: string) => void;
+  consumeListDetailIntent: () => string | null;
+  focusCalendarDate: (date: string) => void;
+  consumeCalendarFocusDate: () => string | null;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -49,6 +55,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   isSidebarOpen: false,
   mealPlacementDraft: null,
   recipeCreationDraft: null,
+  listDetailIntent: null,
+  calendarFocusDate: null,
 
   // Actions
   setActiveModule: (module) => set({ activeModule: module }),
@@ -70,4 +78,18 @@ export const useAppStore = create<AppState>((set, get) => ({
   closeSidebar: () => set({ isSidebarOpen: false }),
   toggleSidebar: () =>
     set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
+  openListDetail: (listId) =>
+    set({ listDetailIntent: listId, activeModule: "lists" }),
+  consumeListDetailIntent: () => {
+    const v = get().listDetailIntent;
+    set({ listDetailIntent: null });
+    return v;
+  },
+  focusCalendarDate: (date) =>
+    set({ calendarFocusDate: date, activeModule: "calendar" }),
+  consumeCalendarFocusDate: () => {
+    const v = get().calendarFocusDate;
+    set({ calendarFocusDate: null });
+    return v;
+  },
 }));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -101,6 +101,8 @@ function resetAllStores(): void {
     isSidebarOpen: false,
     mealPlacementDraft: null,
     recipeCreationDraft: null,
+    listDetailIntent: null,
+    calendarFocusDate: null,
   });
 
   // Reset auth store


### PR DESCRIPTION
Closes #239

## Story / Spec / Plan
- **Story:** https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/mobile-ux/home-organizer-summary.md
- **Spec:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-06-20-home-organizer-summary-design.md
- **Plan:** https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-06-21-home-organizer-summary.md

## Summary
Evolves the mobile Home from calendar-only "The Now" into an organizer summary **without redesigning the hero/agenda**. Two additions, both family-wide and mobile-only:

1. **State line** under the hero — chores remaining today + tonight's dinner (each segment omits when empty; the whole line omits when both are empty).
2. **"Since you last opened" activity feed** for **calendar + lists only** — coalesced, expandable, with a "new" divider, member-color dots, and entity deep-links.

Everything is **derived on-device via a client-side diff** behind a normalized `ActivityItem` seam — **no new backend endpoint, no new dependency**. A future `GET /api/activity` is a drop-in replacement for the source.

### Architecture
- `src/lib/home-activity/` — pure functions (`normalize` → `diff`/`mergeLog`/`reconcileLog`/`pruneLog` → `buildFeed`), a window-aware composite-keyed snapshot diff, the meaningful-open classifier, the deep-link resolver, and a dedicated `idb-keyval` store (its **own** database `family-hub-home-activity`, mirroring the FE #222 persister DI shape).
- `src/components/home/hooks/use-activity-feed.ts` — the orchestration hook: gates detection until both queries settle, serializes cycles through a promise-queue mutex, classifies meaningful opens against a cross-cycle frozen divider baseline, and refetches on return-to-visible before diffing.
- `src/components/home/components/` — `StateLine` + `ActivityFeed` (expand/collapse, divider, member dot, `usePressable`, reduced-motion-aware, `inert` collapsed sub-rows).
- Wired into `home-dashboard.tsx` behind a **synchronous `useIsMobile` child-component gate** (the organizer hooks never mount off-mobile); deep-links reuse the app-store navigation-intent pattern; `clearHomeActivity()` is awaited on logout + 401 before reload.

## Verification evidence (run fresh on `5afe708`)
| Gate | Result |
|------|--------|
| `npm run lint` | **exit 0** — 381 files checked, 0 errors (1 pre-existing `meals-view.tsx` warning in an untouched file) |
| `npm test -- --run` | **exit 0** — **121 files, 1135 tests passing** (baseline 1053 → +82 from this feature) |
| `npm run build` (`tsc -b` + Vite) | **exit 0** — `✓ built` (typecheck clean) |

Delivered TDD task-by-task (13 plan tasks, red→green→commit) with a spec-compliance review and a code-quality review per task plus a final whole-branch review. No backend work, no new dependency, no `fake-indexeddb` (IDB tested via Map-based DI fakes), dates device-local.

## Eight-item contract → code & tests

| # | Contract requirement | Code | Tests |
|---|---|---|---|
| **1** | Blend, mobile-only, no backend; hero/chips/agenda/"+" unchanged; feed = calendar + lists only; **synchronous** mobile gate via `useIsMobile` child components (hooks never mount off-mobile), not the desktop redirect | `home-dashboard.tsx` (`{isMobile && <StateLineSection/>}` / `<ActivityFeedSection/>`; hero/agenda untouched), `types.ts` (`ActivityModule = "calendar"\|"lists"`); no API service added | `home-dashboard.test.tsx` (feed mounts on mobile / **not** on desktop) |
| **2** | Dedicated IDB database `family-hub-home-activity`; `clearHomeActivity()` clears IDB **and** both markers, awaited in `useLogout()` **and** `handleUnauthorized()` before reload | `constants.ts` (`ACTIVITY_DB_NAME`), `store.ts` (`clearHomeActivity`), `use-auth.ts`, `http-client.ts` | `store.test.ts` (round-trip/clear/markers), `use-auth.test.tsx` + `http-client.test.ts` (`invocationCallOrder`: offline < activity < reload) |
| **3** | Gated until both queries settle (stable `EMPTY_*`); promise-queue **mutex**; meaningful open advances divider only on cold-start/return-to-visible; cross-cycle frozen baseline; `hiddenAt > 0` gate; refetch both before diffing | `use-activity-feed.ts` (`settled`, `queueRef`, `displayBaselineRef`, `refetchRef`), `markers.ts` (`isMeaningfulOpen`) | `use-activity-feed.test.tsx` (gate, no-advance-on-background, frozen baseline, refetch-ordering, serialized writes, hide records `hiddenAt`), `markers.test.ts` |
| **4** | Window-bounds-aware **diff AND reconcile** (snapshot stores its window; aged-out events neither reported nor dropped); composite key via `getEventKey` | `diff.ts` (`inWindow` in `diffSnapshots` + window-aware `reconcileLog`), `types.ts` (`EventWindow`), `use-activity-feed.ts` (`overlapOf`), `normalize.ts` | `diff.test.ts` (window-edge churn), `log.test.ts` (out-of-window preserved; in-window dropped/demoted) |
| **5** | Lists = summary signals only (created/renamed/removed + `+N items`/`N checked off`/`N removed`); no per-item diff; bare un-check suppressed; recurring collapse by `(recurringEventId, kind, title, memberId, detail)` | `diff.ts` (`listChanged`/`listDetail`), `group.ts` (`seriesSignature`, one group per list) | `diff.test.ts` (count deltas, un-check suppressed, "New list"), `group.test.ts` (identical vs distinct series) |
| **6** | Entity deep-links via app-store intent pattern; in-window → `handleEventClick`; out-of-window → focus date; **removed rows never deep-link to the deleted entity** | `navigation.ts` (`resolveFeedSelection`), `app-store.ts` (`openListDetail`/`focusCalendarDate` + consumers), `lists-view.tsx`, `calendar-module.tsx`, `home-dashboard.tsx` (`handleSelect`) | `navigation.test.ts` (5 cases incl. removed-list/event), `app-store.test.ts` |
| **7** | No new tokens; reuse motion; every row `usePressable` + `min-h-11`; member dot `colorMap[member.color].hex` via `useFamilyMemberMap`; reduced-motion opacity-only; collapsed sub-rows `inert`+`aria-hidden`; ephemeral expansion | `activity-feed.tsx` (pressable rows, `min-h-11`, `motion-safe` height + opacity, `inert`, `meaningfulOpenId` remount), `home-dashboard.tsx` (`memberColorOf`), `state-line.tsx` | `activity-feed.test.tsx` (aria-expanded/tabindex, member dot, epoch collapse, empty state, row select), `state-line.test.tsx` |
| **8** | Reuse existing helpers/DI/draft pattern; **no new dependency**; device-local dates; new `useAppStore` intent fields added to `resetAllStores()`; lint + test + build green | reuses `getEventKey`/`formatLocalDate`/`getWeekStartSunday`/`parseLocalDate`/`usePressable`/`useFamilyMemberMap`/persister DI/app-store drafts; `setup.ts` reset; `package.json`/`package-lock.json` unchanged | `store.test.ts` (Map DI fake, no `fake-indexeddb`); full suite + lint + build green (above) |

## Test plan
- [ ] Mobile home: state line shows chores/dinner when present; making a list change on another device and returning to Home surfaces it under "Since you last opened" (visibility handler refetches).
- [ ] A quick background→foreground (peek) does **not** advance the "new" divider; a real return after the gap does.
- [ ] Expanding a calendar group then backgrounding/foregrounding collapses it again (ephemeral).
- [ ] Tapping a list row opens that list's detail; an out-of-window calendar row focuses its day; a removed row does not 404.
- [ ] Desktop/tablet: the state line + feed do not render.
- [ ] Logging out (or a 401) clears the feed for the next account on a shared device.
