### PR TITLE
fix(mobile): keep meal collision dialogs within narrow viewports

### DIFF
--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
 import {
   clearStorage,
@@ -21,6 +21,22 @@ async function openMealsBoard(page: Page) {
   await expect(
     page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
   ).toBeVisible();
+}
+
+/**
+ * Wait for a Radix dialog's open animation to finish before measuring its
+ * geometry. `data-state="open"` (and visibility) flip at animation frame 0, so
+ * the box is still mid `zoom-in-95`/`slide-in` transform when first visible —
+ * boundingBox would read the off-screen start frame, not the settled position.
+ */
+async function waitForDialogAnimationsSettled(dialog: Locator) {
+  await dialog.evaluate((el) =>
+    Promise.all(
+      el
+        .getAnimations({ subtree: true })
+        .map((animation) => animation.finished.catch(() => undefined)),
+    ).then(() => undefined),
+  );
 }
 
 test.describe("Mobile Meals", () => {
@@ -193,5 +209,79 @@ test.describe("Mobile Meals", () => {
     await expect(
       page.getByRole("button", { name: /open dinner: leftovers/i }),
     ).toBeHidden();
+  });
+
+  test("keeps the occupied-slot collision dialog within narrow viewports", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Collision Crew",
+      members: [{ name: "Pat", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+
+    // Occupy a dinner slot so the next placement collides with its primary.
+    await safeClick(
+      page.getByRole("button", { name: "Add dinner meal" }).first(),
+    );
+    const planSheet = page.getByRole("dialog", { name: "Plan Dinner" });
+    await waitForSheetSettled(planSheet);
+    await planSheet.getByLabel("Meal name").fill("Leftovers");
+    await planSheet.getByRole("button", { name: "Create quick meal" }).click();
+    await expect(planSheet).toBeHidden();
+
+    const occupiedSlot = page
+      .getByRole("button", { name: /open dinner: leftovers/i })
+      .first();
+    await expect(occupiedSlot).toBeVisible();
+
+    // Open the editor, choose Replace, then place a new meal — placing onto an
+    // occupied primary raises the shared collision dialog.
+    await safeClick(occupiedSlot);
+    const editorSheet = page.getByRole("dialog", { name: "Dinner Plan" });
+    await waitForSheetSettled(editorSheet);
+    await editorSheet.getByRole("button", { name: "Replace meal" }).click();
+
+    const replaceSheet = page.getByRole("dialog", { name: "Plan Dinner" });
+    await waitForSheetSettled(replaceSheet);
+    await replaceSheet.getByLabel("Meal name").fill("Pasta");
+    await replaceSheet
+      .getByRole("button", { name: "Create quick meal" })
+      .click();
+
+    const collisionDialog = page.getByRole("dialog", {
+      name: "That slot already has a meal",
+    });
+    await expect(collisionDialog).toBeVisible();
+    await waitForDialogAnimationsSettled(collisionDialog);
+
+    // The dialog and all three actions must stay fully on-screen and tappable
+    // across the narrowest supported widths (issue #249).
+    for (const width of [320, 360]) {
+      await page.setViewportSize({ width, height: 800 });
+
+      const dialogBox = await collisionDialog.boundingBox();
+      expect(dialogBox).not.toBeNull();
+      expect(dialogBox!.x).toBeGreaterThanOrEqual(0);
+      expect(dialogBox!.x + dialogBox!.width).toBeLessThanOrEqual(width);
+
+      for (const name of ["Cancel", "Add as extra", "Replace primary"]) {
+        const action = collisionDialog.getByRole("button", { name });
+        await expect(action).toBeVisible();
+        const actionBox = await action.boundingBox();
+        expect(actionBox).not.toBeNull();
+        expect(actionBox!.height).toBeGreaterThanOrEqual(44);
+        expect(actionBox!.x).toBeGreaterThanOrEqual(0);
+        expect(actionBox!.x + actionBox!.width).toBeLessThanOrEqual(width);
+      }
+    }
   });
 });

--- a/src/components/meals/meal-composer-sheet.test.tsx
+++ b/src/components/meals/meal-composer-sheet.test.tsx
@@ -144,6 +144,26 @@ describe("MealComposerSheet", () => {
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
   });
 
+  it("gives the collision actions a >=44px touch target", async () => {
+    const occupiedDinnerSlot = {
+      ...createOccupiedMealsBoard().days[1].slots[2],
+      seededRecipeId: testRecipeDetail.id,
+    };
+    const { user } = renderComposer(occupiedDinnerSlot);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add recipe to slot" }),
+    );
+    await screen.findByText("That slot already has a meal");
+
+    // min-h-11 == 44px keeps each action tappable when stacked on mobile.
+    for (const name of ["Cancel", "Add as extra", "Replace primary"]) {
+      expect(screen.getByRole("button", { name }).className).toContain(
+        "min-h-11",
+      );
+    }
+  });
+
   it("adds a quick meal as an extra without a collision prompt in extra intent", async () => {
     const occupiedDinner = {
       ...createOccupiedMealsBoard().days[1].slots[2],

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -394,6 +394,7 @@ export function MealComposerSheet({
             <Button
               type="button"
               variant="ghost"
+              className="min-h-11"
               onClick={() => setCollisionRequest(null)}
             >
               Cancel
@@ -401,12 +402,14 @@ export function MealComposerSheet({
             <Button
               type="button"
               variant="outline"
+              className="min-h-11"
               onClick={() => resolveCollision("add_as_extra")}
             >
               Add as extra
             </Button>
             <Button
               type="button"
+              className="min-h-11"
               onClick={() => resolveCollision("replace_primary")}
             >
               Replace primary

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -430,6 +430,7 @@ export function MealEditorSheet({
             <Button
               type="button"
               variant="ghost"
+              className="min-h-11"
               onClick={() => setPendingCollision(null)}
             >
               Cancel
@@ -437,12 +438,14 @@ export function MealEditorSheet({
             <Button
               type="button"
               variant="outline"
+              className="min-h-11"
               onClick={() => resolveCollision("add_as_extra")}
             >
               Add as extra
             </Button>
             <Button
               type="button"
+              className="min-h-11"
               onClick={() => resolveCollision("replace_primary")}
             >
               Replace primary

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/test/test-utils";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+
+describe("DialogContent mobile sizing contract", () => {
+  function renderContent(className?: string) {
+    render(
+      <Dialog open>
+        <DialogContent className={className}>
+          <DialogTitle>Sizing</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    return screen.getByRole("dialog");
+  }
+
+  it("reserves explicit horizontal gutters via a width calc instead of full width plus external margins", () => {
+    const content = renderContent();
+
+    // The centered box must subtract gutters from its own width so it never
+    // overflows narrow phones (issue #249). Full width + external margins
+    // (w-full + mx-4) is the regression that cut content off horizontally.
+    expect(content.className).toContain("w-[calc(100%-2rem)]");
+    expect(content.className).not.toContain("w-full");
+    expect(content.className).not.toMatch(/(^|\s)mx-4(\s|$)/);
+  });
+
+  it("preserves the desktop max-w-md cap", () => {
+    const content = renderContent();
+    expect(content.className).toContain("max-w-md");
+  });
+
+  it("still merges caller-supplied classes", () => {
+    const content = renderContent("max-w-lg");
+    expect(content.className).toContain("max-w-lg");
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -35,8 +35,12 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
-          "bg-card rounded-xl shadow-2xl p-5 sm:p-6 mx-4",
+          // Reserve explicit horizontal gutters in the width itself
+          // (calc(100% - 2rem)) so the centered box keeps a 1rem margin on each
+          // edge at narrow phone widths. Combining w-full with external margins
+          // (mx-4) overflowed because margins don't shrink a full-width box.
+          "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2",
+          "bg-card rounded-xl shadow-2xl p-5 sm:p-6",
           "duration-200",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",
           "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",


### PR DESCRIPTION
## Summary

On narrow phones the meal collision dialog ("That slot already has a meal") was cut off horizontally. The shared `DialogContent` combined `w-full` with external `mx-4` margins — margins don't shrink a full-width fixed box, so the centered dialog overflowed the viewport. This fixes the shared sizing primitive (not a meals-only override) and ensures the collision actions stay tappable.

- **Shared primitive**: `DialogContent` now reserves gutters in its own width via `w-[calc(100%-2rem)]` (keeping `max-w-md`), so the centered box keeps a 1rem margin on each edge below ~480px while desktop sizing is unchanged.
- **Touch targets**: the Cancel / Add as extra / Replace primary buttons get `min-h-11` (44px) so they stay comfortably tappable when stacked on mobile.
- **Coverage**: a unit regression test pins the sizing contract; a mobile E2E drives the occupied-slot collision and asserts the dialog + actions fit at 320px and 360px.

## Contract checklist

| Acceptance criterion (#249) | Code | Tests |
|---|---|---|
| Shared dialog sizing reserves explicit horizontal viewport gutters instead of combining full width with external margins | `src/components/ui/dialog.tsx` (`w-[calc(100%-2rem)]`, dropped `w-full` + `mx-4`) | `src/components/ui/dialog.test.tsx` |
| Collision dialogs fit at 320px, 360px, and Galaxy S10-class widths | shared primitive fix | `e2e/mobile-meals.spec.ts` asserts dialog box within viewport at 320 & 360 |
| Cancel, Add as extra, Replace primary remain visible and ≥44px tappable | `min-h-11` on the three actions in `meal-composer-sheet.tsx` and `meal-editor-sheet.tsx` | unit: `meal-composer-sheet.test.tsx` (`min-h-11`); E2E: action `boundingBox().height >= 44` |
| Content usable with increased text size / long translated copy | width-based gutters + stacked `flex-col` footer wrap regardless of label length | E2E exercises the full footer at narrow widths |
| Existing desktop `max-w-md` behavior preserved | `max-w-md` retained; `calc` only engages below ~480px | `dialog.test.tsx` "preserves the desktop max-w-md cap" |
| Regression test asserts the mobile sizing contract; mobile E2E covers the occupied-slot collision dialog | — | `dialog.test.tsx` + `mobile-meals.spec.ts` |

Per the issue note, the fix lives in the shared primitive (`dialog.tsx`) rather than a meals-only override, since the same overflow applied to any centered dialog.

## Verification

- `npm run lint` → exit 0 (only a pre-existing warning in `meals-view.tsx`, untouched)
- `npm run test -- --run` → 1153 passed (123 files)
- `npm run build` → success
- `npx playwright test mobile-meals.spec.ts --project="Mobile Chrome"` → 3 passed (against the released backend)

Closes #249
