### PR TITLE
fix(shared): keep fixed FABs viewport-anchored during module-switch fade

### DIFF
--- a/src/components/shared/screen-transition.test.tsx
+++ b/src/components/shared/screen-transition.test.tsx
@@ -35,9 +35,12 @@ describe("ScreenTransition", () => {
       </ScreenTransition>,
     );
     expect(animateMock).toHaveBeenCalledTimes(1);
-    expect(animateMock.mock.calls[0][0][0]).toMatchObject({
-      transform: "scale(1.012)",
-    });
+    // Opacity-only cross-fade: no transform, so the animating wrapper never
+    // becomes a containing block for position: fixed FABs mid-transition.
+    expect(animateMock.mock.calls[0][0]).toEqual([
+      { opacity: 0 },
+      { opacity: 1 },
+    ]);
   });
   it("slides right on forward, left on back", () => {
     setReduce(false);

--- a/src/components/shared/screen-transition.tsx
+++ b/src/components/shared/screen-transition.tsx
@@ -37,10 +37,10 @@ export function ScreenTransition({
             },
             { opacity: 1, transform: "none" },
           ]
-        : [
-            { opacity: 0, transform: "scale(1.012)" },
-            { opacity: 1, transform: "none" },
-          ];
+        : // Opacity-only cross-fade: a transform here (even animating to
+          // `none`) would make this wrapper the containing block for
+          // position: fixed FAB descendants mid-transition. Keep it absent.
+          [{ opacity: 0 }, { opacity: 1 }];
     el.animate(keyframes, {
       duration: mode === "slide" ? 280 : 200,
       easing: "cubic-bezier(0.2, 0, 0, 1)",


### PR DESCRIPTION
## Summary

The app-shell wraps every module in `<ScreenTransition mode="fade">` (`src/App.tsx`). Its fade keyframes animated `transform: scale(1.012) → none` over ~200ms. Because any element with an active (non-`none`) transform becomes the **containing block for `position: fixed` descendants**, each module's floating action button was briefly anchored to the animating wrapper instead of the viewport during the ~200ms fade — a small transient shift (~1.2% scale, easing to 0) on every module switch. The resting position was already correct; this only happened mid-transition.

This is **pre-existing** — it predates the shared-FAB work and affects Calendar's `AddEventButton` on `main` today. It also affects Lists/Chores/Recipes once they adopt the shared `FloatingActionButton`.

## Fix

Drop the scale; cross-fade on opacity only:

```diff
-  [{ opacity: 0, transform: "scale(1.012)" }, { opacity: 1, transform: "none" }]
+  [{ opacity: 0 }, { opacity: 1 }]
```

With no transform, the wrapper never establishes a containing block, so fixed FABs stay viewport-anchored throughout the fade. Duration (200ms), easing, the `slide` path, and the reduced-motion path are unchanged. The visual difference — removing a 1.2% scale from a 200ms opacity cross-fade — is imperceptible.

## Why FABs are unaffected elsewhere

The inner per-module slide `ScreenTransition`s (Lists, Recipes) use `translateX`, but their FABs render as **siblings** of those wrappers (`lists-view.tsx:172`, `recipes-view.tsx:390`), not descendants — so the inner slide never anchored them. The only transform ancestor in play was the outer fade, which this PR fixes.

## Testing

- Updated `screen-transition.test.tsx` to assert the fade emits exactly `[{ opacity: 0 }, { opacity: 1 }]` (no transform) — the no-containing-block contract. TDD: confirmed it failed against the old keyframes first.
- `npm test -- --run` → 1163 passing
- `npm run build` (tsc) → clean
- `npm run lint` / `format:check` → clean