### PR TITLE
fix(meals): send the remove-slot payload in the DELETE request body

### DIFF
--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
@@ -6,6 +6,22 @@ import {
   waitForHydration,
   waitForSheetSettled,
 } from "./helpers/test-helpers";
+
+/**
+ * Navigate to the weekly Meals board via the bottom-nav "More" sheet. The active
+ * view is not persisted, so this is re-run after a reload to return to Meals.
+ */
+async function openMealsBoard(page: Page) {
+  const nav = page.getByRole("navigation", { name: /primary/i });
+  await safeClick(nav.getByRole("button", { name: "More" }));
+  const moreSheet = page.getByRole("dialog", { name: "More" });
+  await waitForSheetSettled(moreSheet);
+  await safeClick(moreSheet.getByRole("button", { name: "Meals" }));
+  await expect(moreSheet).toBeHidden();
+  await expect(
+    page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+  ).toBeVisible();
+}
 
 test.describe("Mobile Meals", () => {
   test.beforeEach(async ({ page, isMobile }) => {
@@ -116,5 +132,66 @@ test.describe("Mobile Meals", () => {
     await expect(
       page.getByRole("button", { name: /open lunch: sunday pancakes/i }),
     ).toBeVisible();
+  });
+
+  test("removes a planned meal and it stays removed after a board reload", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Meal Removers",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+
+    // Plan a quick dinner so there is a populated slot to remove.
+    await safeClick(
+      page.getByRole("button", { name: "Add dinner meal" }).first(),
+    );
+    const planSheet = page.getByRole("dialog", { name: "Plan Dinner" });
+    await waitForSheetSettled(planSheet);
+    await planSheet.getByLabel("Meal name").fill("Leftovers");
+    await planSheet.getByRole("button", { name: "Create quick meal" }).click();
+
+    await expect(planSheet).toBeHidden();
+    const plannedMeal = page.getByRole("button", {
+      name: /open dinner: leftovers/i,
+    });
+    await expect(plannedMeal).toBeVisible();
+
+    // Remove it from the editor.
+    await safeClick(plannedMeal.first());
+    const editorSheet = page.getByRole("dialog", { name: "Dinner Plan" });
+    await waitForSheetSettled(editorSheet);
+    await editorSheet.getByRole("button", { name: "Remove meal" }).click();
+
+    // The editor closes only after a successful removal, and the slot is empty.
+    await expect(editorSheet).toBeHidden();
+    await expect(
+      page.getByRole("button", { name: "Add dinner meal" }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /open dinner: leftovers/i }),
+    ).toBeHidden();
+
+    // Reload to force a fresh board fetch from the backend. The removal persisted
+    // only if the DELETE used the backend's request-body contract.
+    await page.reload();
+    await waitForHydration(page);
+    await openMealsBoard(page);
+
+    await expect(
+      page.getByRole("button", { name: "Add dinner meal" }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /open dinner: leftovers/i }),
+    ).toBeHidden();
   });
 });

--- a/src/api/hooks/use-meals.test.tsx
+++ b/src/api/hooks/use-meals.test.tsx
@@ -320,6 +320,60 @@ describe("useMeals", () => {
     ).toBe(true);
   });
 
+  it("clears the primary, extras, and note in the cached board after removal", async () => {
+    const board = structuredClone(emptyBoard);
+    board.days[3].slots[2] = {
+      id: "slot-wednesday-dinner",
+      weekStartDate: "2026-06-07",
+      dayIndex: 3,
+      mealType: "dinner",
+      primary: {
+        id: "entry-primary",
+        role: "primary",
+        sourceType: "quick",
+        recipeId: null,
+        title: "Roast Chicken",
+        imageUrl: null,
+        note: null,
+      },
+      extras: [
+        {
+          id: "entry-extra",
+          role: "extra",
+          sourceType: "quick",
+          recipeId: null,
+          title: "Garlic Bread",
+          imageUrl: null,
+          note: null,
+        },
+      ],
+      note: "Preheat oven to 220C",
+    };
+    seedMockMealsBoard(board);
+    queryClient.setQueryData(mealsKeys.board("2026-06-07"), {
+      data: board,
+    } satisfies ApiResponse<MealBoard>);
+
+    const { result } = renderHook(() => useRemoveMealSlot(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      weekStartDate: "2026-06-07",
+      dayIndex: 3,
+      mealType: "dinner",
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const cachedDinner = queryClient.getQueryData<ApiResponse<MealBoard>>(
+      mealsKeys.board("2026-06-07"),
+    )?.data.days[3].slots[2];
+    expect(cachedDinner?.primary).toBe(null);
+    expect(cachedDinner?.extras).toEqual([]);
+    expect(cachedDinner?.note).toBe(null);
+  });
+
   it("moves a Saturday meal to Sunday of the following week", async () => {
     const saturdayBoard: MealBoard = structuredClone(emptyBoard);
     saturdayBoard.days[6].slots[2] = {

--- a/src/api/services/meals.service.test.ts
+++ b/src/api/services/meals.service.test.ts
@@ -1,0 +1,66 @@
+import { HttpResponse, http } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import type { RemoveMealSlotRequest } from "@/lib/types";
+import { API_BASE, server } from "@/test/mocks/server";
+import { mealsService } from "./meals.service";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("mealsService.removeSlot", () => {
+  /**
+   * Capture the raw outgoing DELETE so we can assert the wire contract directly,
+   * independent of the shared handler. The body is read as text (not json) so an
+   * empty body — the regression we are guarding against — is observable rather
+   * than throwing inside the handler.
+   */
+  function captureDeleteRequest() {
+    const captured = { body: "", url: "" };
+    server.use(
+      http.delete(`${API_BASE}/meals/slots`, async ({ request }) => {
+        captured.url = request.url;
+        captured.body = await request.text();
+        return HttpResponse.json({
+          data: { weekStartDate: "2026-06-07", days: [] },
+          message: "Meal slot removed successfully",
+        });
+      }),
+    );
+    return captured;
+  }
+
+  it("sends the RemoveMealSlotRequest as the DELETE JSON body, not query params", async () => {
+    const captured = captureDeleteRequest();
+    const request: RemoveMealSlotRequest = {
+      weekStartDate: "2026-06-07",
+      dayIndex: 1,
+      mealType: "dinner",
+    };
+
+    await mealsService.removeSlot(request);
+
+    // The released backend reads a @RequestBody — the payload must travel as the
+    // JSON body, never as query parameters.
+    expect(captured.body).not.toBe("");
+    expect(JSON.parse(captured.body)).toEqual(request);
+
+    const url = new URL(captured.url);
+    expect(url.searchParams.get("weekStartDate")).toBeNull();
+    expect(url.searchParams.get("dayIndex")).toBeNull();
+    expect(url.searchParams.get("mealType")).toBeNull();
+  });
+
+  it("keeps dayIndex 0 (Sunday) in the JSON body", async () => {
+    const captured = captureDeleteRequest();
+    const request: RemoveMealSlotRequest = {
+      weekStartDate: "2026-06-07",
+      dayIndex: 0,
+      mealType: "breakfast",
+    };
+
+    await mealsService.removeSlot(request);
+
+    expect(JSON.parse(captured.body)).toEqual(request);
+  });
+});

--- a/src/api/services/meals.service.ts
+++ b/src/api/services/meals.service.ts
@@ -33,12 +33,6 @@ export const mealsService = {
   },
 
   removeSlot(request: RemoveMealSlotRequest): Promise<MealBoardApiResponse> {
-    return httpClient.delete<MealBoardApiResponse>("/meals/slots", undefined, {
-      params: {
-        weekStartDate: request.weekStartDate,
-        dayIndex: request.dayIndex,
-        mealType: request.mealType,
-      },
-    });
+    return httpClient.delete<MealBoardApiResponse>("/meals/slots", request);
   },
 };

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -362,6 +362,68 @@ describe("MealsView", () => {
     });
   });
 
+  it("closes the editor only after a successful removal", async () => {
+    const board = createOccupiedMealsBoard();
+    seedMockMealsBoard(board);
+    const onOpenChange = vi.fn();
+    const { user } = renderWithUser(
+      <MealEditorSheet
+        isOpen
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
+        board={board}
+        readOnly={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    // The editor is not dismissed before the removal is requested.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByRole("button", { name: "Remove meal" }));
+
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("keeps the editor open with an actionable error when removal fails", async () => {
+    const board = createOccupiedMealsBoard();
+    seedMockMealsBoard(board);
+    server.use(
+      http.delete(`${API_BASE}/meals/slots`, () =>
+        HttpResponse.json(
+          { message: "Could not remove meal" },
+          { status: 500 },
+        ),
+      ),
+    );
+    const onOpenChange = vi.fn();
+    const { user } = renderWithUser(
+      <MealEditorSheet
+        isOpen
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
+        board={board}
+        readOnly={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Remove meal" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Could not remove meal");
+
+    // Failure leaves the editor open and the action retryable.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(screen.getByRole("button", { name: "Remove meal" })).toBeEnabled();
+  });
+
   it("edits the slot note from the editor", async () => {
     const board = createOccupiedMealsBoard();
     seedMockMealsBoard(board);

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -33,6 +33,7 @@ import type {
   RecipeSummary,
   RegisterRequest,
   RegisterResponse,
+  RemoveMealSlotRequest,
   UpdateChoreTemplateRequest,
   UpdateCurrentPeriodCompletionRequest,
   UpdateEventRequest,
@@ -839,21 +840,34 @@ export const handlers = [
     );
   }),
 
-  // DELETE /meals/slots - Remove one planned slot
-  http.delete(`${API_BASE}/meals/slots`, ({ request }) => {
-    const url = new URL(request.url);
-    const weekStartDate = url.searchParams.get("weekStartDate");
-    const dayIndexStr = url.searchParams.get("dayIndex");
-    const mealType = url.searchParams.get("mealType") as MealType | null;
+  // DELETE /meals/slots - Remove one planned slot.
+  // Mirrors the released backend: the payload is a validated @RequestBody, not
+  // query parameters. An absent or malformed body is a 400, exactly as
+  // production rejects it.
+  http.delete(`${API_BASE}/meals/slots`, async ({ request }) => {
+    let body: Partial<RemoveMealSlotRequest> | null = null;
+    try {
+      body = (await request.json()) as RemoveMealSlotRequest;
+    } catch {
+      body = null;
+    }
 
-    if (!weekStartDate || !dayIndexStr || !mealType) {
+    const weekStartDate = body?.weekStartDate;
+    const dayIndex = body?.dayIndex;
+    const mealType = body?.mealType;
+
+    if (
+      !weekStartDate ||
+      dayIndex === undefined ||
+      dayIndex === null ||
+      !mealType
+    ) {
       return HttpResponse.json(
         { message: "weekStartDate, dayIndex, and mealType are required" },
         { status: 400 },
       );
     }
 
-    const dayIndex = parseInt(dayIndexStr, 10);
     const board = getMealsBoard(weekStartDate);
     const slot = findMealSlot(board, dayIndex, mealType);
     setMealSlot(board, clearMealSlot(slot));


### PR DESCRIPTION
Closes #250

## Problem
Tapping **Remove meal** did nothing against the real backend. The frontend sent `weekStartDate`/`dayIndex`/`mealType` as **query parameters with an empty body**, but the released `MealController.removeSlot` reads a validated `@RequestBody RemoveMealSlotRequest`. The MSW mock mirrored the same wrong query-parameter shape, so unit tests passed while production returned **400 Bad Request** and the slot stayed planned.

## Fix
- `mealsService.removeSlot` now sends the `RemoveMealSlotRequest` as the DELETE JSON body (`httpClient.delete("/meals/slots", request)`).
- The MSW DELETE handler reads and validates the JSON body, matching the released contract (an absent/malformed body is a 400, exactly like production).

No hook or editor change was needed: the success path already caches the server-returned board (clearing primary/extras/note) and closes the editor only on success — those behaviors were correct once the wire contract was honored. Tests now lock them.

## Acceptance criteria → code/tests
| Criterion | Where |
|---|---|
| `removeSlot` sends the payload as the DELETE JSON body | `src/api/services/meals.service.ts` + `meals.service.test.ts` |
| MSW DELETE reads/validates the JSON body | `src/test/mocks/handlers.ts` |
| Service/hook tests fail if reverted to query params | `meals.service.test.ts` (asserts body **and** no query params); `use-meals.test.tsx` (mutation 400s → never succeeds) |
| Cache clears primary, extras, and note on success | `use-meals.test.tsx` |
| Editor closes only after success; failures stay visible/actionable | `meals-view.test.tsx` (close-on-success + stays-open-with-`alert`) |
| Mobile E2E: removed meal stays removed after a reload | `e2e/mobile-meals.spec.ts` |

## Verification
- Unit: **1145 passed**; Biome lint clean; `tsc`/build clean.
- E2E run against the released backend (`ghcr.io/joe-bor/family-hub-api:1.6.0`, the tag CI resolves): the new mobile test **passes with the fix** and **fails without it** — the editor stays open showing `alert: Bad Request` and the meal survives the reload, proving the test catches exactly this regression.