### PR TITLE
fix(chores): optimistically update current-period completion

### DIFF
--- a/e2e/mobile-chores.spec.ts
+++ b/e2e/mobile-chores.spec.ts
@@ -68,4 +68,89 @@ test.describe("Mobile Chores", () => {
     await expect(row).toBeHidden();
     await expect(page.getByText("No recurring chores yet")).toBeVisible();
   });
+
+  test("completing a chore updates immediately and persists after reload", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "Optimistic Chore Family",
+      members: [{ name: "Leo", color: "coral" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    const nav = page.getByRole("navigation", { name: /primary/i });
+    await nav.getByRole("button", { name: "Chores" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Chores", level: 1 }),
+    ).toBeVisible();
+
+    // A daily routine lands in the default Today column, so no scope switch.
+    await page.getByRole("button", { name: "Add recurring chore" }).click();
+    const dialog = page.getByRole("dialog", { name: "New Chore" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/chore name/i).fill("Feed the cat");
+    await dialog.getByRole("button", { name: "Daily" }).click();
+    await dialog.getByRole("button", { name: "Save Chore" }).click();
+    await expect(dialog).toBeHidden();
+
+    const row = page
+      .locator('[data-testid^="chore-row-"]')
+      .filter({ hasText: "Feed the cat" })
+      .first();
+    await expect(row).toBeVisible();
+    await expect(row.locator("p").first()).not.toHaveClass(/line-through/);
+
+    // Hold the completion response open: for the next ~2.5s the only thing that
+    // can flip the row to "done" is the optimistic cache update, not the server.
+    await page.route(
+      "**/chores/templates/*/current-period-completion",
+      async (route) => {
+        if (route.request().method() === "PUT") {
+          await new Promise((resolve) => setTimeout(resolve, 2500));
+        }
+        await route.continue();
+      },
+    );
+    const completionPersisted = page.waitForResponse(
+      (response) =>
+        response.url().includes("current-period-completion") &&
+        response.request().method() === "PUT",
+    );
+
+    await page
+      .getByRole("button", { name: /mark feed the cat complete/i })
+      .click();
+
+    // Immediate acknowledgment: the strikethrough shows well before the delayed
+    // response. Without the optimistic update this assertion would time out.
+    await expect(row.locator("p").first()).toHaveClass(/line-through/, {
+      timeout: 1200,
+    });
+
+    // Let the real request settle so the completion is persisted server-side.
+    await completionPersisted;
+    await page.unroute("**/chores/templates/*/current-period-completion");
+
+    // Eventual persistence: a fresh load from the backend still shows it done.
+    // Reload drops back to the default view, so re-open Chores before asserting.
+    await page.reload();
+    await waitForHydration(page);
+    await page
+      .getByRole("navigation", { name: /primary/i })
+      .getByRole("button", { name: "Chores" })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: "Chores", level: 1 }),
+    ).toBeVisible();
+
+    const reloadedRow = page
+      .locator('[data-testid^="chore-row-"]')
+      .filter({ hasText: "Feed the cat" })
+      .first();
+    await expect(reloadedRow.locator("p").first()).toHaveClass(/line-through/);
+  });
 });

--- a/src/api/hooks/use-chores.test.tsx
+++ b/src/api/hooks/use-chores.test.tsx
@@ -43,6 +43,21 @@ function createCacheQueryClient() {
   });
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+// Lets a test hold a mock response open so the optimistic window (after
+// onMutate, before onSuccess/onError) can be observed deterministically.
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createBoardItem(
   overrides: Partial<ChoreBoardItem> & Pick<ChoreBoardItem, "templateId">,
 ): ChoreBoardItem {
@@ -363,6 +378,291 @@ describe("useChores hooks", () => {
         .getQueryData<ApiResponse<ChoresBoard>>(choreKeys.board())
         ?.data.today.assignees[0].chores.map((chore) => chore.templateId),
     ).toEqual(["second-id", "first-id"]);
+  });
+
+  it("optimistically completes a routine in the board cache before the server responds", async () => {
+    const queryClient = createCacheQueryClient();
+    const board = sampleBoardWithTodayChores([
+      createBoardItem({ templateId: "first-id", title: "First routine" }),
+      createBoardItem({ templateId: "second-id", title: "Second routine" }),
+    ]);
+    queryClient.setQueryData<ApiResponse<ChoresBoard>>(choreKeys.board(), {
+      data: board,
+    });
+
+    const gate = deferred();
+    server.use(
+      http.put(
+        `${API_BASE}/chores/templates/first-id/current-period-completion`,
+        async () => {
+          await gate.promise;
+          return HttpResponse.json({
+            data: {
+              scope: "TODAY",
+              periodStartDate: "2026-05-17",
+              periodEndDate: "2026-05-17",
+              item: createBoardItem({
+                templateId: "first-id",
+                title: "First routine",
+                completed: true,
+                completedAt: "2026-05-17T09:15:00Z",
+              }),
+            },
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useCompleteChoreForCurrentPeriod(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      templateId: "first-id",
+      request: { scope: "TODAY", periodStartDate: "2026-05-17" },
+    });
+
+    // Optimistic window: the board reflects completion, reordering, and updated
+    // counts while the request is still in flight (gate unresolved).
+    await waitFor(() => {
+      const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      )?.data.today;
+      expect(
+        today?.assignees[0].chores.map((chore) => chore.templateId),
+      ).toEqual(["second-id", "first-id"]);
+      expect(
+        today?.assignees[0].chores.find(
+          (chore) => chore.templateId === "first-id",
+        )?.completed,
+      ).toBe(true);
+      expect(today?.summary).toEqual({ total: 2, completed: 1, remaining: 1 });
+      expect(today?.assignees[0].summary).toEqual({
+        total: 2,
+        completed: 1,
+        remaining: 1,
+      });
+    });
+    expect(result.current.isSuccess).toBe(false);
+
+    // Reconciliation: the server response replaces the synthesized optimistic
+    // state with canonical fields (the real completedAt).
+    gate.resolve();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(
+      queryClient
+        .getQueryData<ApiResponse<ChoresBoard>>(choreKeys.board())
+        ?.data.today.assignees[0].chores.find(
+          (chore) => chore.templateId === "first-id",
+        )?.completedAt,
+    ).toBe("2026-05-17T09:15:00Z");
+  });
+
+  it("optimistically uncompletes a routine in the board cache before the server responds", async () => {
+    const queryClient = createCacheQueryClient();
+    const board = sampleBoardWithTodayChores([
+      createBoardItem({
+        templateId: "first-id",
+        title: "First routine",
+        completed: true,
+        completedAt: "2026-05-17T09:15:00Z",
+      }),
+      createBoardItem({
+        templateId: "second-id",
+        title: "Second routine",
+        completed: true,
+        completedAt: "2026-05-17T09:20:00Z",
+      }),
+    ]);
+    queryClient.setQueryData<ApiResponse<ChoresBoard>>(choreKeys.board(), {
+      data: board,
+    });
+
+    const gate = deferred();
+    server.use(
+      http.delete(
+        `${API_BASE}/chores/templates/second-id/current-period-completion`,
+        async () => {
+          await gate.promise;
+          return HttpResponse.json({
+            data: {
+              scope: "TODAY",
+              periodStartDate: "2026-05-17",
+              periodEndDate: "2026-05-17",
+              item: createBoardItem({
+                templateId: "second-id",
+                title: "Second routine",
+                completed: false,
+              }),
+            },
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useUncompleteChoreForCurrentPeriod(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      templateId: "second-id",
+      request: { scope: "TODAY", periodStartDate: "2026-05-17" },
+    });
+
+    await waitFor(() => {
+      const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      )?.data.today;
+      expect(
+        today?.assignees[0].chores.map((chore) => chore.templateId),
+      ).toEqual(["second-id", "first-id"]);
+      const second = today?.assignees[0].chores.find(
+        (chore) => chore.templateId === "second-id",
+      );
+      expect(second?.completed).toBe(false);
+      expect(second?.completedAt).toBeNull();
+      expect(today?.summary).toEqual({ total: 2, completed: 1, remaining: 1 });
+    });
+    expect(result.current.isSuccess).toBe(false);
+
+    gate.resolve();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it("rolls the entire board back to its previous state when completion fails", async () => {
+    const queryClient = createCacheQueryClient();
+    const board = sampleBoardWithTodayChores([
+      createBoardItem({ templateId: "first-id", title: "First routine" }),
+      createBoardItem({ templateId: "second-id", title: "Second routine" }),
+    ]);
+    queryClient.setQueryData<ApiResponse<ChoresBoard>>(choreKeys.board(), {
+      data: board,
+    });
+
+    const gate = deferred();
+    server.use(
+      http.put(
+        `${API_BASE}/chores/templates/first-id/current-period-completion`,
+        async () => {
+          await gate.promise;
+          return HttpResponse.json(
+            { message: "Server error" },
+            { status: 500 },
+          );
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useCompleteChoreForCurrentPeriod(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    result.current.mutate({
+      templateId: "first-id",
+      request: { scope: "TODAY", periodStartDate: "2026-05-17" },
+    });
+
+    // The optimistic completion lands first...
+    await waitFor(() => {
+      const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      )?.data.today;
+      expect(
+        today?.assignees[0].chores.map((chore) => chore.templateId),
+      ).toEqual(["second-id", "first-id"]);
+      expect(
+        today?.assignees[0].chores.find(
+          (chore) => chore.templateId === "first-id",
+        )?.completed,
+      ).toBe(true);
+    });
+
+    // ...then the failure rolls the whole board back to the pre-tap snapshot.
+    gate.resolve();
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+      choreKeys.board(),
+    )?.data.today;
+    expect(today?.assignees[0].chores.map((chore) => chore.templateId)).toEqual(
+      ["first-id", "second-id"],
+    );
+    expect(today?.assignees[0].chores.every((chore) => !chore.completed)).toBe(
+      true,
+    );
+    expect(today?.summary).toEqual({ total: 2, completed: 0, remaining: 2 });
+  });
+
+  it("keeps the board consistent under rapid repeated completion taps", async () => {
+    const queryClient = createCacheQueryClient();
+    const board = sampleBoardWithTodayChores([
+      createBoardItem({ templateId: "first-id", title: "First routine" }),
+    ]);
+    queryClient.setQueryData<ApiResponse<ChoresBoard>>(choreKeys.board(), {
+      data: board,
+    });
+
+    const gate = deferred();
+    server.use(
+      http.put(
+        `${API_BASE}/chores/templates/first-id/current-period-completion`,
+        async () => {
+          await gate.promise;
+          return HttpResponse.json({
+            data: {
+              scope: "TODAY",
+              periodStartDate: "2026-05-17",
+              periodEndDate: "2026-05-17",
+              item: createBoardItem({
+                templateId: "first-id",
+                title: "First routine",
+                completed: true,
+                completedAt: "2026-05-17T09:15:00Z",
+              }),
+            },
+          });
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useCompleteChoreForCurrentPeriod(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const variables = {
+      templateId: "first-id",
+      request: { scope: "TODAY" as const, periodStartDate: "2026-05-17" },
+    };
+    result.current.mutate(variables);
+    result.current.mutate(variables);
+    result.current.mutate(variables);
+
+    // Overlapping optimistic updates must not duplicate the routine or
+    // double-count the summary while the requests are in flight.
+    await waitFor(() => {
+      const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      )?.data.today;
+      expect(today?.assignees[0].chores).toHaveLength(1);
+      expect(today?.assignees[0].chores[0].completed).toBe(true);
+      expect(today?.summary).toEqual({ total: 1, completed: 1, remaining: 0 });
+    });
+    expect(result.current.isSuccess).toBe(false);
+
+    gate.resolve();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    const today = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+      choreKeys.board(),
+    )?.data.today;
+    expect(today?.assignees[0].chores).toHaveLength(1);
+    expect(today?.summary).toEqual({ total: 1, completed: 1, remaining: 0 });
   });
 
   it("refetches the board when completion fails because the current period is stale", async () => {

--- a/src/api/hooks/use-chores.ts
+++ b/src/api/hooks/use-chores.ts
@@ -116,6 +116,47 @@ function applyCurrentPeriodState(
   };
 }
 
+function findChoreInScope(
+  scope: ChoreScopeBoard,
+  templateId: string,
+): ChoreBoardItem | undefined {
+  for (const group of scope.assignees) {
+    const match = group.chores.find((chore) => chore.templateId === templateId);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+// Synthesize the completion state locally so the board updates the moment a
+// routine is tapped, before the server's canonical response arrives. Reuses the
+// same scope recalculation as the success path so counts and ordering stay
+// consistent. The request scope tells us which board column owns the routine.
+function applyOptimisticCompletion(
+  board: ChoresBoard,
+  scope: ChoreScope,
+  templateId: string,
+  completed: boolean,
+): ChoresBoard {
+  const scopeKey = boardKeyForScope(scope);
+  const existing = findChoreInScope(board[scopeKey], templateId);
+  if (!existing) return board;
+
+  const optimisticItem: ChoreBoardItem = {
+    ...existing,
+    completed,
+    // completedAt is an instant, not a calendar date, so toISOString() is
+    // correct here; the server overwrites it with the canonical value on success.
+    completedAt: completed
+      ? (existing.completedAt ?? new Date().toISOString())
+      : null,
+  };
+
+  return {
+    ...board,
+    [scopeKey]: replaceChoreInScope(board[scopeKey], optimisticItem),
+  };
+}
+
 function removeTemplateFromBoard(
   board: ChoresBoard,
   templateId: string,
@@ -228,6 +269,28 @@ export function useCompleteChoreForCurrentPeriod(
       templateId: string;
       request: UpdateCurrentPeriodCompletionRequest;
     }) => choreService.completeCurrentPeriod(templateId, request),
+    onMutate: async ({ templateId, request }) => {
+      await queryClient.cancelQueries({ queryKey: choreKeys.board() });
+      const previous = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      );
+      queryClient.setQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+        (current) =>
+          current
+            ? {
+                ...current,
+                data: applyOptimisticCompletion(
+                  current.data,
+                  request.scope,
+                  templateId,
+                  true,
+                ),
+              }
+            : current,
+      );
+      return { previous };
+    },
     onSuccess: (response) => {
       queryClient.setQueryData<ApiResponse<ChoresBoard>>(
         choreKeys.board(),
@@ -245,7 +308,12 @@ export function useCompleteChoreForCurrentPeriod(
       });
       callbacks?.onSuccess?.(response);
     },
-    onError: (error: ApiException) => {
+    onError: (error: ApiException, _variables, context) => {
+      // Roll the whole board back to the pre-tap snapshot, then let the
+      // stale-period path force a refetch for the canonical server state.
+      if (context?.previous) {
+        queryClient.setQueryData(choreKeys.board(), context.previous);
+      }
       if (isStaleChorePeriodError(error)) {
         queryClient.invalidateQueries({
           queryKey: choreKeys.board(),
@@ -270,6 +338,28 @@ export function useUncompleteChoreForCurrentPeriod(
       templateId: string;
       request: UpdateCurrentPeriodCompletionRequest;
     }) => choreService.uncompleteCurrentPeriod(templateId, request),
+    onMutate: async ({ templateId, request }) => {
+      await queryClient.cancelQueries({ queryKey: choreKeys.board() });
+      const previous = queryClient.getQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+      );
+      queryClient.setQueryData<ApiResponse<ChoresBoard>>(
+        choreKeys.board(),
+        (current) =>
+          current
+            ? {
+                ...current,
+                data: applyOptimisticCompletion(
+                  current.data,
+                  request.scope,
+                  templateId,
+                  false,
+                ),
+              }
+            : current,
+      );
+      return { previous };
+    },
     onSuccess: (response) => {
       queryClient.setQueryData<ApiResponse<ChoresBoard>>(
         choreKeys.board(),
@@ -287,7 +377,12 @@ export function useUncompleteChoreForCurrentPeriod(
       });
       callbacks?.onSuccess?.(response);
     },
-    onError: (error: ApiException) => {
+    onError: (error: ApiException, _variables, context) => {
+      // Roll the whole board back to the pre-tap snapshot, then let the
+      // stale-period path force a refetch for the canonical server state.
+      if (context?.previous) {
+        queryClient.setQueryData(choreKeys.board(), context.previous);
+      }
       if (isStaleChorePeriodError(error)) {
         queryClient.invalidateQueries({
           queryKey: choreKeys.board(),


### PR DESCRIPTION
Closes #248

## Problem

On mobile, checking/unchecking a chore felt delayed because the board only updated after the request succeeded. `useCompleteChoreForCurrentPeriod` / `useUncompleteChoreForCurrentPeriod` updated `choreKeys.board()` only in `onSuccess`, with no `onMutate` optimistic update or rollback — unlike the Lists completion path.

## Change

Both current-period mutations now apply an optimistic board update in `onMutate` and roll back in `onError`:

- New `applyOptimisticCompletion` helper synthesizes the completion state and reuses the existing `replaceChoreInScope` / `recalculateScope` helpers, so the tapped routine, assignee/scope counts, and incomplete→completed ordering all update immediately.
- `onMutate` cancels in-flight board refetches and snapshots the board; `onError` restores that snapshot.
- The stale-period path is preserved: a stale `400` still rolls back, forces a refetch (`refetchType: "all"`), and surfaces the existing recovery toast.
- `onSuccess` still reconciles the cache with the canonical server response.

## Acceptance criteria → code & tests

| Requirement | Code | Test |
|---|---|---|
| Complete/uncomplete mutate cache immediately | `onMutate` in both hooks | _optimistically completes / uncompletes … before the server responds_ |
| Counts & ordering consistent during optimistic state | `applyOptimisticCompletion` → `recalculateScope` | same tests assert summary + order |
| Failure rolls the entire board back | `onError` restores `context.previous` | _rolls the entire board back …_ |
| Stale-period still refetches + recovery toast | `isStaleChorePeriodError` branch retained | existing stale-period tests |
| Rapid/repeated taps stay consistent | `cancelQueries` + idempotent transform + `onSuccess` reconcile | _keeps the board consistent under rapid repeated completion taps_ |
| Hook tests use a non-GC'd client | `createCacheQueryClient` (`gcTime: Infinity`) | 4 new hook tests |
| Mobile E2E: immediate ack + persistence | — | _completing a chore updates immediately and persists after reload_ |

## Testing

- `npm test -- --run` → **1144 passing**
- `npm run build` (tsc) → clean
- `npm run lint` → clean
- E2E on Mobile Chrome against released BE `v1.6.0`: both `mobile-chores.spec.ts` tests pass. The new test holds the completion response open 2.5s and asserts the strikethrough within 1.2s (proving the update is optimistic, not server-driven), then reloads to confirm the completion persisted.
