### PR TITLE
fix(family): break import cycle that skipped boot localStorage hydration

### DIFF
--- a/src/api/hooks/family-storage.ts
+++ b/src/api/hooks/family-storage.ts
@@ -1,0 +1,84 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { FAMILY_STORAGE_KEY } from "@/lib/constants";
+import type { FamilyApiResponse, FamilyData } from "@/lib/types";
+import { validateFamilyData } from "@/lib/validations/family";
+
+// Query keys and localStorage helpers for family data live in this
+// React-free module (no @/stores import) so family-store.ts can run its
+// module-scope hydration without re-entering use-family.ts mid-evaluation.
+// Importing them from use-family.ts created a cycle
+// (use-family → @/stores → family-store → use-family) that left the
+// `familyKeys` const in its temporal dead zone during boot.
+
+// ============================================================================
+// Query Keys Factory
+// ============================================================================
+
+export const familyKeys = {
+  all: ["family"] as const,
+  family: () => [...familyKeys.all, "data"] as const,
+};
+
+// ============================================================================
+// localStorage Helpers
+// ============================================================================
+
+/**
+ * Write family data to localStorage for:
+ * 1. Instant startup on next page load (cache seeding)
+ * 2. Cross-tab sync via storage events
+ */
+export function writeFamilyToStorage(family: FamilyData | null): void {
+  try {
+    if (family === null) {
+      localStorage.removeItem(FAMILY_STORAGE_KEY);
+    } else {
+      // Match Zustand persist format for compatibility
+      const stored = {
+        state: {
+          family,
+          _hasHydrated: true,
+        },
+        version: 0,
+      };
+      localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(stored));
+    }
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to write family to localStorage:", error);
+    }
+  }
+}
+
+/**
+ * Read family data from localStorage for cache seeding.
+ */
+export function readFamilyFromStorage(): FamilyData | null {
+  try {
+    const stored = localStorage.getItem(FAMILY_STORAGE_KEY);
+    if (!stored) return null;
+
+    const parsed = JSON.parse(stored);
+    return validateFamilyData(parsed?.state?.family);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.error("Failed to read family from localStorage:", error);
+    }
+    return null;
+  }
+}
+
+// ============================================================================
+// Cross-Tab Sync Helper
+// ============================================================================
+
+/**
+ * Sync family data from localStorage to query cache.
+ * Called by the hydration init and storage event listener in family-store.ts.
+ */
+export function syncFamilyFromStorage(queryClient: QueryClient): void {
+  const family = readFamilyFromStorage();
+  queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+    data: family,
+  });
+}

--- a/src/api/hooks/use-family.ts
+++ b/src/api/hooks/use-family.ts
@@ -2,8 +2,12 @@ import type { UseQueryOptions } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import type { ApiException } from "@/api/client";
+import {
+  familyKeys,
+  readFamilyFromStorage,
+  writeFamilyToStorage,
+} from "@/api/hooks/family-storage";
 import { familyService } from "@/api/services";
-import { FAMILY_STORAGE_KEY } from "@/lib/constants";
 import { assertOnlineForWrite } from "@/lib/offline/read-only-guard";
 import type {
   AddMemberRequest,
@@ -17,17 +21,19 @@ import type {
   UpdateMemberRequest,
 } from "@/lib/types";
 import { familyColors } from "@/lib/types";
-import { validateFamilyData } from "@/lib/validations/family";
 import { useIsAuthenticated } from "@/stores";
 
 // ============================================================================
-// Query Keys Factory
+// Query Keys & localStorage Helpers (re-exported from family-storage.ts)
 // ============================================================================
 
-export const familyKeys = {
-  all: ["family"] as const,
-  family: () => [...familyKeys.all, "data"] as const,
-};
+// Defined in a React-free module so family-store.ts can import them without
+// creating an import cycle through @/stores. See family-storage.ts.
+export {
+  familyKeys,
+  readFamilyFromStorage,
+  syncFamilyFromStorage,
+} from "@/api/hooks/family-storage";
 
 // ============================================================================
 // Optimistic Member Helpers
@@ -48,55 +54,6 @@ export const TEMP_MEMBER_ID_PREFIX = "temp-";
  */
 export function isTempMemberId(id: string): boolean {
   return id.startsWith(TEMP_MEMBER_ID_PREFIX);
-}
-
-// ============================================================================
-// localStorage Helpers
-// ============================================================================
-
-/**
- * Write family data to localStorage for:
- * 1. Instant startup on next page load (cache seeding)
- * 2. Cross-tab sync via storage events
- */
-function writeFamilyToStorage(family: FamilyData | null): void {
-  try {
-    if (family === null) {
-      localStorage.removeItem(FAMILY_STORAGE_KEY);
-    } else {
-      // Match Zustand persist format for compatibility
-      const stored = {
-        state: {
-          family,
-          _hasHydrated: true,
-        },
-        version: 0,
-      };
-      localStorage.setItem(FAMILY_STORAGE_KEY, JSON.stringify(stored));
-    }
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.error("Failed to write family to localStorage:", error);
-    }
-  }
-}
-
-/**
- * Read family data from localStorage for cache seeding.
- */
-export function readFamilyFromStorage(): FamilyData | null {
-  try {
-    const stored = localStorage.getItem(FAMILY_STORAGE_KEY);
-    if (!stored) return null;
-
-    const parsed = JSON.parse(stored);
-    return validateFamilyData(parsed?.state?.family);
-  } catch (error) {
-    if (import.meta.env.DEV) {
-      console.error("Failed to read family from localStorage:", error);
-    }
-    return null;
-  }
 }
 
 // ============================================================================
@@ -513,22 +470,5 @@ export function useDeleteFamily(callbacks?: DeleteFamilyCallbacks) {
     onError: (error: ApiException) => {
       callbacks?.onError?.(error);
     },
-  });
-}
-
-// ============================================================================
-// Cross-Tab Sync Helper
-// ============================================================================
-
-/**
- * Sync family data from localStorage to query cache.
- * Called by the storage event listener in family-store.ts.
- */
-export function syncFamilyFromStorage(
-  queryClient: ReturnType<typeof useQueryClient>,
-): void {
-  const family = readFamilyFromStorage();
-  queryClient.setQueryData<FamilyApiResponse>(familyKeys.family(), {
-    data: family,
   });
 }

--- a/src/stores/family-store.hydration.test.ts
+++ b/src/stores/family-store.hydration.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { FAMILY_STORAGE_KEY } from "@/lib/constants";
+import type { FamilyData } from "@/lib/types";
+
+/**
+ * Regression tests for the module-initialization import cycle:
+ *
+ *   use-family.ts → @/stores (index) → family-store.ts → use-family.ts
+ *
+ * family-store.ts runs initializeHydration() at module scope. When
+ * use-family.ts is the first module in the cycle to evaluate (the normal app
+ * boot order), family-store.ts executed before use-family.ts finished
+ * initializing, so syncFamilyFromStorage() hit the `familyKeys` const in its
+ * temporal dead zone. The resulting ReferenceError was caught and only
+ * logged, silently skipping the boot-time localStorage → query cache seed.
+ *
+ * These tests force that exact evaluation order with a fresh module registry.
+ */
+
+const storedFamily: FamilyData = {
+  id: "family-1",
+  name: "Test Family",
+  members: [{ id: "member-1", name: "Alice", color: "coral" }],
+  createdAt: "2025-01-01T00:00:00.000Z",
+};
+
+describe("family hydration when use-family evaluates before family-store", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.setItem(
+      FAMILY_STORAGE_KEY,
+      JSON.stringify({
+        state: { family: storedFamily, _hasHydrated: true },
+        version: 0,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(FAMILY_STORAGE_KEY);
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("seeds the query cache from localStorage without a hydration error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Evaluate use-family.ts first — its @/stores import pulls in
+    // family-store.ts, whose module-scope hydration runs mid-cycle.
+    const { familyKeys } = await import("@/api/hooks/use-family");
+    const { queryClient } = await import("@/providers/query-client");
+
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      "Failed to check localStorage for family data:",
+      expect.anything(),
+    );
+    expect(queryClient.getQueryData(familyKeys.family())).toEqual({
+      data: storedFamily,
+    });
+  });
+
+  it("marks the store as hydrated", async () => {
+    await import("@/api/hooks/use-family");
+    const { useFamilyStore } = await import("@/stores/family-store");
+
+    expect(useFamilyStore.getState()._hasHydrated).toBe(true);
+  });
+});

--- a/src/stores/family-store.ts
+++ b/src/stores/family-store.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { syncFamilyFromStorage } from "@/api/hooks/use-family";
+import { syncFamilyFromStorage } from "@/api/hooks/family-storage";
 import { FAMILY_STORAGE_KEY } from "@/lib/constants";
 import { queryClient } from "@/providers/query-provider";
 


### PR DESCRIPTION
## Problem

Every app boot logged (dev only):

```
Failed to check localStorage for family data: ReferenceError: Cannot access 'familyKeys' before initialization
```

thrown from `syncFamilyFromStorage` (`use-family.ts`), called by `initializeHydration` which runs at **module scope** in `family-store.ts`.

**Root cause — import cycle + temporal dead zone:**

`use-family.ts` → `@/stores` (index) → `family-store.ts` → `use-family.ts`

When `use-family.ts` is the first module of the cycle to evaluate (the normal boot order), `family-store.ts`'s module body runs while `use-family.ts` is only partially initialized. `syncFamilyFromStorage` is a hoisted function declaration so the call resolves, but its body reads the `familyKeys` const which is still in its TDZ → ReferenceError. The error was caught and only logged, so the boot-time localStorage → query-cache seed silently never ran.

**Production was affected too, silently.** Verified in an unminified production build: `initializeHydration()` executes at chunk line ~23450 while `const familyKeys` initializes at ~23506 (Rollup preserves ESM evaluation order and TDZ). The `console.error` is DEV-gated and compiled out, so prod swallowed the failure with no signal.

## Fix

Same pattern already used for `queryClient` (`providers/query-client.ts`): extract `familyKeys` + the localStorage helpers (`readFamilyFromStorage`, `writeFamilyToStorage`, `syncFamilyFromStorage`) into a React-free `src/api/hooks/family-storage.ts` that does **not** import `@/stores`. `family-store.ts` now imports from it directly, removing its edge in the cycle entirely. `use-family.ts` re-exports the moved symbols so all existing consumers (`use-auth.ts`, `api/hooks/index.ts`, `test-utils.tsx`) are unchanged.

## Verification

- New regression test (`family-store.hydration.test.ts`) forces the failing evaluation order with a fresh module registry — red before the fix (reproduced the exact ReferenceError), green after; asserts the query cache is actually seeded from localStorage and `_hasHydrated` is set
- Full unit suite: 1319 tests / 132 files pass
- `biome check` clean on changed files; `tsc -b && vite build` passes
- Manual: dev server + real BE (GHCR 1.8.0), registered a family, seeded auth + family into localStorage, reloaded — zero console errors, family name and members render immediately
- Fixed production chunk verified: `familyKeys` initializes before `initializeHydration()` runs