### PR TITLE
Add focused meal planning session UI and released-contract E2E

### DIFF
--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -1,6 +1,7 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import type { CreateEventRequest } from "../../src/lib/types/calendar";
 import type { FamilyColor } from "../../src/lib/types/family";
+import type { CreateRecipeRequest } from "../../src/lib/types/recipes";
 
 const API_BASE = "http://127.0.0.1:8080/api";
 
@@ -93,4 +94,28 @@ export async function createCalendarEvent(
     const body = await response.text();
     throw new Error(`Create event failed (${response.status()}): ${body}`);
   }
+}
+
+/**
+ * Create a recipe through the real backend API using an authenticated token.
+ */
+export async function createRecipe(
+  request: APIRequestContext,
+  token: string,
+  recipe: CreateRecipeRequest,
+): Promise<{ id: string; title: string }> {
+  const response = await request.post(`${API_BASE}/recipes`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data: recipe,
+  });
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(`Create recipe failed (${response.status()}): ${body}`);
+  }
+
+  const json = await response.json();
+  return json.data;
 }

--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -1,5 +1,9 @@
 import { expect, type Locator, type Page, test } from "@playwright/test";
-import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  createRecipe,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
 import {
   clearStorage,
   safeClick,
@@ -20,6 +24,37 @@ async function openMealsBoard(page: Page) {
   await expect(moreSheet).toBeHidden();
   await expect(
     page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+  ).toBeVisible();
+}
+
+async function startDefaultMealPlanning(page: Page) {
+  await safeClick(page.getByRole("button", { name: "Fill empty slots" }));
+
+  const scopeDialog = page.getByRole("dialog", { name: "Fill empty slots" });
+  await waitForSheetSettled(scopeDialog);
+  await expect(scopeDialog.getByLabel("Empty dinners")).toBeChecked();
+  await safeClick(scopeDialog.getByRole("button", { name: "Start planning" }));
+
+  const planningSheet = page.getByRole("dialog", { name: "Meal planning" });
+  await waitForSheetSettled(planningSheet);
+  return planningSheet;
+}
+
+async function addQuickMealDraft(planningSheet: Locator, title: string) {
+  await planningSheet.getByLabel("Meal name").fill(title);
+  await safeClick(
+    planningSheet.getByRole("button", { name: "Add quick meal draft" }),
+  );
+  await expect(
+    planningSheet.getByRole("button", { name: `Draft dinner: ${title}` }),
+  ).toBeVisible();
+}
+
+async function expectDinnerCard(page: Page, title: string) {
+  await expect(
+    page.getByRole("button", {
+      name: new RegExp(`open dinner: ${title}`, "i"),
+    }),
   ).toBeVisible();
 }
 
@@ -45,6 +80,119 @@ test.describe("Mobile Meals", () => {
 
     await page.goto("/");
     await clearStorage(page);
+  });
+
+  test("fills empty dinners in one focused planning session", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Focused Dinner Planners",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+
+    const planningSheet = await startDefaultMealPlanning(page);
+    for (const title of ["Tacos", "Leftovers", "Pasta"]) {
+      await addQuickMealDraft(planningSheet, title);
+    }
+
+    await safeClick(planningSheet.getByRole("button", { name: "Review plan" }));
+    await expect(planningSheet.getByText("3 meals ready to add")).toBeVisible();
+    await safeClick(
+      planningSheet.getByRole("button", { name: "Save to week" }),
+    );
+
+    await expect(planningSheet).toBeHidden();
+    for (const title of ["Tacos", "Leftovers", "Pasta"]) {
+      await expectDinnerCard(page, title);
+    }
+
+    await page.reload();
+    await waitForHydration(page);
+    await openMealsBoard(page);
+
+    for (const title of ["Tacos", "Leftovers", "Pasta"]) {
+      await expectDinnerCard(page, title);
+    }
+  });
+
+  test("saves a recipe-backed dinner to a future week from focused planning", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Future Recipe Planners",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await createRecipe(request, registration.token, {
+      title: "Sheet Pan Chicken",
+      ingredients: ["1 lb chicken thighs", "2 cups chopped vegetables"],
+      instructions: ["Roast everything on a sheet pan until cooked through."],
+      tags: ["Dinner"],
+      favorite: true,
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+    await safeClick(page.getByRole("button", { name: "Next week" }));
+
+    const planningSheet = await startDefaultMealPlanning(page);
+    await safeClick(
+      planningSheet.getByRole("button", {
+        name: "Select recipe: Sheet Pan Chicken",
+      }),
+    );
+    await expect(
+      planningSheet.getByRole("button", {
+        name: "Draft dinner: Sheet Pan Chicken",
+      }),
+    ).toBeVisible();
+
+    await safeClick(planningSheet.getByRole("button", { name: "Review plan" }));
+    await safeClick(
+      planningSheet.getByRole("button", { name: "Save to week" }),
+    );
+
+    await expect(planningSheet).toBeHidden();
+    await expectDinnerCard(page, "Sheet Pan Chicken");
+  });
+
+  test("shows past meal weeks as review only on mobile", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Past Meal Reviewers",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+    await safeClick(page.getByRole("button", { name: "Previous week" }));
+
+    await expect(page.getByText("Review only")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Fill empty slots" }),
+    ).toBeHidden();
   });
 
   test("plans quick meals and recipe-backed meals from the weekly board", async ({

--- a/e2e/mobile-meals.spec.ts
+++ b/e2e/mobile-meals.spec.ts
@@ -50,10 +50,38 @@ async function addQuickMealDraft(planningSheet: Locator, title: string) {
   ).toBeVisible();
 }
 
+const WEEK_RANGE_PATTERN = /^[A-Z][a-z]{2} \d{1,2} - [A-Z][a-z]{2} \d{1,2}$/;
+
+async function getVisibleWeekRange(page: Page) {
+  const range = page.getByText(WEEK_RANGE_PATTERN).first();
+  await expect(range).toBeVisible();
+
+  const text = (await range.textContent())?.trim();
+  expect(text).toBeTruthy();
+  return text!;
+}
+
+async function expectWeekRangeChanged(page: Page, previousRange: string) {
+  const range = page.getByText(WEEK_RANGE_PATTERN).first();
+  await expect(range).toBeVisible();
+  await expect(range).not.toHaveText(previousRange);
+
+  const text = (await range.textContent())?.trim();
+  expect(text).toBeTruthy();
+  return text!;
+}
+
+async function expectWeekRange(page: Page, weekRange: string) {
+  await expect(
+    page.getByText(weekRange, { exact: true }).first(),
+  ).toBeVisible();
+}
+
 async function expectDinnerCard(page: Page, title: string) {
   await expect(
     page.getByRole("button", {
-      name: new RegExp(`open dinner: ${title}`, "i"),
+      exact: true,
+      name: `Open dinner: ${title}`,
     }),
   ).toBeVisible();
 }
@@ -148,7 +176,12 @@ test.describe("Mobile Meals", () => {
     await waitForHydration(page);
 
     await openMealsBoard(page);
+    const initialWeekRange = await getVisibleWeekRange(page);
     await safeClick(page.getByRole("button", { name: "Next week" }));
+    const futureWeekRange = await expectWeekRangeChanged(
+      page,
+      initialWeekRange,
+    );
 
     const planningSheet = await startDefaultMealPlanning(page);
     await safeClick(
@@ -168,6 +201,7 @@ test.describe("Mobile Meals", () => {
     );
 
     await expect(planningSheet).toBeHidden();
+    await expectWeekRange(page, futureWeekRange);
     await expectDinnerCard(page, "Sheet Pan Chicken");
   });
 

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -86,6 +86,7 @@ export {
   useMealsBoard,
   useMoveMealSlot,
   useRemoveMealSlot,
+  useSaveMealPlan,
   useUpsertMealSlot,
 } from "./use-meals";
 

--- a/src/api/hooks/use-meals.test.tsx
+++ b/src/api/hooks/use-meals.test.tsx
@@ -466,6 +466,60 @@ describe("useMeals", () => {
     });
   });
 
+  it.each([
+    ["move", useMoveMealSlot],
+    ["duplicate", useDuplicateMealSlot],
+  ] as const)("rejects %s into an extras-only destination instead of replacing extras", async (_kind, useMutationHook) => {
+    const board = boardWithOccupiedDinner();
+    board.days[2].slots[2] = {
+      id: "slot-tuesday-dinner-extras",
+      weekStartDate: "2026-06-07",
+      dayIndex: 2,
+      mealType: "dinner",
+      primary: null,
+      extras: [
+        {
+          id: "entry-extra",
+          role: "extra",
+          sourceType: "quick",
+          recipeId: null,
+          title: "Garlic bread",
+          imageUrl: null,
+          note: null,
+        },
+      ],
+      note: null,
+    };
+    seedMockMealsBoard(board);
+    const onError = vi.fn<(error: Error) => void>();
+
+    const { result } = renderHook(() => useMutationHook({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      sourceWeekStartDate: "2026-06-07",
+      sourceDayIndex: 1,
+      sourceMealType: "dinner",
+      destinationWeekStartDate: "2026-06-07",
+      destinationDayIndex: 2,
+      destinationMealType: "dinner",
+      collisionMode: "replace_primary",
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    expect(onError.mock.calls[0][0].message).toBe(
+      "Meal slot already has content",
+    );
+    expect(getMockMealsBoard("2026-06-07").days[2].slots[2]).toMatchObject({
+      primary: null,
+      extras: [expect.objectContaining({ title: "Garlic bread" })],
+    });
+  });
+
   it("removes a planned slot and invalidates its board", async () => {
     const board = boardWithOccupiedDinner();
     seedMockMealsBoard(board);

--- a/src/api/hooks/use-meals.test.tsx
+++ b/src/api/hooks/use-meals.test.tsx
@@ -294,6 +294,9 @@ describe("useMeals", () => {
     expect(cached).toEqual(result.current.data);
     expect(cached?.data.days[0].slots[0].primary?.title).toBe("Pancakes");
     expect(cached?.data.days[1].slots[2].extras[0].title).toBe("Guacamole");
+    expect(
+      queryClient.getQueryState(mealsKeys.board("2026-06-07"))?.isInvalidated,
+    ).toBe(true);
   });
 
   it("rejects focused meal plan saves that target the same slot twice", async () => {

--- a/src/api/hooks/use-meals.test.tsx
+++ b/src/api/hooks/use-meals.test.tsx
@@ -9,6 +9,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import type { ApiResponse, MealBoard } from "@/lib/types";
 import { testRecipeDetail } from "@/test/fixtures/recipes";
@@ -25,6 +26,7 @@ import {
   useMealsBoard,
   useMoveMealSlot,
   useRemoveMealSlot,
+  useSaveMealPlan,
   useUpsertMealSlot,
 } from "./use-meals";
 
@@ -228,6 +230,175 @@ describe("useMeals", () => {
         note: testRecipeDetail.note,
       });
     });
+  });
+
+  it("replaces the board cache with the saved focused meal plan response", async () => {
+    seedMockMealsBoard(emptyBoard);
+    queryClient.setQueryData(mealsKeys.board("2026-06-07"), {
+      data: boardWithOccupiedDinner(),
+    } satisfies ApiResponse<MealBoard>);
+
+    const { result } = renderHook(() => useSaveMealPlan(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      weekStartDate: "2026-06-07",
+      slots: [
+        {
+          dayIndex: 0,
+          mealType: "breakfast",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Pancakes",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [],
+          note: null,
+        },
+        {
+          dayIndex: 1,
+          mealType: "dinner",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Tacos",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [
+            {
+              sourceType: "quick",
+              recipeId: null,
+              title: "Guacamole",
+              imageUrl: null,
+              note: null,
+            },
+          ],
+          note: "Serve family style",
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.data.days[1].slots[2].primary?.title).toBe(
+        "Tacos",
+      );
+    });
+
+    const cached = queryClient.getQueryData<ApiResponse<MealBoard>>(
+      mealsKeys.board("2026-06-07"),
+    );
+    expect(cached).toEqual(result.current.data);
+    expect(cached?.data.days[0].slots[0].primary?.title).toBe("Pancakes");
+    expect(cached?.data.days[1].slots[2].extras[0].title).toBe("Guacamole");
+  });
+
+  it("rejects focused meal plan saves that target the same slot twice", async () => {
+    seedMockMealsBoard(emptyBoard);
+    const onError = vi.fn<(error: Error) => void>();
+
+    const { result } = renderHook(() => useSaveMealPlan({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      weekStartDate: "2026-06-07",
+      slots: [
+        {
+          dayIndex: 1,
+          mealType: "dinner",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Pasta",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [],
+          note: null,
+        },
+        {
+          dayIndex: 1,
+          mealType: "dinner",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Soup",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [],
+          note: null,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    expect(onError.mock.calls[0][0].message).toBe(
+      "Meal plan contains duplicate target slots.",
+    );
+  });
+
+  it("rejects focused meal plan saves when a target has only extras", async () => {
+    const board = structuredClone(emptyBoard);
+    board.days[4].slots[1] = {
+      id: "slot-thursday-lunch",
+      weekStartDate: "2026-06-07",
+      dayIndex: 4,
+      mealType: "lunch",
+      primary: null,
+      extras: [
+        {
+          id: "entry-extra",
+          role: "extra",
+          sourceType: "quick",
+          recipeId: null,
+          title: "Apple slices",
+          imageUrl: null,
+          note: null,
+        },
+      ],
+      note: null,
+    };
+    seedMockMealsBoard(board);
+    const onError = vi.fn<(error: Error) => void>();
+
+    const { result } = renderHook(() => useSaveMealPlan({ onError }), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      weekStartDate: "2026-06-07",
+      slots: [
+        {
+          dayIndex: 4,
+          mealType: "lunch",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Grilled cheese",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [],
+          note: null,
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    expect(onError.mock.calls[0][0].message).toBe(
+      "Some meal slots are no longer empty.",
+    );
   });
 
   it("moves a meal with an explicit lowercase collision mode", async () => {

--- a/src/api/hooks/use-meals.ts
+++ b/src/api/hooks/use-meals.ts
@@ -6,6 +6,7 @@ import type {
   MealSlotApiResponse,
   MoveMealSlotRequest,
   RemoveMealSlotRequest,
+  SaveMealPlanRequest,
   UpsertMealSlotRequest,
 } from "@/lib/types";
 
@@ -49,6 +50,28 @@ export function useUpsertMealSlot(callbacks?: {
     mutationFn: (request: UpsertMealSlotRequest) =>
       mealsService.upsertSlot(request),
     onSuccess: (response, request) => {
+      invalidateBoard(queryClient, request.weekStartDate);
+      callbacks?.onSuccess?.(response);
+    },
+    onError: (error) => {
+      callbacks?.onError?.(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    },
+  });
+}
+
+export function useSaveMealPlan(callbacks?: {
+  onSuccess?: (data: MealBoardApiResponse) => void;
+  onError?: (error: Error) => void;
+}) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: SaveMealPlanRequest) =>
+      mealsService.savePlan(request),
+    onSuccess: (response, request) => {
+      cacheBoard(queryClient, response);
       invalidateBoard(queryClient, request.weekStartDate);
       callbacks?.onSuccess?.(response);
     },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -71,6 +71,7 @@ export {
   useRemoveMember,
   useRenameListCategory,
   useReorderListCategories,
+  useSaveMealPlan,
   useSetupComplete,
   useSyncGoogleCalendar,
   useUncompleteChoreForCurrentPeriod,

--- a/src/api/services/meals.service.test.ts
+++ b/src/api/services/meals.service.test.ts
@@ -107,4 +107,13 @@ describe("mealsService.savePlan", () => {
     expect(new URL(captured.url).pathname).toBe("/api/meals/plans");
     expect(JSON.parse(captured.body)).toEqual(request);
   });
+
+  it("returns 400 from MSW when the meal plan slots payload is empty", async () => {
+    await expect(
+      mealsService.savePlan({
+        weekStartDate: "2026-06-07",
+        slots: [],
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
 });

--- a/src/api/services/meals.service.test.ts
+++ b/src/api/services/meals.service.test.ts
@@ -1,6 +1,6 @@
 import { HttpResponse, http } from "msw";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import type { RemoveMealSlotRequest } from "@/lib/types";
+import type { RemoveMealSlotRequest, SaveMealPlanRequest } from "@/lib/types";
 import { API_BASE, server } from "@/test/mocks/server";
 import { mealsService } from "./meals.service";
 
@@ -61,6 +61,50 @@ describe("mealsService.removeSlot", () => {
 
     await mealsService.removeSlot(request);
 
+    expect(JSON.parse(captured.body)).toEqual(request);
+  });
+});
+
+describe("mealsService.savePlan", () => {
+  function captureSavePlanRequest() {
+    const captured = { body: "", url: "" };
+    server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        captured.url = request.url;
+        captured.body = await request.text();
+        return HttpResponse.json({
+          data: { weekStartDate: "2026-06-07", days: [] },
+          message: "Meal plan saved successfully",
+        });
+      }),
+    );
+    return captured;
+  }
+
+  it("posts the SaveMealPlanRequest to /api/meals/plans", async () => {
+    const captured = captureSavePlanRequest();
+    const request: SaveMealPlanRequest = {
+      weekStartDate: "2026-06-07",
+      slots: [
+        {
+          dayIndex: 1,
+          mealType: "dinner",
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Pasta",
+            imageUrl: null,
+            note: null,
+          },
+          extras: [],
+          note: "Use the red sauce",
+        },
+      ],
+    };
+
+    await mealsService.savePlan(request);
+
+    expect(new URL(captured.url).pathname).toBe("/api/meals/plans");
     expect(JSON.parse(captured.body)).toEqual(request);
   });
 });

--- a/src/api/services/meals.service.ts
+++ b/src/api/services/meals.service.ts
@@ -5,6 +5,7 @@ import type {
   MealSlotApiResponse,
   MoveMealSlotRequest,
   RemoveMealSlotRequest,
+  SaveMealPlanRequest,
   UpsertMealSlotRequest,
 } from "@/lib/types";
 
@@ -17,6 +18,10 @@ export const mealsService = {
 
   upsertSlot(request: UpsertMealSlotRequest): Promise<MealSlotApiResponse> {
     return httpClient.put<MealSlotApiResponse>("/meals/slots", request);
+  },
+
+  savePlan(request: SaveMealPlanRequest): Promise<MealBoardApiResponse> {
+    return httpClient.post<MealBoardApiResponse>("/meals/plans", request);
   },
 
   moveSlot(request: MoveMealSlotRequest): Promise<MealBoardApiResponse> {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -7,6 +7,7 @@ import type { ApiResponse, MealBoard, SaveMealPlanRequest } from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealsBoard,
+  createExtrasOnlyMealsBoard,
   createOccupiedMealsBoard,
   createRecipeBackedMealsBoard,
   testWeekStartDate,
@@ -283,6 +284,36 @@ describe("MealsView", () => {
     expect(
       (await screen.findAllByRole("button", { name: /add dinner/i }))[0],
     ).toBeEnabled();
+  });
+
+  it("treats extras-only dinner slots as existing context and opens the editor", async () => {
+    seedMockMealsBoard(createExtrasOnlyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    const dayHeading = await screen.findByRole("heading", {
+      name: "Thursday, Jun 11",
+    });
+    const daySection = dayHeading.closest("section");
+    expect(daySection).not.toBeNull();
+    const thursday = within(daySection as HTMLElement);
+
+    const extrasButton = thursday.getByRole("button", {
+      name: /open dinner: extras - garlic bread/i,
+    });
+    expect(
+      thursday.queryByRole("button", { name: "Add dinner meal" }),
+    ).not.toBeInTheDocument();
+    expect(thursday.getByText("Garlic bread")).toBeInTheDocument();
+
+    await user.click(extrasButton);
+
+    const editorDialog = await screen.findByRole("dialog", {
+      name: "Dinner Plan",
+    });
+    expect(within(editorDialog).getByText("Garlic bread")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("dialog", { name: "Plan Dinner" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows Fill empty slots on editable weeks and hides it on past weeks", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -104,6 +104,44 @@ function withOccupiedDinnerSlot(
   return withOccupiedMealSlot(board, dayIndex, "dinner", title);
 }
 
+function withExtrasOnlyDinnerSlot(
+  board: MealBoard,
+  dayIndex: number,
+  extraTitle: string,
+): MealBoard {
+  return {
+    ...board,
+    days: board.days.map((day) =>
+      day.dayIndex === dayIndex
+        ? {
+            ...day,
+            slots: day.slots.map((slot) =>
+              slot.mealType === "dinner"
+                ? {
+                    ...slot,
+                    id: `slot-${dayIndex}-dinner-extras`,
+                    primary: null,
+                    extras: [
+                      {
+                        id: `entry-${dayIndex}-dinner-extra`,
+                        role: "extra",
+                        sourceType: "quick",
+                        recipeId: null,
+                        title: extraTitle,
+                        imageUrl: null,
+                        note: null,
+                      },
+                    ],
+                    note: null,
+                  }
+                : slot,
+            ),
+          }
+        : day,
+    ),
+  };
+}
+
 function withSavedMealPlan(
   board: MealBoard,
   request: SaveMealPlanRequest,
@@ -311,6 +349,20 @@ describe("MealsView", () => {
       name: "Dinner Plan",
     });
     expect(within(editorDialog).getByText("Garlic bread")).toBeInTheDocument();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Add extra or side" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Move meal" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).getByRole("button", { name: "Duplicate meal" }),
+    ).toBeDisabled();
+    expect(
+      within(editorDialog).queryByRole("button", {
+        name: /remove extra:/i,
+      }),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("dialog", { name: "Plan Dinner" }),
     ).not.toBeInTheDocument();
@@ -1025,6 +1077,44 @@ describe("MealsView", () => {
     });
   });
 
+  it.each([
+    ["move", "Move meal", "Move here"],
+    ["duplicate", "Duplicate meal", "Duplicate here"],
+  ])("prompts when trying to %s into an extras-only slot", async (_kind, actionLabel, confirmLabel) => {
+    const board = withExtrasOnlyDinnerSlot(
+      createOccupiedMealsBoard(),
+      2,
+      "Garlic bread",
+    );
+    seedMockMealsBoard(board);
+    const { user } = renderWithUser(
+      <MealEditorSheet
+        isOpen
+        slotId={{
+          weekStartDate: board.weekStartDate,
+          dayIndex: 1,
+          mealType: "dinner",
+        }}
+        board={board}
+        readOnly={false}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: actionLabel }));
+    await user.click(screen.getByRole("button", { name: confirmLabel }));
+
+    expect(
+      screen.getByText("That slot already has a meal"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Replace primary" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add as extra" }),
+    ).toBeInTheDocument();
+  });
+
   it("removes a planned meal from the editor", async () => {
     const board = createOccupiedMealsBoard();
     seedMockMealsBoard(board);
@@ -1250,6 +1340,68 @@ describe("MealsView", () => {
     expect(
       screen.getByRole("heading", { name: "Instructions" }),
     ).toBeInTheDocument();
+  });
+
+  it("resets recipe detail mode when reopening on an extras-only slot", async () => {
+    const recipeBoard = createRecipeBackedMealsBoard();
+    const extrasBoard = createExtrasOnlyMealsBoard();
+    seedMockRecipes([testRecipeDetail]);
+    const onOpenChange = vi.fn();
+    const recipeSlotId = {
+      weekStartDate: recipeBoard.weekStartDate,
+      dayIndex: 1,
+      mealType: "dinner" as const,
+    };
+    const extrasSlotId = {
+      weekStartDate: extrasBoard.weekStartDate,
+      dayIndex: 4,
+      mealType: "dinner" as const,
+    };
+    const { user, rerender } = renderWithUser(
+      <MealEditorSheet
+        isOpen
+        slotId={recipeSlotId}
+        board={recipeBoard}
+        readOnly={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "View recipe" }));
+    expect(
+      await screen.findByRole("heading", { name: testRecipeDetail.title }),
+    ).toBeInTheDocument();
+
+    rerender(
+      <MealEditorSheet
+        isOpen={false}
+        slotId={recipeSlotId}
+        board={recipeBoard}
+        readOnly={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+    rerender(
+      <MealEditorSheet
+        isOpen
+        slotId={extrasSlotId}
+        board={extrasBoard}
+        readOnly={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const editorDialog = await screen.findByRole("dialog", {
+      name: "Dinner Plan",
+    });
+    expect(within(editorDialog).getByText("Dinner extras")).toBeInTheDocument();
+    expect(within(editorDialog).getByText("Garlic bread")).toBeInTheDocument();
+    expect(
+      within(editorDialog).queryByText("Recipe could not be loaded."),
+    ).not.toBeInTheDocument();
+    expect(
+      within(editorDialog).queryByRole("button", { name: "View recipe" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows no Edit/Add-to-Meals/Favorite buttons in the meal-context recipe detail", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -11,7 +11,10 @@ import {
   createRecipeBackedMealsBoard,
   testWeekStartDate,
 } from "@/test/fixtures/meals";
-import { testRecipeDetail } from "@/test/fixtures/recipes";
+import {
+  importedRecipeDetail,
+  testRecipeDetail,
+} from "@/test/fixtures/recipes";
 import {
   API_BASE,
   getMockMealsBoard,
@@ -219,6 +222,222 @@ describe("MealsView", () => {
     expect(
       (await screen.findAllByRole("button", { name: /add dinner/i }))[0],
     ).toBeEnabled();
+  });
+
+  it("shows Fill empty slots on editable weeks and hides it on past weeks", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    seedMockMealsBoard(createEmptyMealsBoard("2026-06-14"));
+    seedMockMealsBoard(createEmptyMealsBoard("2026-05-31"));
+    const { user } = renderWithUser(<MealsView />);
+
+    expect(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next week" }));
+    expect(await screen.findByText("Jun 14 - Jun 20")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fill empty slots" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Previous week" }));
+    await user.click(screen.getByRole("button", { name: "Previous week" }));
+    expect(await screen.findByText("Review only")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Fill empty slots" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("starts empty-dinners planning and projects a quick draft without saving", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    expect(
+      await screen.findByRole("dialog", { name: /fill empty slots/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Empty dinners")).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "Meal planning" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sunday dinner - 1 of 7")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Draft dinner: Chili",
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
+    expect(getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary).toBe(
+      null,
+    );
+  });
+
+  it("cancel planning discards local drafts without mutating the persisted board", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(await screen.findByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: "Draft dinner: Chili",
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel planning" }));
+
+    expect(
+      screen.queryByRole("dialog", { name: "Meal planning" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Draft dinner: Chili",
+        hidden: true,
+      }),
+    ).not.toBeInTheDocument();
+    expect(getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary).toBe(
+      null,
+    );
+  });
+
+  it("selected-days scope queues only Monday and Wednesday empty slots", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByLabelText("Selected days"));
+
+    const startButton = screen.getByRole("button", { name: "Start planning" });
+    expect(startButton).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Monday"));
+    await user.click(screen.getByLabelText("Wednesday"));
+    expect(startButton).toBeEnabled();
+    await user.click(startButton);
+
+    expect(
+      await screen.findByRole("dialog", { name: "Meal planning" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Monday breakfast - 1 of 6")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Skip this slot" }));
+    expect(screen.getByText("Monday lunch - 2 of 6")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Skip this slot" }));
+    expect(screen.getByText("Monday dinner - 3 of 6")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Skip this slot" }));
+    expect(
+      screen.getByText("Wednesday breakfast - 4 of 6"),
+    ).toBeInTheDocument();
+  });
+
+  it("starts planning from a blank future week without leaving Meals", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(await screen.findByRole("button", { name: "Next week" }));
+    expect(await screen.findByText("Jun 14 - Jun 20")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Fill empty slots" }));
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+
+    expect(
+      await screen.findByRole("dialog", { name: "Meal planning" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sunday dinner - 1 of 7")).toBeInTheDocument();
+    expect(screen.getByText("Jun 14 - Jun 20")).toBeInTheDocument();
+  });
+
+  it("projects a recipe-backed draft from candidates without saving early", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.click(
+      await screen.findByRole("button", {
+        name: `Select recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+
+    expect(
+      await screen.findByRole("button", {
+        name: `Draft dinner: ${testRecipeDetail.title}`,
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+    expect(getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary).toBe(
+      null,
+    );
+  });
+
+  it("skip, remove draft, and change draft update planning state without saving", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+
+    await user.click(screen.getByRole("button", { name: "Skip this slot" }));
+    expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: "Draft dinner: Tacos",
+        hidden: true,
+      }),
+    ).toBeInTheDocument();
+    expect(getMockMealsBoard(testWeekStartDate).days[1].slots[2].primary).toBe(
+      null,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    expect(screen.getByText("1 meals ready to add")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Change draft" }));
+    expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove draft: Tacos" }),
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Draft dinner: Tacos",
+        hidden: true,
+      }),
+    ).not.toBeInTheDocument();
+    expect(getMockMealsBoard(testWeekStartDate).days[1].slots[2].primary).toBe(
+      null,
+    );
   });
 
   it("renders occupied slots as meal cards rather than add affordances", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -368,6 +368,43 @@ describe("MealsView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("adds a primary meal to an extras-only slot while preserving extras", async () => {
+    seedMockMealsBoard(createExtrasOnlyMealsBoard());
+    const { user } = renderWithUser(<MealsView />);
+
+    const dayHeading = await screen.findByRole("heading", {
+      name: "Thursday, Jun 11",
+    });
+    const daySection = dayHeading.closest("section");
+    expect(daySection).not.toBeNull();
+    const thursday = within(daySection as HTMLElement);
+
+    await user.click(
+      thursday.getByRole("button", {
+        name: /open dinner: extras - garlic bread/i,
+      }),
+    );
+    await user.click(screen.getByRole("button", { name: "Replace meal" }));
+
+    const composerDialog = await screen.findByRole("dialog", {
+      name: "Plan Dinner",
+    });
+    await user.type(within(composerDialog).getByLabelText("Meal name"), "Soup");
+    await user.click(
+      within(composerDialog).getByRole("button", {
+        name: "Create quick meal",
+      }),
+    );
+
+    await waitFor(() => {
+      const dinner = getMockMealsBoard(testWeekStartDate).days[4].slots[2];
+      expect(dinner.primary?.title).toBe("Soup");
+      expect(dinner.extras.map((extra) => extra.title)).toEqual([
+        "Garlic bread",
+      ]);
+    });
+  });
+
   it("shows Fill empty slots on editable weeks and hides it on past weeks", async () => {
     seedMockMealsBoard(createEmptyMealsBoard());
     seedMockMealsBoard(createEmptyMealsBoard("2026-06-14"));

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -58,6 +58,42 @@ function mockCurrentWeek() {
   vi.stubGlobal("Date", MockDate as DateConstructor);
 }
 
+function withOccupiedDinnerSlot(
+  board: MealBoard,
+  dayIndex: number,
+  title: string,
+): MealBoard {
+  return {
+    ...board,
+    days: board.days.map((day) =>
+      day.dayIndex === dayIndex
+        ? {
+            ...day,
+            slots: day.slots.map((slot) =>
+              slot.mealType === "dinner"
+                ? {
+                    ...slot,
+                    id: `slot-${dayIndex}-dinner`,
+                    primary: {
+                      id: `entry-${dayIndex}-dinner`,
+                      role: "primary",
+                      sourceType: "quick",
+                      recipeId: null,
+                      title,
+                      imageUrl: null,
+                      note: null,
+                    },
+                    extras: [],
+                    note: null,
+                  }
+                : slot,
+            ),
+          }
+        : day,
+    ),
+  };
+}
+
 describe("MealsView", () => {
   setupMswServer();
 
@@ -275,7 +311,6 @@ describe("MealsView", () => {
     expect(
       await screen.findByRole("button", {
         name: "Draft dinner: Chili",
-        hidden: true,
       }),
     ).toBeInTheDocument();
     expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
@@ -299,7 +334,6 @@ describe("MealsView", () => {
     expect(
       await screen.findByRole("button", {
         name: "Draft dinner: Chili",
-        hidden: true,
       }),
     ).toBeInTheDocument();
 
@@ -311,7 +345,6 @@ describe("MealsView", () => {
     expect(
       screen.queryByRole("button", {
         name: "Draft dinner: Chili",
-        hidden: true,
       }),
     ).not.toBeInTheDocument();
     expect(getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary).toBe(
@@ -386,7 +419,6 @@ describe("MealsView", () => {
     expect(
       await screen.findByRole("button", {
         name: `Draft dinner: ${testRecipeDetail.title}`,
-        hidden: true,
       }),
     ).toBeInTheDocument();
     expect(getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary).toBe(
@@ -413,7 +445,6 @@ describe("MealsView", () => {
     expect(
       await screen.findByRole("button", {
         name: "Draft dinner: Tacos",
-        hidden: true,
       }),
     ).toBeInTheDocument();
     expect(getMockMealsBoard(testWeekStartDate).days[1].slots[2].primary).toBe(
@@ -432,12 +463,101 @@ describe("MealsView", () => {
     expect(
       screen.queryByRole("button", {
         name: "Draft dinner: Tacos",
-        hidden: true,
       }),
     ).not.toBeInTheDocument();
     expect(getMockMealsBoard(testWeekStartDate).days[1].slots[2].primary).toBe(
       null,
     );
+  });
+
+  it("keeps conflict editing focused on the conflicted draft", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Draft dinner: Chili" }),
+    ).toBeInTheDocument();
+
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 0, "Already planned"),
+    );
+    await queryClient.invalidateQueries({
+      queryKey: mealsKeys.board(testWeekStartDate),
+    });
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ApiResponse<MealBoard>>(
+        mealsKeys.board(testWeekStartDate),
+      );
+      expect(cached?.data.days[0].slots[2].primary?.title).toBe(
+        "Already planned",
+      );
+    });
+
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Some meal slots are no longer empty.",
+    );
+
+    await user.click(
+      screen.getAllByRole("button", { name: "Keep editing" })[0],
+    );
+
+    expect(screen.getByText("Sunday dinner - 1 of 7")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Draft dinner: Chili" }),
+    ).toHaveAttribute("aria-current", "true");
+  });
+
+  it("saves focused planning drafts through the meal plan endpoint", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    let singleSlotSaveCalls = 0;
+    server.use(
+      http.put(`${API_BASE}/meals/slots`, () => {
+        singleSlotSaveCalls += 1;
+        return HttpResponse.json(
+          { message: "single-slot save should not be used" },
+          { status: 500 },
+        );
+      }),
+    );
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+
+    await waitFor(() => {
+      expect(
+        getMockMealsBoard(testWeekStartDate).days[0].slots[2].primary?.title,
+      ).toBe("Chili");
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Meal planning" }),
+    ).not.toBeInTheDocument();
+    expect(singleSlotSaveCalls).toBe(0);
   });
 
   it("renders occupied slots as meal cards rather than add affordances", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -3,7 +3,7 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mealsKeys } from "@/api";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
-import type { ApiResponse, MealBoard } from "@/lib/types";
+import type { ApiResponse, MealBoard, SaveMealPlanRequest } from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealsBoard,
@@ -58,9 +58,10 @@ function mockCurrentWeek() {
   vi.stubGlobal("Date", MockDate as DateConstructor);
 }
 
-function withOccupiedDinnerSlot(
+function withOccupiedMealSlot(
   board: MealBoard,
   dayIndex: number,
+  mealType: SaveMealPlanRequest["slots"][number]["mealType"],
   title: string,
 ): MealBoard {
   return {
@@ -70,12 +71,12 @@ function withOccupiedDinnerSlot(
         ? {
             ...day,
             slots: day.slots.map((slot) =>
-              slot.mealType === "dinner"
+              slot.mealType === mealType
                 ? {
                     ...slot,
-                    id: `slot-${dayIndex}-dinner`,
+                    id: `slot-${dayIndex}-${mealType}`,
                     primary: {
-                      id: `entry-${dayIndex}-dinner`,
+                      id: `entry-${dayIndex}-${mealType}`,
                       role: "primary",
                       sourceType: "quick",
                       recipeId: null,
@@ -92,6 +93,30 @@ function withOccupiedDinnerSlot(
         : day,
     ),
   };
+}
+
+function withOccupiedDinnerSlot(
+  board: MealBoard,
+  dayIndex: number,
+  title: string,
+): MealBoard {
+  return withOccupiedMealSlot(board, dayIndex, "dinner", title);
+}
+
+function withSavedMealPlan(
+  board: MealBoard,
+  request: SaveMealPlanRequest,
+): MealBoard {
+  return request.slots.reduce(
+    (nextBoard, slot) =>
+      withOccupiedMealSlot(
+        nextBoard,
+        slot.dayIndex,
+        slot.mealType,
+        slot.primary.title ?? "Recipe meal",
+      ),
+    board,
+  );
 }
 
 describe("MealsView", () => {
@@ -524,10 +549,27 @@ describe("MealsView", () => {
     ).toHaveAttribute("aria-current", "true");
   });
 
-  it("saves focused planning drafts through the meal plan endpoint", async () => {
+  it("saves drafted meals to the week with one batch request", async () => {
     seedMockMealsBoard(createEmptyMealsBoard());
+    const saveRequests: Array<{
+      pathname: string;
+      body: SaveMealPlanRequest;
+    }> = [];
     let singleSlotSaveCalls = 0;
     server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        const body = (await request.json()) as SaveMealPlanRequest;
+        saveRequests.push({
+          pathname: new URL(request.url).pathname,
+          body,
+        });
+        const savedBoard = withSavedMealPlan(
+          getMockMealsBoard(body.weekStartDate),
+          body,
+        );
+        seedMockMealsBoard(savedBoard);
+        return HttpResponse.json({ data: savedBoard });
+      }),
       http.put(`${API_BASE}/meals/slots`, () => {
         singleSlotSaveCalls += 1;
         return HttpResponse.json(
@@ -546,6 +588,11 @@ describe("MealsView", () => {
     await user.click(
       screen.getByRole("button", { name: "Add quick meal draft" }),
     );
+    expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
     await user.click(screen.getByRole("button", { name: "Review plan" }));
     await user.click(screen.getByRole("button", { name: "Save to week" }));
 
@@ -555,9 +602,163 @@ describe("MealsView", () => {
       ).toBe("Chili");
     });
     expect(
+      getMockMealsBoard(testWeekStartDate).days[1].slots[2].primary?.title,
+    ).toBe("Tacos");
+    expect(
       screen.queryByRole("dialog", { name: "Meal planning" }),
     ).not.toBeInTheDocument();
+    expect(saveRequests).toHaveLength(1);
+    expect(saveRequests[0].pathname).toBe("/api/meals/plans");
+    expect(
+      saveRequests[0].body.slots.map((slot) => slot.primary.title),
+    ).toEqual(["Chili", "Tacos"]);
     expect(singleSlotSaveCalls).toBe(0);
+  });
+
+  it("handles backend 409 save-time conflicts without overwriting and can skip conflicted drafts", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const saveRequests: SaveMealPlanRequest[] = [];
+    let singleSlotSaveCalls = 0;
+    server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        const body = (await request.json()) as SaveMealPlanRequest;
+        saveRequests.push(body);
+
+        if (saveRequests.length === 1) {
+          return HttpResponse.json(
+            { message: "Some meal slots are no longer empty." },
+            { status: 409 },
+          );
+        }
+
+        const savedBoard = withSavedMealPlan(
+          getMockMealsBoard(body.weekStartDate),
+          body,
+        );
+        seedMockMealsBoard(savedBoard);
+        return HttpResponse.json({ data: savedBoard });
+      }),
+      http.put(`${API_BASE}/meals/slots`, () => {
+        singleSlotSaveCalls += 1;
+        return HttpResponse.json(
+          { message: "single-slot save should not be used" },
+          { status: 500 },
+        );
+      }),
+    );
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 0, "Already planned"),
+    );
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Some meal slots are no longer empty.",
+    );
+    expect(
+      await screen.findByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Replace primary" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add as extra" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    );
+
+    await waitFor(() => {
+      const board = getMockMealsBoard(testWeekStartDate);
+      expect(board.days[0].slots[2].primary?.title).toBe("Already planned");
+      expect(board.days[1].slots[2].primary?.title).toBe("Tacos");
+    });
+    expect(
+      screen.queryByRole("dialog", { name: "Meal planning" }),
+    ).not.toBeInTheDocument();
+    expect(saveRequests).toHaveLength(2);
+    expect(saveRequests[1].slots).toHaveLength(1);
+    expect(saveRequests[1].slots[0]).toMatchObject({
+      dayIndex: 1,
+      mealType: "dinner",
+    });
+    expect(singleSlotSaveCalls).toBe(0);
+  });
+
+  it("cancel save after a backend conflict returns to review and keeps drafts", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const saveRequests: SaveMealPlanRequest[] = [];
+    server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        saveRequests.push((await request.json()) as SaveMealPlanRequest);
+        return HttpResponse.json(
+          { message: "Some meal slots are no longer empty." },
+          { status: 409 },
+        );
+      }),
+    );
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 0, "Already planned"),
+    );
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+    expect(
+      await screen.findByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel save" }));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("2 meals ready to add")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Draft dinner: Chili" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Draft dinner: Tacos" }),
+    ).toBeInTheDocument();
+    expect(saveRequests).toHaveLength(1);
   });
 
   it("renders occupied slots as meal cards rather than add affordances", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -705,6 +705,124 @@ describe("MealsView", () => {
     expect(singleSlotSaveCalls).toBe(0);
   });
 
+  it("keeps save controls disabled while backend conflict resolution is pending", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const saveRequests: SaveMealPlanRequest[] = [];
+    let boardRefetchStarted = false;
+    let releaseBoardRefetch: () => void = () => {};
+    const boardRefetchGate = new Promise<void>((resolve) => {
+      releaseBoardRefetch = resolve;
+    });
+    server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        saveRequests.push((await request.json()) as SaveMealPlanRequest);
+        return HttpResponse.json(
+          { message: "Some meal slots are no longer empty." },
+          { status: 409 },
+        );
+      }),
+    );
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 0, "Already planned"),
+    );
+    server.use(
+      http.get(`${API_BASE}/meals/board`, async ({ request }) => {
+        boardRefetchStarted = true;
+        await boardRefetchGate;
+        const weekStartDate = new URL(request.url).searchParams.get(
+          "weekStartDate",
+        );
+        return HttpResponse.json({
+          data: getMockMealsBoard(weekStartDate ?? testWeekStartDate),
+        });
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+
+    await waitFor(() => {
+      expect(boardRefetchStarted).toBe(true);
+    });
+    const saveButton = screen.getByRole("button", {
+      name: /^(Save to week|Saving...)$/,
+    });
+    expect(saveButton).toBeDisabled();
+
+    await user.click(saveButton);
+    releaseBoardRefetch();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Some meal slots are no longer empty.",
+    );
+    expect(saveRequests).toHaveLength(1);
+  });
+
+  it("keeps all conflicted drafts when no remaining drafts can be saved", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+    const saveRequests: SaveMealPlanRequest[] = [];
+    server.use(
+      http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+        saveRequests.push((await request.json()) as SaveMealPlanRequest);
+        return HttpResponse.json(
+          { message: "Some meal slots are no longer empty." },
+          { status: 409 },
+        );
+      }),
+    );
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Fill empty slots" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Start planning" }));
+    await user.type(screen.getByLabelText("Meal name"), "Chili");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 0, "Already planned"),
+    );
+    await user.click(screen.getByRole("button", { name: "Review plan" }));
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Some meal slots are no longer empty.",
+    );
+    const skipConflicted = screen.getByRole("button", {
+      name: "Skip conflicted and save remaining",
+    });
+    expect(skipConflicted).toBeDisabled();
+    expect(
+      screen.getByText("No remaining drafts to save."),
+    ).toBeInTheDocument();
+
+    await user.click(skipConflicted);
+    expect(saveRequests).toHaveLength(1);
+
+    await user.click(
+      screen.getAllByRole("button", { name: "Keep editing" })[0],
+    );
+
+    expect(screen.getByText("Sunday dinner - 1 of 7")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Draft dinner: Chili" }),
+    ).toHaveAttribute("aria-current", "true");
+    expect(saveRequests).toHaveLength(1);
+  });
+
   it("cancel save after a backend conflict returns to review and keeps drafts", async () => {
     seedMockMealsBoard(createEmptyMealsBoard());
     const saveRequests: SaveMealPlanRequest[] = [];

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -426,7 +426,7 @@ export function MealsView() {
       }
     }
 
-    if (slot.primary && !pendingRecipeId) {
+    if ((slot.primary || slot.extras.length > 0) && !pendingRecipeId) {
       setEditingSlotId({
         weekStartDate: slot.weekStartDate,
         dayIndex: slot.dayIndex,

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useMealsBoard, useRecipes } from "@/api";
+import { useMealsBoard, useRecipes, useSaveMealPlan } from "@/api";
 import {
   MealComposerSheet,
   type MealSlotSelection,
@@ -10,7 +10,17 @@ import {
   type MealSlotId,
 } from "@/components/meals/meal-editor-sheet";
 import { MealGrid } from "@/components/meals/meal-grid";
-import { WeekHeader } from "@/components/meals/week-header";
+import { MealPlanningPanel } from "@/components/meals/meal-planning-panel";
+import { MealPlanningScopeDialog } from "@/components/meals/meal-planning-scope-dialog";
+import {
+  applyPlanningDraftsToBoard,
+  buildPlanningQueue,
+  getConflictedDraftTargets,
+  type MealPlanningDraft,
+  type MealPlanningTarget,
+  toSaveMealPlanRequest,
+} from "@/components/meals/meal-planning-session";
+import { formatWeekRange, WeekHeader } from "@/components/meals/week-header";
 import { OfflineUnavailable } from "@/components/shared";
 import { Button } from "@/components/ui/button";
 import { useMediaQuery } from "@/hooks";
@@ -18,9 +28,99 @@ import {
   formatLocalDate,
   getWeekStartSunday,
   isPastWeek,
+  parseLocalDate,
 } from "@/lib/time-utils";
+import type { MealPlanningScope, MealSlot } from "@/lib/types";
 import type { MealPlacementDraft } from "@/stores";
 import { useAppStore } from "@/stores";
+
+function samePlanningTarget(
+  left: MealPlanningTarget,
+  right: MealPlanningTarget,
+) {
+  return left.dayIndex === right.dayIndex && left.mealType === right.mealType;
+}
+
+function slotTarget(slot: Pick<MealSlot, "dayIndex" | "mealType">) {
+  return { dayIndex: slot.dayIndex, mealType: slot.mealType };
+}
+
+function upsertPlanningDraft(
+  drafts: MealPlanningDraft[],
+  nextDraft: MealPlanningDraft,
+) {
+  return [
+    ...drafts.filter(
+      (draft) => !samePlanningTarget(draft.target, nextDraft.target),
+    ),
+    nextDraft,
+  ];
+}
+
+function removePlanningTarget<T extends MealPlanningTarget>(
+  targets: T[],
+  targetToRemove: MealPlanningTarget,
+) {
+  return targets.filter(
+    (target) => !samePlanningTarget(target, targetToRemove),
+  );
+}
+
+function hasTarget(targets: MealPlanningTarget[], target: MealPlanningTarget) {
+  return targets.some((candidate) => samePlanningTarget(candidate, target));
+}
+
+function hasDraftForTarget(
+  drafts: MealPlanningDraft[],
+  target: MealPlanningTarget,
+) {
+  return drafts.some((draft) => samePlanningTarget(draft.target, target));
+}
+
+function findQueueIndex(queue: MealSlot[], target: MealPlanningTarget) {
+  return queue.findIndex((slot) =>
+    samePlanningTarget(slotTarget(slot), target),
+  );
+}
+
+function findNextQueueIndex(
+  queue: MealSlot[],
+  startIndex: number,
+  drafts: MealPlanningDraft[],
+  skippedTargets: MealPlanningTarget[],
+) {
+  for (let index = Math.max(0, startIndex); index < queue.length; index += 1) {
+    const target = slotTarget(queue[index]);
+    if (hasTarget(skippedTargets, target)) continue;
+    if (hasDraftForTarget(drafts, target)) continue;
+    return index;
+  }
+
+  return queue.length;
+}
+
+function findPreviousQueueIndex(
+  queue: MealSlot[],
+  startIndex: number,
+  skippedTargets: MealPlanningTarget[],
+) {
+  for (
+    let index = Math.min(startIndex, queue.length - 1);
+    index >= 0;
+    index -= 1
+  ) {
+    const target = slotTarget(queue[index]);
+    if (!hasTarget(skippedTargets, target)) return index;
+  }
+
+  return -1;
+}
+
+function formatScopeDayLabel(date: string) {
+  return parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "long",
+  });
+}
 
 export function MealsView() {
   const [visibleWeekStartDate, setVisibleWeekStartDate] = useState(() =>
@@ -32,6 +132,22 @@ export function MealsView() {
   const [editingSlotId, setEditingSlotId] = useState<MealSlotId | null>(null);
   const [placementDraft, setPlacementDraft] =
     useState<MealPlacementDraft | null>(null);
+  const [scopeOpen, setScopeOpen] = useState(false);
+  const [planningScope, setPlanningScope] = useState<MealPlanningScope | null>(
+    null,
+  );
+  const [planningQueue, setPlanningQueue] = useState<MealSlot[]>([]);
+  const [planningDrafts, setPlanningDrafts] = useState<MealPlanningDraft[]>([]);
+  const [skippedPlanningTargets, setSkippedPlanningTargets] = useState<
+    MealPlanningTarget[]
+  >([]);
+  const [currentPlanningIndex, setCurrentPlanningIndex] = useState(0);
+  const [conflictedTargets, setConflictedTargets] = useState<
+    MealPlanningTarget[]
+  >([]);
+  const [planningSaveError, setPlanningSaveError] = useState<Error | null>(
+    null,
+  );
   const board = useMealsBoard(visibleWeekStartDate);
   const recipes = useRecipes();
   const pendingPlacementDraft = useAppStore(
@@ -42,6 +158,25 @@ export function MealsView() {
   );
   const readOnly = isPastWeek(visibleWeekStartDate);
   const showGrid = useMediaQuery("(min-width: 1024px)");
+  const persistedBoard = board.data?.data ?? null;
+  const planningActive = planningScope !== null;
+  const currentPlanningTarget =
+    planningActive && currentPlanningIndex < planningQueue.length
+      ? slotTarget(planningQueue[currentPlanningIndex])
+      : null;
+  const displayBoard = useMemo(() => {
+    if (!persistedBoard) return null;
+    return planningActive
+      ? applyPlanningDraftsToBoard(persistedBoard, planningDrafts)
+      : persistedBoard;
+  }, [persistedBoard, planningActive, planningDrafts]);
+  const saveMealPlan = useSaveMealPlan({
+    onSuccess: () => resetPlanningSession(),
+    onError: (error) => {
+      setPlanningSaveError(error);
+      setCurrentPlanningIndex(planningQueue.length);
+    },
+  });
 
   useEffect(() => {
     if (!pendingPlacementDraft) return;
@@ -52,7 +187,7 @@ export function MealsView() {
   }, [consumeMealPlacementDraft, pendingPlacementDraft]);
 
   useEffect(() => {
-    if (!placementDraft || placementDraft.source.kind !== "meals-slot") return;
+    if (placementDraft?.source.kind !== "meals-slot") return;
     const source = placementDraft.source;
     const day = board.data?.data.days[source.dayIndex];
     const slot = day?.slots.find(
@@ -81,7 +216,179 @@ export function MealsView() {
       ? placementDraft.recipeId
       : null;
 
+  function resetPlanningSession() {
+    setScopeOpen(false);
+    setPlanningScope(null);
+    setPlanningQueue([]);
+    setPlanningDrafts([]);
+    setSkippedPlanningTargets([]);
+    setCurrentPlanningIndex(0);
+    setConflictedTargets([]);
+    setPlanningSaveError(null);
+  }
+
+  function startPlanningSession(scope: MealPlanningScope) {
+    if (!persistedBoard) return;
+    const nextQueue = buildPlanningQueue(persistedBoard, scope);
+    setPlanningScope(scope);
+    setPlanningQueue(nextQueue);
+    setPlanningDrafts([]);
+    setSkippedPlanningTargets([]);
+    setCurrentPlanningIndex(0);
+    setConflictedTargets([]);
+    setPlanningSaveError(null);
+    setScopeOpen(false);
+    setSelectedSlot(null);
+    setEditingSlotId(null);
+  }
+
+  function addPlanningDraft(draft: MealPlanningDraft) {
+    const nextDrafts = upsertPlanningDraft(planningDrafts, draft);
+    const nextSkippedTargets = removePlanningTarget(
+      skippedPlanningTargets,
+      draft.target,
+    );
+
+    setPlanningDrafts(nextDrafts);
+    setSkippedPlanningTargets(nextSkippedTargets);
+    setConflictedTargets(removePlanningTarget(conflictedTargets, draft.target));
+    setPlanningSaveError(null);
+    setCurrentPlanningIndex(
+      findNextQueueIndex(
+        planningQueue,
+        currentPlanningIndex + 1,
+        nextDrafts,
+        nextSkippedTargets,
+      ),
+    );
+  }
+
+  function removePlanningDraft(target: MealPlanningTarget) {
+    setPlanningDrafts((current) =>
+      current.filter((draft) => !samePlanningTarget(draft.target, target)),
+    );
+    setConflictedTargets((current) => removePlanningTarget(current, target));
+    setPlanningSaveError(null);
+  }
+
+  function skipPlanningSlot() {
+    const currentSlot = planningQueue[currentPlanningIndex];
+    if (!currentSlot) {
+      setCurrentPlanningIndex(planningQueue.length);
+      return;
+    }
+
+    const target = slotTarget(currentSlot);
+    const nextSkippedTargets = hasTarget(skippedPlanningTargets, target)
+      ? skippedPlanningTargets
+      : [...skippedPlanningTargets, target];
+
+    setSkippedPlanningTargets(nextSkippedTargets);
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    setCurrentPlanningIndex(
+      findNextQueueIndex(
+        planningQueue,
+        currentPlanningIndex + 1,
+        planningDrafts,
+        nextSkippedTargets,
+      ),
+    );
+  }
+
+  function goBackInPlanningQueue() {
+    const previousIndex = findPreviousQueueIndex(
+      planningQueue,
+      currentPlanningIndex - 1,
+      skippedPlanningTargets,
+    );
+    if (previousIndex >= 0) {
+      setPlanningSaveError(null);
+      setConflictedTargets([]);
+      setCurrentPlanningIndex(previousIndex);
+    }
+  }
+
+  function reviewPlanningDrafts() {
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    setCurrentPlanningIndex(planningQueue.length);
+  }
+
+  function keepEditingPlanningDrafts() {
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    const nextIndex = findNextQueueIndex(
+      planningQueue,
+      0,
+      planningDrafts,
+      skippedPlanningTargets,
+    );
+    setCurrentPlanningIndex(nextIndex < planningQueue.length ? nextIndex : 0);
+  }
+
+  function changePlanningDraft(target: MealPlanningTarget) {
+    const index = findQueueIndex(planningQueue, target);
+    if (index < 0) return;
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    setCurrentPlanningIndex(index);
+  }
+
+  function cancelPlanningSave() {
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    setCurrentPlanningIndex(planningQueue.length);
+  }
+
+  function savePlanningDrafts() {
+    if (!persistedBoard || planningDrafts.length === 0) return;
+
+    const conflicts = getConflictedDraftTargets(persistedBoard, planningDrafts);
+    if (conflicts.length > 0) {
+      setConflictedTargets(conflicts);
+      setPlanningSaveError(new Error("Some meal slots are no longer empty."));
+      setCurrentPlanningIndex(planningQueue.length);
+      return;
+    }
+
+    setPlanningSaveError(null);
+    setConflictedTargets([]);
+    saveMealPlan.mutate(
+      toSaveMealPlanRequest(visibleWeekStartDate, planningDrafts),
+    );
+  }
+
+  function saveNonConflictedPlanningDrafts() {
+    const remainingDrafts = planningDrafts.filter(
+      (draft) => !hasTarget(conflictedTargets, draft.target),
+    );
+    setPlanningDrafts(remainingDrafts);
+    setConflictedTargets([]);
+    setPlanningSaveError(null);
+
+    if (remainingDrafts.length === 0) {
+      setCurrentPlanningIndex(planningQueue.length);
+      return;
+    }
+
+    saveMealPlan.mutate(
+      toSaveMealPlanRequest(visibleWeekStartDate, remainingDrafts),
+    );
+  }
+
   function selectSlot(slot: MealSlotSelection) {
+    if (planningActive) {
+      const target = slotTarget(slot);
+      const queueIndex = findQueueIndex(planningQueue, target);
+      if (queueIndex >= 0) {
+        setCurrentPlanningIndex(queueIndex);
+        setPlanningSaveError(null);
+        setConflictedTargets([]);
+        return;
+      }
+    }
+
     if (slot.primary && !pendingRecipeId) {
       setEditingSlotId({
         weekStartDate: slot.weekStartDate,
@@ -124,8 +431,21 @@ export function MealsView() {
             setVisibleWeekStartDate(weekStartDate);
             setSelectedSlot(null);
             setEditingSlotId(null);
+            resetPlanningSession();
           }}
         />
+
+        {persistedBoard && !readOnly ? (
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setScopeOpen(true)}
+            >
+              Fill empty slots
+            </Button>
+          </div>
+        ) : null}
 
         {placementRecipe ? (
           <div className="rounded-lg border border-primary/30 bg-primary/5 p-3 text-sm font-medium text-primary">
@@ -168,25 +488,29 @@ export function MealsView() {
           <OfflineUnavailable label="meals" />
         ) : null}
 
-        {board.data?.data && !showGrid ? (
+        {displayBoard && !showGrid ? (
           <div className="space-y-4">
-            {board.data.data.days.map((day) => (
+            {displayBoard.days.map((day) => (
               <MealDayCard
                 key={day.date}
                 day={day}
                 readOnly={readOnly}
                 pendingRecipeId={pendingRecipeId}
+                planningDrafts={planningActive ? planningDrafts : []}
+                planningTarget={currentPlanningTarget}
                 onSelectSlot={selectSlot}
               />
             ))}
           </div>
         ) : null}
 
-        {board.data?.data && showGrid ? (
+        {displayBoard && showGrid ? (
           <MealGrid
-            board={board.data.data}
+            board={displayBoard}
             readOnly={readOnly}
             pendingRecipeId={pendingRecipeId}
+            planningDrafts={planningActive ? planningDrafts : []}
+            planningTarget={currentPlanningTarget}
             onSelectSlot={selectSlot}
           />
         ) : null}
@@ -206,7 +530,7 @@ export function MealsView() {
       <MealEditorSheet
         isOpen={editingSlotId !== null}
         slotId={editingSlotId}
-        board={board.data?.data ?? null}
+        board={persistedBoard}
         readOnly={readOnly}
         onReplace={replaceFromEditor}
         onAddExtra={addExtraFromEditor}
@@ -216,6 +540,42 @@ export function MealsView() {
           }
         }}
       />
+
+      <MealPlanningScopeDialog
+        isOpen={scopeOpen}
+        weekLabel={formatWeekRange(visibleWeekStartDate)}
+        days={(persistedBoard?.days ?? []).map((day) => ({
+          dayIndex: day.dayIndex,
+          label: formatScopeDayLabel(day.date),
+        }))}
+        onStart={startPlanningSession}
+        onOpenChange={setScopeOpen}
+      />
+
+      {planningActive && persistedBoard ? (
+        <MealPlanningPanel
+          isOpen
+          board={persistedBoard}
+          queue={planningQueue}
+          drafts={planningDrafts}
+          currentIndex={currentPlanningIndex}
+          recipes={recipes.data?.data ?? []}
+          isSaving={saveMealPlan.isPending}
+          saveError={planningSaveError}
+          conflictedTargets={conflictedTargets}
+          onAddDraft={addPlanningDraft}
+          onRemoveDraft={removePlanningDraft}
+          onSkip={skipPlanningSlot}
+          onBack={goBackInPlanningQueue}
+          onReview={reviewPlanningDrafts}
+          onSave={savePlanningDrafts}
+          onSaveNonConflicted={saveNonConflictedPlanningDrafts}
+          onKeepEditing={keepEditingPlanningDrafts}
+          onCancelSave={cancelPlanningSave}
+          onCancel={resetPlanningSession}
+          onChangeDraft={changePlanningDraft}
+        />
+      ) : null}
     </section>
   );
 }

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useMealsBoard, useRecipes, useSaveMealPlan } from "@/api";
+import { ApiException } from "@/api/client";
 import {
   MealComposerSheet,
   type MealSlotSelection,
@@ -172,10 +173,7 @@ export function MealsView() {
   }, [persistedBoard, planningActive, planningDrafts]);
   const saveMealPlan = useSaveMealPlan({
     onSuccess: () => resetPlanningSession(),
-    onError: (error) => {
-      setPlanningSaveError(error);
-      setCurrentPlanningIndex(planningQueue.length);
-    },
+    onError: handlePlanningSaveError,
   });
 
   useEffect(() => {
@@ -225,6 +223,26 @@ export function MealsView() {
     setCurrentPlanningIndex(0);
     setConflictedTargets([]);
     setPlanningSaveError(null);
+  }
+
+  async function handlePlanningSaveError(error: Error) {
+    setCurrentPlanningIndex(planningQueue.length);
+
+    if (ApiException.isApiException(error) && error.status === 409) {
+      const refreshedBoard = (await board.refetch()).data?.data ?? null;
+      const conflicts = refreshedBoard
+        ? getConflictedDraftTargets(refreshedBoard, planningDrafts)
+        : [];
+
+      if (conflicts.length > 0) {
+        setConflictedTargets(conflicts);
+        setPlanningSaveError(error);
+        return;
+      }
+    }
+
+    setConflictedTargets([]);
+    setPlanningSaveError(error);
   }
 
   function startPlanningSession(scope: MealPlanningScope) {

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -316,14 +316,19 @@ export function MealsView() {
   }
 
   function keepEditingPlanningDrafts() {
+    const firstConflictedIndex = conflictedTargets
+      .map((target) => findQueueIndex(planningQueue, target))
+      .find((index) => index >= 0);
     setPlanningSaveError(null);
     setConflictedTargets([]);
-    const nextIndex = findNextQueueIndex(
-      planningQueue,
-      0,
-      planningDrafts,
-      skippedPlanningTargets,
-    );
+    const nextIndex =
+      firstConflictedIndex ??
+      findNextQueueIndex(
+        planningQueue,
+        0,
+        planningDrafts,
+        skippedPlanningTargets,
+      );
     setCurrentPlanningIndex(nextIndex < planningQueue.length ? nextIndex : 0);
   }
 

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useMealsBoard, useRecipes, useSaveMealPlan } from "@/api";
 import { ApiException } from "@/api/client";
 import {
@@ -149,6 +149,9 @@ export function MealsView() {
   const [planningSaveError, setPlanningSaveError] = useState<Error | null>(
     null,
   );
+  const [isResolvingPlanningConflicts, setIsResolvingPlanningConflicts] =
+    useState(false);
+  const submittedPlanningDraftsRef = useRef<MealPlanningDraft[]>([]);
   const board = useMealsBoard(visibleWeekStartDate);
   const recipes = useRecipes();
   const pendingPlacementDraft = useAppStore(
@@ -223,21 +226,29 @@ export function MealsView() {
     setCurrentPlanningIndex(0);
     setConflictedTargets([]);
     setPlanningSaveError(null);
+    setIsResolvingPlanningConflicts(false);
+    submittedPlanningDraftsRef.current = [];
   }
 
   async function handlePlanningSaveError(error: Error) {
     setCurrentPlanningIndex(planningQueue.length);
 
     if (ApiException.isApiException(error) && error.status === 409) {
-      const refreshedBoard = (await board.refetch()).data?.data ?? null;
-      const conflicts = refreshedBoard
-        ? getConflictedDraftTargets(refreshedBoard, planningDrafts)
-        : [];
+      setIsResolvingPlanningConflicts(true);
+      try {
+        const submittedDrafts = submittedPlanningDraftsRef.current;
+        const refreshedBoard = (await board.refetch()).data?.data ?? null;
+        const conflicts = refreshedBoard
+          ? getConflictedDraftTargets(refreshedBoard, submittedDrafts)
+          : [];
 
-      if (conflicts.length > 0) {
-        setConflictedTargets(conflicts);
-        setPlanningSaveError(error);
-        return;
+        if (conflicts.length > 0) {
+          setConflictedTargets(conflicts);
+          setPlanningSaveError(error);
+          return;
+        }
+      } finally {
+        setIsResolvingPlanningConflicts(false);
       }
     }
 
@@ -377,8 +388,10 @@ export function MealsView() {
 
     setPlanningSaveError(null);
     setConflictedTargets([]);
+    const submittedDrafts = [...planningDrafts];
+    submittedPlanningDraftsRef.current = submittedDrafts;
     saveMealPlan.mutate(
-      toSaveMealPlanRequest(visibleWeekStartDate, planningDrafts),
+      toSaveMealPlanRequest(visibleWeekStartDate, submittedDrafts),
     );
   }
 
@@ -386,15 +399,16 @@ export function MealsView() {
     const remainingDrafts = planningDrafts.filter(
       (draft) => !hasTarget(conflictedTargets, draft.target),
     );
-    setPlanningDrafts(remainingDrafts);
-    setConflictedTargets([]);
-    setPlanningSaveError(null);
 
     if (remainingDrafts.length === 0) {
       setCurrentPlanningIndex(planningQueue.length);
       return;
     }
 
+    setPlanningDrafts(remainingDrafts);
+    setConflictedTargets([]);
+    setPlanningSaveError(null);
+    submittedPlanningDraftsRef.current = remainingDrafts;
     saveMealPlan.mutate(
       toSaveMealPlanRequest(visibleWeekStartDate, remainingDrafts),
     );
@@ -583,7 +597,7 @@ export function MealsView() {
           drafts={planningDrafts}
           currentIndex={currentPlanningIndex}
           recipes={recipes.data?.data ?? []}
-          isSaving={saveMealPlan.isPending}
+          isSaving={saveMealPlan.isPending || isResolvingPlanningConflicts}
           saveError={planningSaveError}
           conflictedTargets={conflictedTargets}
           onAddDraft={addPlanningDraft}

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -13,7 +13,9 @@ import { MobileSheet } from "@/components/ui/mobile-sheet";
 import { useBackHandler } from "@/hooks";
 import type {
   MealCollisionMode,
+  MealEntryRequest,
   MealSlot,
+  MealSlotEntry,
   RecipeSummary,
   UpsertMealSlotRequest,
 } from "@/lib/types";
@@ -50,6 +52,26 @@ function recipeMatchesQuery(recipe: RecipeSummary, query: string) {
     normalizedTitle.includes(query) ||
     normalizedTags.some((tag) => tag.includes(query))
   );
+}
+
+function existingEntryToRequest(entry: MealSlotEntry): MealEntryRequest {
+  if (entry.sourceType === "recipe" && entry.recipeId) {
+    return {
+      sourceType: "recipe",
+      recipeId: entry.recipeId,
+      title: null,
+      imageUrl: null,
+      note: null,
+    };
+  }
+
+  return {
+    sourceType: "quick",
+    recipeId: null,
+    title: entry.title,
+    imageUrl: entry.imageUrl,
+    note: entry.note,
+  };
 }
 
 function sortedByFavoriteThenRecent(recipes: RecipeSummary[]) {
@@ -134,6 +156,9 @@ export function MealComposerSheet({
     : `Plan ${formatMealType(activeSlot.mealType)}`;
   const trimmedMealName = mealName.trim();
   const seededRecipeId = activeSlot.seededRecipeId ?? null;
+  const existingExtrasForNewPrimary = activeSlot.primary
+    ? []
+    : activeSlot.extras.map(existingEntryToRequest);
 
   function submitRequest(request: UpsertMealSlotRequest) {
     if (isExtraIntent) {
@@ -184,7 +209,7 @@ export function MealComposerSheet({
       // The user's meal-planning note belongs to the slot; the recipe entry
       // snapshot is sourced from the saved recipe (entry note forced to null).
       primary: { sourceType: "recipe", recipeId },
-      extras: [],
+      extras: existingExtrasForNewPrimary,
       note,
       collisionMode: null,
     });
@@ -214,7 +239,7 @@ export function MealComposerSheet({
       mealType: activeSlot.mealType,
       // Quick-meal note belongs to the entry, not the slot (unchanged behavior).
       primary: { sourceType: "quick", title: mealName, imageUrl, note },
-      extras: [],
+      extras: existingExtrasForNewPrimary,
       note: null,
       collisionMode: null,
     });

--- a/src/components/meals/meal-day-card.tsx
+++ b/src/components/meals/meal-day-card.tsx
@@ -1,5 +1,9 @@
 import { parseLocalDate } from "@/lib/time-utils";
 import type { MealDay, MealSlot } from "@/lib/types";
+import type {
+  MealPlanningDraft,
+  MealPlanningTarget,
+} from "./meal-planning-session";
 import { MealSlotCard } from "./meal-slot-card";
 
 function formatDayLabel(date: string) {
@@ -14,6 +18,8 @@ interface MealDayCardProps {
   day: MealDay;
   readOnly: boolean;
   pendingRecipeId?: string | null;
+  planningDrafts?: MealPlanningDraft[];
+  planningTarget?: MealPlanningTarget | null;
   onSelectSlot: (slot: MealSlot) => void;
 }
 
@@ -21,6 +27,8 @@ export function MealDayCard({
   day,
   readOnly,
   pendingRecipeId = null,
+  planningDrafts = [],
+  planningTarget = null,
   onSelectSlot,
 }: MealDayCardProps) {
   return (
@@ -35,6 +43,17 @@ export function MealDayCard({
             slot={slot}
             readOnly={readOnly}
             pendingRecipeId={pendingRecipeId}
+            draft={
+              planningDrafts.find(
+                (draft) =>
+                  draft.target.dayIndex === slot.dayIndex &&
+                  draft.target.mealType === slot.mealType,
+              ) ?? null
+            }
+            isPlanningTarget={
+              planningTarget?.dayIndex === slot.dayIndex &&
+              planningTarget.mealType === slot.mealType
+            }
             onSelectSlot={onSelectSlot}
           />
         ))}

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -99,13 +99,20 @@ export function MealEditorSheet({
   const [mover, setMover] = useState<{ kind: "move" | "duplicate" } | null>(
     null,
   );
-  const [showRecipe, setShowRecipe] = useState(false);
+  const [recipeDetailSlotKey, setRecipeDetailSlotKey] = useState<string | null>(
+    null,
+  );
+  const selectedSlotKey = slotId
+    ? `${slotId.weekStartDate}:${slotId.dayIndex}:${slotId.mealType}`
+    : null;
   // The slot is always read from the live board so saves and collisions stay
   // accurate; local state only ever holds in-progress drafts.
   const liveSlot = board && slotId ? findSlot(board, slotId) : undefined;
   const selectedSlotMissing =
     isOpen && Boolean(board && slotId && !hasSlotContent(liveSlot));
   const recipeId = liveSlot?.primary?.recipeId ?? null;
+  const showRecipe =
+    recipeDetailSlotKey === selectedSlotKey && recipeId !== null;
   const recipe = useRecipe(showRecipe ? recipeId : null);
   const moveSlot = useMoveMealSlot({
     onSuccess: () => onOpenChange(false),
@@ -125,6 +132,16 @@ export function MealEditorSheet({
     setNoteDraft(liveSlot?.note ?? "");
     setIsEditingNote(false);
   }, [slotId?.weekStartDate, slotId?.dayIndex, slotId?.mealType]);
+  useEffect(() => {
+    setRecipeDetailSlotKey((current) =>
+      current === selectedSlotKey ? current : null,
+    );
+  }, [selectedSlotKey]);
+  useEffect(() => {
+    if (!isOpen) {
+      setRecipeDetailSlotKey(null);
+    }
+  }, [isOpen]);
   useEffect(() => {
     if (selectedSlotMissing) {
       onOpenChange(false);
@@ -208,7 +225,7 @@ export function MealEditorSheet({
     const destinationSlot = activeBoard.days[target.dayIndex]?.slots.find(
       (candidate) => candidate.mealType === target.mealType,
     );
-    if (destinationSlot?.primary) {
+    if (hasSlotContent(destinationSlot)) {
       setPendingCollision({ kind, request });
       return;
     }
@@ -243,7 +260,7 @@ export function MealEditorSheet({
           recipe.data?.data ? (
             <RecipeDetailView
               recipe={recipe.data.data}
-              onBack={() => setShowRecipe(false)}
+              onBack={() => setRecipeDetailSlotKey(null)}
             />
           ) : recipe.isLoading ? (
             <p className="text-sm text-muted-foreground">Loading recipe...</p>
@@ -394,7 +411,7 @@ export function MealEditorSheet({
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => setShowRecipe(true)}
+                  onClick={() => setRecipeDetailSlotKey(selectedSlotKey)}
                 >
                   View recipe
                 </Button>

--- a/src/components/meals/meal-editor-sheet.tsx
+++ b/src/components/meals/meal-editor-sheet.tsx
@@ -80,6 +80,10 @@ function findSlot(board: MealBoard, slotId: MealSlotId): MealSlot | undefined {
   );
 }
 
+function hasSlotContent(slot: MealSlot | undefined): slot is MealSlot {
+  return Boolean(slot?.primary) || (slot?.extras.length ?? 0) > 0;
+}
+
 export function MealEditorSheet({
   isOpen,
   slotId,
@@ -100,7 +104,7 @@ export function MealEditorSheet({
   // accurate; local state only ever holds in-progress drafts.
   const liveSlot = board && slotId ? findSlot(board, slotId) : undefined;
   const selectedSlotMissing =
-    isOpen && Boolean(board && slotId && !liveSlot?.primary);
+    isOpen && Boolean(board && slotId && !hasSlotContent(liveSlot));
   const recipeId = liveSlot?.primary?.recipeId ?? null;
   const recipe = useRecipe(showRecipe ? recipeId : null);
   const moveSlot = useMoveMealSlot({
@@ -133,11 +137,12 @@ export function MealEditorSheet({
     },
   });
 
-  if (!board || !slotId || !liveSlot?.primary) return null;
+  if (!board || !slotId || !hasSlotContent(liveSlot)) return null;
 
   const activeSlot = liveSlot;
   const activeBoard = board;
   const activePrimary = liveSlot.primary;
+  const hasPrimary = activePrimary !== null;
   const actionDisabled =
     readOnly ||
     moveSlot.isPending ||
@@ -155,6 +160,8 @@ export function MealEditorSheet({
     nextExtras: MealSlotEntry[],
     nextNote: string | null,
   ) {
+    if (!activePrimary) return;
+
     const request: UpsertMealSlotRequest = {
       weekStartDate: activeSlot.weekStartDate,
       dayIndex: activeSlot.dayIndex,
@@ -184,7 +191,7 @@ export function MealEditorSheet({
     dayIndex: number;
     mealType: MealSlot["mealType"];
   }) {
-    if (!mover) return;
+    if (!mover || !activePrimary) return;
     const kind = mover.kind;
     setMover(null);
 
@@ -249,12 +256,13 @@ export function MealEditorSheet({
           <div className="space-y-5">
             <div className="rounded-lg border border-border bg-card p-4">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Primary
+                {hasPrimary ? "Primary" : "Extras"}
               </p>
               <h2 className="mt-1 text-xl font-semibold text-foreground">
-                {activePrimary.title}
+                {activePrimary?.title ??
+                  `${formatMealType(activeSlot.mealType)} extras`}
               </h2>
-              {activePrimary.note ? (
+              {activePrimary?.note ? (
                 <p className="mt-2 text-sm text-muted-foreground">
                   {activePrimary.note}
                 </p>
@@ -267,7 +275,7 @@ export function MealEditorSheet({
                       className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-1 text-xs font-medium text-secondary-foreground"
                     >
                       {extra.title}
-                      {!readOnly ? (
+                      {!readOnly && hasPrimary ? (
                         <button
                           type="button"
                           aria-label={`Remove extra: ${extra.title}`}
@@ -283,6 +291,12 @@ export function MealEditorSheet({
                 </div>
               ) : null}
               {readOnly ? (
+                activeSlot.note ? (
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {activeSlot.note}
+                  </p>
+                ) : null
+              ) : !hasPrimary ? (
                 activeSlot.note ? (
                   <p className="mt-3 text-sm text-muted-foreground">
                     {activeSlot.note}
@@ -355,7 +369,7 @@ export function MealEditorSheet({
               <Button
                 type="button"
                 variant="outline"
-                disabled={actionDisabled}
+                disabled={actionDisabled || !hasPrimary}
                 onClick={() => onAddExtra?.(activeSlot)}
               >
                 Add extra or side
@@ -363,7 +377,7 @@ export function MealEditorSheet({
               <Button
                 type="button"
                 variant="outline"
-                disabled={actionDisabled}
+                disabled={actionDisabled || !hasPrimary}
                 onClick={() => setMover({ kind: "move" })}
               >
                 Move meal
@@ -371,7 +385,7 @@ export function MealEditorSheet({
               <Button
                 type="button"
                 variant="outline"
-                disabled={actionDisabled}
+                disabled={actionDisabled || !hasPrimary}
                 onClick={() => setMover({ kind: "duplicate" })}
               >
                 Duplicate meal

--- a/src/components/meals/meal-grid.tsx
+++ b/src/components/meals/meal-grid.tsx
@@ -1,5 +1,9 @@
 import { parseLocalDate } from "@/lib/time-utils";
 import type { MealBoard, MealSlot } from "@/lib/types";
+import type {
+  MealPlanningDraft,
+  MealPlanningTarget,
+} from "./meal-planning-session";
 import { MealSlotCard } from "./meal-slot-card";
 import { formatMealType } from "./meal-type-utils";
 
@@ -15,6 +19,8 @@ interface MealGridProps {
   board: MealBoard;
   readOnly: boolean;
   pendingRecipeId?: string | null;
+  planningDrafts?: MealPlanningDraft[];
+  planningTarget?: MealPlanningTarget | null;
   onSelectSlot: (slot: MealSlot) => void;
 }
 
@@ -22,6 +28,8 @@ export function MealGrid({
   board,
   readOnly,
   pendingRecipeId = null,
+  planningDrafts = [],
+  planningTarget = null,
   onSelectSlot,
 }: MealGridProps) {
   return (
@@ -71,6 +79,17 @@ export function MealGrid({
                       slot={slot}
                       readOnly={readOnly}
                       pendingRecipeId={pendingRecipeId}
+                      draft={
+                        planningDrafts.find(
+                          (draft) =>
+                            draft.target.dayIndex === slot.dayIndex &&
+                            draft.target.mealType === slot.mealType,
+                        ) ?? null
+                      }
+                      isPlanningTarget={
+                        planningTarget?.dayIndex === slot.dayIndex &&
+                        planningTarget.mealType === slot.mealType
+                      }
                       onSelectSlot={onSelectSlot}
                     />
                   </td>

--- a/src/components/meals/meal-planning-panel.test.tsx
+++ b/src/components/meals/meal-planning-panel.test.tsx
@@ -140,6 +140,21 @@ describe("MealPlanningPanel", () => {
     });
   });
 
+  it("shows inline feedback instead of drafting an invalid quick meal title", async () => {
+    const { props, user } = renderPanel();
+
+    await user.type(screen.getByLabelText("Meal name"), "A".repeat(161));
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Meal name must be 160 characters or less",
+    );
+    expect(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    ).toBeDisabled();
+
+    expect(props.onAddDraft).not.toHaveBeenCalled();
+  });
+
   it("keeps the recipe tray visible across draft choices", async () => {
     function Harness() {
       const [drafts, setDrafts] = useState<MealPlanningDraft[]>([]);

--- a/src/components/meals/meal-planning-panel.test.tsx
+++ b/src/components/meals/meal-planning-panel.test.tsx
@@ -16,7 +16,7 @@ import {
 
 const board = createEmptyMealsBoard();
 const queue = buildPlanningQueue(board, { kind: "empty_dinners" });
-const recipes: Array<RecipeSummary & { note: string | null }> = [
+const recipes: RecipeSummary[] = [
   {
     id: testRecipeDetail.id,
     title: testRecipeDetail.title,
@@ -24,7 +24,6 @@ const recipes: Array<RecipeSummary & { note: string | null }> = [
     favorite: true,
     tags: testRecipeDetail.tags,
     updatedAt: testRecipeDetail.updatedAt,
-    note: testRecipeDetail.note,
   },
   {
     id: importedRecipeDetail.id,
@@ -33,7 +32,6 @@ const recipes: Array<RecipeSummary & { note: string | null }> = [
     favorite: false,
     tags: importedRecipeDetail.tags,
     updatedAt: importedRecipeDetail.updatedAt,
-    note: importedRecipeDetail.note,
   },
 ];
 
@@ -130,7 +128,7 @@ describe("MealPlanningPanel", () => {
       target: { dayIndex: 0, mealType: "dinner" },
       displayTitle: testRecipeDetail.title,
       displayImageUrl: testRecipeDetail.imageUrl,
-      displayNote: testRecipeDetail.note,
+      displayNote: null,
       primary: {
         sourceType: "recipe",
         recipeId: testRecipeDetail.id,
@@ -208,6 +206,97 @@ describe("MealPlanningPanel", () => {
 
     await user.click(screen.getByRole("button", { name: "Keep editing" }));
     expect(props.onKeepEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it("mirrors current target and draft controls inside the planning surface", async () => {
+    const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    const { props, user } = renderPanel({
+      drafts: [draft],
+      currentIndex: 1,
+    });
+
+    const surface = screen.getByRole("region", {
+      name: "Planning board status",
+    });
+    const draftButton = within(surface).getByRole("button", {
+      name: "Draft dinner: Tacos",
+    });
+    expect(draftButton).toBeInTheDocument();
+    await user.click(draftButton);
+    expect(props.onChangeDraft).toHaveBeenCalledWith(draft.target);
+
+    const currentTarget = within(surface).getByRole("button", {
+      name: "Current dinner target: Monday dinner",
+    });
+    expect(currentTarget).toHaveAttribute("aria-current", "true");
+  });
+
+  it("disables editing controls and sheet cancellation while a save is pending", async () => {
+    const draft = draftFor(
+      { dayIndex: 1, mealType: "dinner" },
+      testRecipeDetail.title,
+    );
+    const { props, user } = renderPanel({
+      drafts: [draft],
+      currentIndex: 1,
+      isSaving: true,
+    });
+
+    expect(screen.getByRole("button", { name: "Update draft" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Skip this slot" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: `Remove draft: ${testRecipeDetail.title}`,
+      }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Review plan" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Back" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Cancel planning" }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: `Select recipe: ${testRecipeDetail.title}`,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Show all recipes" }),
+    ).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(props.onCancel).not.toHaveBeenCalled();
+  });
+
+  it("disables review and conflict controls while a save is pending", () => {
+    const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    renderPanel({
+      drafts: [draft],
+      currentIndex: queue.length,
+      isSaving: true,
+      conflictedTargets: [draft.target],
+    });
+
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(
+      screen.getByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    ).toBeDisabled();
+    for (const button of screen.getAllByRole("button", {
+      name: "Keep editing",
+    })) {
+      expect(button).toBeDisabled();
+    }
+    expect(screen.getByRole("button", { name: "Cancel save" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Cancel planning" }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Change draft" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Remove draft: Tacos" }),
+    ).toBeDisabled();
   });
 
   it("renders review, save, and conflict actions", async () => {

--- a/src/components/meals/meal-planning-panel.test.tsx
+++ b/src/components/meals/meal-planning-panel.test.tsx
@@ -299,16 +299,20 @@ describe("MealPlanningPanel", () => {
     ).toBeDisabled();
   });
 
-  it("renders review, save, and conflict actions", async () => {
+  it("renders review, save, and conflict actions when remaining drafts can be saved", async () => {
     const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    const remainingDraft = draftFor(
+      { dayIndex: 1, mealType: "dinner" },
+      "Soup",
+    );
     const { props, user } = renderPanel({
-      drafts: [draft],
+      drafts: [draft, remainingDraft],
       currentIndex: queue.length,
       conflictedTargets: [draft.target],
       saveError: new Error("Some meal slots are no longer empty."),
     });
 
-    expect(screen.getByText("1 meals ready to add")).toBeInTheDocument();
+    expect(screen.getByText("2 meals ready to add")).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
       "Some meal slots are no longer empty.",
     );
@@ -334,5 +338,26 @@ describe("MealPlanningPanel", () => {
 
     const summary = screen.getByRole("list", { name: "Draft meals" });
     expect(within(summary).getByText("Tacos")).toBeInTheDocument();
+    expect(within(summary).getByText("Soup")).toBeInTheDocument();
+  });
+
+  it("disables skip-conflicted when every draft is conflicted", () => {
+    const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    const { props } = renderPanel({
+      drafts: [draft],
+      currentIndex: queue.length,
+      conflictedTargets: [draft.target],
+      saveError: new Error("Some meal slots are no longer empty."),
+    });
+
+    expect(
+      screen.getByText("No remaining drafts to save."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    ).toBeDisabled();
+    expect(props.onSaveNonConflicted).not.toHaveBeenCalled();
   });
 });

--- a/src/components/meals/meal-planning-panel.test.tsx
+++ b/src/components/meals/meal-planning-panel.test.tsx
@@ -1,0 +1,243 @@
+import { type ComponentProps, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { RecipeSummary } from "@/lib/types";
+import { createEmptyMealsBoard } from "@/test/fixtures/meals";
+import {
+  importedRecipeDetail,
+  testRecipeDetail,
+} from "@/test/fixtures/recipes";
+import { renderWithUser, screen, within } from "@/test/test-utils";
+import { MealPlanningPanel } from "./meal-planning-panel";
+import {
+  buildPlanningQueue,
+  type MealPlanningDraft,
+  type MealPlanningTarget,
+} from "./meal-planning-session";
+
+const board = createEmptyMealsBoard();
+const queue = buildPlanningQueue(board, { kind: "empty_dinners" });
+const recipes: Array<RecipeSummary & { note: string | null }> = [
+  {
+    id: testRecipeDetail.id,
+    title: testRecipeDetail.title,
+    imageUrl: testRecipeDetail.imageUrl,
+    favorite: true,
+    tags: testRecipeDetail.tags,
+    updatedAt: testRecipeDetail.updatedAt,
+    note: testRecipeDetail.note,
+  },
+  {
+    id: importedRecipeDetail.id,
+    title: importedRecipeDetail.title,
+    imageUrl: importedRecipeDetail.imageUrl,
+    favorite: false,
+    tags: importedRecipeDetail.tags,
+    updatedAt: importedRecipeDetail.updatedAt,
+    note: importedRecipeDetail.note,
+  },
+];
+
+function draftFor(
+  target: MealPlanningTarget,
+  title = "Tacos",
+): MealPlanningDraft {
+  return {
+    target,
+    displayTitle: title,
+    displayImageUrl: null,
+    displayNote: null,
+    primary: {
+      sourceType: "quick",
+      recipeId: null,
+      title,
+      imageUrl: null,
+      note: null,
+    },
+    note: null,
+  };
+}
+
+function renderPanel(
+  overrides: Partial<ComponentProps<typeof MealPlanningPanel>> = {},
+) {
+  const props = {
+    isOpen: true,
+    board,
+    queue,
+    drafts: [],
+    currentIndex: 0,
+    recipes,
+    isSaving: false,
+    saveError: null,
+    conflictedTargets: [],
+    onAddDraft: vi.fn(),
+    onRemoveDraft: vi.fn(),
+    onSkip: vi.fn(),
+    onBack: vi.fn(),
+    onReview: vi.fn(),
+    onSave: vi.fn(),
+    onSaveNonConflicted: vi.fn(),
+    onKeepEditing: vi.fn(),
+    onCancelSave: vi.fn(),
+    onCancel: vi.fn(),
+    onChangeDraft: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    props,
+    ...renderWithUser(<MealPlanningPanel {...props} />),
+  };
+}
+
+describe("MealPlanningPanel", () => {
+  it("creates quick and recipe drafts without saving the slot", async () => {
+    const { props, user } = renderPanel();
+
+    expect(
+      screen.getByRole("dialog", { name: "Meal planning" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Sunday dinner - 1 of 7")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Meal name"), "  Tacos  ");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    expect(props.onAddDraft).toHaveBeenLastCalledWith({
+      target: { dayIndex: 0, mealType: "dinner" },
+      displayTitle: "Tacos",
+      displayImageUrl: null,
+      displayNote: null,
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title: "Tacos",
+        imageUrl: null,
+        note: null,
+      },
+      note: null,
+    });
+
+    await user.clear(screen.getByLabelText("Meal name"));
+    await user.click(
+      screen.getByRole("button", {
+        name: `Select recipe: ${testRecipeDetail.title}`,
+      }),
+    );
+
+    expect(props.onAddDraft).toHaveBeenLastCalledWith({
+      target: { dayIndex: 0, mealType: "dinner" },
+      displayTitle: testRecipeDetail.title,
+      displayImageUrl: testRecipeDetail.imageUrl,
+      displayNote: testRecipeDetail.note,
+      primary: {
+        sourceType: "recipe",
+        recipeId: testRecipeDetail.id,
+        title: null,
+        imageUrl: null,
+        note: null,
+      },
+      note: null,
+    });
+  });
+
+  it("keeps the recipe tray visible across draft choices", async () => {
+    function Harness() {
+      const [drafts, setDrafts] = useState<MealPlanningDraft[]>([]);
+      const [currentIndex, setCurrentIndex] = useState(0);
+
+      return (
+        <MealPlanningPanel
+          isOpen
+          board={board}
+          queue={queue}
+          drafts={drafts}
+          currentIndex={currentIndex}
+          recipes={recipes}
+          isSaving={false}
+          saveError={null}
+          conflictedTargets={[]}
+          onAddDraft={(draft) => {
+            setDrafts((current) => [...current, draft]);
+            setCurrentIndex((index) => index + 1);
+          }}
+          onRemoveDraft={vi.fn()}
+          onSkip={vi.fn()}
+          onBack={vi.fn()}
+          onReview={vi.fn()}
+          onSave={vi.fn()}
+          onSaveNonConflicted={vi.fn()}
+          onKeepEditing={vi.fn()}
+          onCancelSave={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+    }
+
+    const { user } = renderWithUser(<Harness />);
+
+    await user.type(screen.getByLabelText("Meal name"), "Tacos");
+    await user.click(
+      screen.getByRole("button", { name: "Add quick meal draft" }),
+    );
+
+    expect(screen.getByText("Monday dinner - 2 of 7")).toBeInTheDocument();
+    expect(screen.getByText("Favorite recipes")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: `Select recipe: ${testRecipeDetail.title}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls skip, remove, and change-draft callbacks with the active target", async () => {
+    const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    const { props, user } = renderPanel({
+      drafts: [draft],
+      currentIndex: queue.length,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Change draft" }));
+    expect(props.onChangeDraft).toHaveBeenCalledWith(draft.target);
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove draft: Tacos" }),
+    );
+    expect(props.onRemoveDraft).toHaveBeenCalledWith(draft.target);
+
+    await user.click(screen.getByRole("button", { name: "Keep editing" }));
+    expect(props.onKeepEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders review, save, and conflict actions", async () => {
+    const draft = draftFor({ dayIndex: 0, mealType: "dinner" });
+    const { props, user } = renderPanel({
+      drafts: [draft],
+      currentIndex: queue.length,
+      conflictedTargets: [draft.target],
+      saveError: new Error("Some meal slots are no longer empty."),
+    });
+
+    expect(screen.getByText("1 meals ready to add")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Some meal slots are no longer empty.",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Save to week" }));
+    expect(props.onSave).toHaveBeenCalledTimes(1);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Skip conflicted and save remaining",
+      }),
+    );
+    expect(props.onSaveNonConflicted).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Cancel save" }));
+    expect(props.onCancelSave).toHaveBeenCalledTimes(1);
+
+    const summary = screen.getByRole("list", { name: "Draft meals" });
+    expect(within(summary).getByText("Tacos")).toBeInTheDocument();
+  });
+});

--- a/src/components/meals/meal-planning-panel.test.tsx
+++ b/src/components/meals/meal-planning-panel.test.tsx
@@ -322,6 +322,12 @@ describe("MealPlanningPanel", () => {
       }),
     );
     expect(props.onSaveNonConflicted).toHaveBeenCalledTimes(1);
+    expect(
+      screen.queryByRole("button", { name: "Replace primary" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add as extra" }),
+    ).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Cancel save" }));
     expect(props.onCancelSave).toHaveBeenCalledTimes(1);

--- a/src/components/meals/meal-planning-panel.tsx
+++ b/src/components/meals/meal-planning-panel.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { MobileSheet } from "@/components/ui/mobile-sheet";
 import { parseLocalDate } from "@/lib/time-utils";
 import type { MealBoard, MealSlot, RecipeSummary } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { mealEntrySchema, toMealEntryRequest } from "@/lib/validations";
 import type {
   MealPlanningDraft,
   MealPlanningTarget,
@@ -109,6 +110,7 @@ export function MealPlanningPanel({
 }: MealPlanningPanelProps) {
   const [mealName, setMealName] = useState("");
   const [showAll, setShowAll] = useState(false);
+  const mealNameErrorId = useId();
 
   const currentSlot = queue[currentIndex] ?? null;
   const currentTarget = currentSlot
@@ -118,6 +120,17 @@ export function MealPlanningPanel({
   const currentDraft = draftForTarget(drafts, currentTarget);
   const isReviewing = currentIndex >= queue.length;
   const query = normalize(mealName);
+  const quickMealResult = mealEntrySchema.safeParse({
+    sourceType: "quick",
+    recipeId: null,
+    title: mealName,
+    imageUrl: null,
+    note: null,
+  });
+  const quickMealError =
+    mealName.trim().length > 0 && !quickMealResult.success
+      ? quickMealResult.error.issues[0]?.message
+      : null;
 
   useEffect(() => {
     if (!isOpen) return;
@@ -173,21 +186,17 @@ export function MealPlanningPanel({
 
   function addQuickDraft() {
     if (!currentTarget) return;
-    const title = mealName.trim();
-    if (!title) return;
+    if (!quickMealResult.success || quickMealResult.data.sourceType !== "quick")
+      return;
+
+    const primary = toMealEntryRequest(quickMealResult.data);
 
     onAddDraft({
       target: currentTarget,
-      displayTitle: title,
-      displayImageUrl: null,
-      displayNote: null,
-      primary: {
-        sourceType: "quick",
-        recipeId: null,
-        title,
-        imageUrl: null,
-        note: null,
-      },
+      displayTitle: quickMealResult.data.title,
+      displayImageUrl: primary.imageUrl,
+      displayNote: primary.note,
+      primary,
       note: null,
     });
   }
@@ -540,15 +549,28 @@ export function MealPlanningPanel({
                   value={mealName}
                   onChange={(event) => setMealName(event.target.value)}
                   disabled={isSaving}
+                  aria-invalid={quickMealError ? true : undefined}
+                  aria-describedby={
+                    quickMealError ? mealNameErrorId : undefined
+                  }
                   className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
                 />
+                {quickMealError ? (
+                  <p
+                    id={mealNameErrorId}
+                    className="text-sm text-destructive"
+                    role="alert"
+                  >
+                    {quickMealError}
+                  </p>
+                ) : null}
               </label>
 
               <div className="grid gap-2 sm:grid-cols-2">
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={!mealName.trim() || isSaving}
+                  disabled={!quickMealResult.success || isSaving}
                   onClick={addQuickDraft}
                 >
                   {currentDraft ? "Update draft" : "Add quick meal draft"}

--- a/src/components/meals/meal-planning-panel.tsx
+++ b/src/components/meals/meal-planning-panel.tsx
@@ -11,15 +11,13 @@ import type {
 import { formatMealType } from "./meal-type-utils";
 import { RecipeMatchList } from "./recipe-match-list";
 
-type MealPlanningRecipe = RecipeSummary & { note?: string | null };
-
 export interface MealPlanningPanelProps {
   isOpen: boolean;
   board: MealBoard;
   queue: MealSlot[];
   drafts: MealPlanningDraft[];
   currentIndex: number;
-  recipes: MealPlanningRecipe[];
+  recipes: RecipeSummary[];
   isSaving: boolean;
   saveError: Error | null;
   conflictedTargets: MealPlanningTarget[];
@@ -166,11 +164,6 @@ export function MealPlanningPanel({
       ),
     [recipes, query],
   );
-  const recipesById = useMemo(
-    () => new Map(recipes.map((recipe) => [recipe.id, recipe])),
-    [recipes],
-  );
-
   const progressLabel =
     currentSlot !== null
       ? `${dayLabelForTarget(board, currentSlot)} ${currentSlot.mealType} - ${
@@ -206,7 +199,7 @@ export function MealPlanningPanel({
       target: currentTarget,
       displayTitle: recipe.title,
       displayImageUrl: recipe.imageUrl,
-      displayNote: recipesById.get(recipe.id)?.note ?? null,
+      displayNote: null,
       primary: {
         sourceType: "recipe",
         recipeId: recipe.id,
@@ -220,6 +213,84 @@ export function MealPlanningPanel({
 
   function changeDraft(target: MealPlanningTarget) {
     onChangeDraft?.(target);
+  }
+
+  function guardedCancel() {
+    if (isSaving) return;
+    onCancel();
+  }
+
+  function renderPlanningSurface() {
+    if (!currentTarget && drafts.length === 0) return null;
+
+    const sortedDrafts = [...drafts].sort((left, right) => {
+      const leftIndex = queue.findIndex((slot) =>
+        sameTarget(slot, left.target),
+      );
+      const rightIndex = queue.findIndex((slot) =>
+        sameTarget(slot, right.target),
+      );
+      return (
+        (leftIndex < 0 ? Number.MAX_SAFE_INTEGER : leftIndex) -
+        (rightIndex < 0 ? Number.MAX_SAFE_INTEGER : rightIndex)
+      );
+    });
+
+    return (
+      <section
+        aria-label="Planning board status"
+        className="space-y-2 rounded-lg border border-border bg-muted/30 p-3"
+      >
+        <h3 className="text-sm font-semibold text-foreground">
+          Planning board status
+        </h3>
+        <div className="space-y-2">
+          {currentTarget && !currentDraft ? (
+            <button
+              type="button"
+              aria-current="true"
+              aria-label={`Current ${currentTarget.mealType} target: ${dayLabelForTarget(
+                board,
+                currentTarget,
+              )} ${currentTarget.mealType}`}
+              className="w-full rounded-lg border border-primary/50 bg-primary/5 p-3 text-left text-sm font-medium text-foreground"
+              disabled={isSaving}
+              onClick={() => changeDraft(currentTarget)}
+            >
+              Current target: {dayLabelForTarget(board, currentTarget)}{" "}
+              {formatMealType(currentTarget.mealType)}
+            </button>
+          ) : null}
+
+          {sortedDrafts.map((draft) => {
+            const isCurrent =
+              currentTarget !== null && sameTarget(currentTarget, draft.target);
+            return (
+              <button
+                key={targetKey(draft.target)}
+                type="button"
+                aria-current={isCurrent ? "true" : undefined}
+                aria-label={`Draft ${draft.target.mealType}: ${draft.displayTitle}`}
+                className={cn(
+                  "w-full rounded-lg border border-border bg-card p-3 text-left text-sm transition-colors",
+                  isCurrent ? "border-primary/70 bg-primary/5" : null,
+                )}
+                disabled={isSaving}
+                onClick={() => changeDraft(draft.target)}
+              >
+                <span className="block font-semibold text-foreground">
+                  Draft: {draft.displayTitle}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  {dayLabelForTarget(board, draft.target)}{" "}
+                  {formatMealType(draft.target.mealType)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    );
   }
 
   function renderRecipeTray() {
@@ -256,6 +327,7 @@ export function MealPlanningPanel({
           type="button"
           variant="ghost"
           className="w-full justify-start"
+          disabled={isSaving}
           onClick={() => setShowAll(true)}
         >
           Show all recipes
@@ -316,6 +388,7 @@ export function MealPlanningPanel({
               <Button
                 type="button"
                 variant="outline"
+                disabled={isSaving}
                 onClick={() => changeDraft(draft.target)}
               >
                 Change draft
@@ -324,6 +397,7 @@ export function MealPlanningPanel({
                 type="button"
                 variant="ghost"
                 aria-label={`Remove draft: ${draft.displayTitle}`}
+                disabled={isSaving}
                 onClick={() => onRemoveDraft(draft.target)}
               >
                 Remove draft
@@ -358,10 +432,20 @@ export function MealPlanningPanel({
           >
             Skip conflicted and save remaining
           </Button>
-          <Button type="button" variant="outline" onClick={onKeepEditing}>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={isSaving}
+            onClick={onKeepEditing}
+          >
             Keep editing
           </Button>
-          <Button type="button" variant="ghost" onClick={onCancelSave}>
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={isSaving}
+            onClick={onCancelSave}
+          >
             Cancel save
           </Button>
         </div>
@@ -370,7 +454,7 @@ export function MealPlanningPanel({
   }
 
   return (
-    <MobileSheet isOpen={isOpen} onClose={onCancel} title="Meal planning">
+    <MobileSheet isOpen={isOpen} onClose={guardedCancel} title="Meal planning">
       <div className="space-y-5">
         {saveError ? (
           <p className="text-sm text-destructive" role="alert">
@@ -380,6 +464,8 @@ export function MealPlanningPanel({
 
         {isReviewing ? (
           <div className="space-y-5">
+            {renderPlanningSurface()}
+
             <section className="space-y-3">
               <div>
                 <h2 className="text-base font-semibold text-foreground">
@@ -402,16 +488,28 @@ export function MealPlanningPanel({
               >
                 {isSaving ? "Saving..." : "Save to week"}
               </Button>
-              <Button type="button" variant="outline" onClick={onKeepEditing}>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isSaving}
+                onClick={onKeepEditing}
+              >
                 Keep editing
               </Button>
-              <Button type="button" variant="ghost" onClick={onCancel}>
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={isSaving}
+                onClick={guardedCancel}
+              >
                 Cancel planning
               </Button>
             </div>
           </div>
         ) : (
           <div className="space-y-5">
+            {renderPlanningSurface()}
+
             <section className="space-y-3">
               <div>
                 <p className="text-sm font-semibold text-foreground">
@@ -431,6 +529,7 @@ export function MealPlanningPanel({
                 <input
                   value={mealName}
                   onChange={(event) => setMealName(event.target.value)}
+                  disabled={isSaving}
                   className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
                 />
               </label>
@@ -439,12 +538,17 @@ export function MealPlanningPanel({
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={!mealName.trim()}
+                  disabled={!mealName.trim() || isSaving}
                   onClick={addQuickDraft}
                 >
                   {currentDraft ? "Update draft" : "Add quick meal draft"}
                 </Button>
-                <Button type="button" variant="secondary" onClick={onSkip}>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={isSaving}
+                  onClick={onSkip}
+                >
                   Skip this slot
                 </Button>
               </div>
@@ -455,6 +559,7 @@ export function MealPlanningPanel({
                   variant="ghost"
                   className="w-full justify-start"
                   aria-label={`Remove draft: ${currentDraft.displayTitle}`}
+                  disabled={isSaving}
                   onClick={() => onRemoveDraft(currentDraft.target)}
                 >
                   Remove draft
@@ -462,22 +567,32 @@ export function MealPlanningPanel({
               ) : null}
             </section>
 
-            <div className="space-y-3">{renderRecipeTray()}</div>
+            <fieldset
+              disabled={isSaving}
+              className="m-0 min-w-0 space-y-3 border-0 p-0"
+            >
+              {renderRecipeTray()}
+            </fieldset>
 
             <div className="grid gap-2">
-              <Button type="button" onClick={onReview}>
+              <Button type="button" disabled={isSaving} onClick={onReview}>
                 Review plan
               </Button>
               <div className="grid gap-2 sm:grid-cols-2">
                 <Button
                   type="button"
                   variant="outline"
-                  disabled={currentIndex === 0}
+                  disabled={currentIndex === 0 || isSaving}
                   onClick={onBack}
                 >
                   Back
                 </Button>
-                <Button type="button" variant="ghost" onClick={onCancel}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={isSaving}
+                  onClick={guardedCancel}
+                >
                   Cancel planning
                 </Button>
               </div>

--- a/src/components/meals/meal-planning-panel.tsx
+++ b/src/components/meals/meal-planning-panel.tsx
@@ -412,6 +412,11 @@ export function MealPlanningPanel({
   function renderConflictSummary() {
     if (conflictedTargets.length === 0) return null;
 
+    const hasNonConflictedDrafts = drafts.some(
+      (draft) =>
+        !conflictedTargets.some((target) => sameTarget(target, draft.target)),
+    );
+
     return (
       <section className="space-y-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
         <div>
@@ -423,11 +428,16 @@ export function MealPlanningPanel({
             {conflictedTargets.length === 1 ? "" : "s"} can no longer be saved
             because the slot is no longer empty.
           </p>
+          {!hasNonConflictedDrafts ? (
+            <p className="mt-1 text-sm font-medium text-foreground">
+              No remaining drafts to save.
+            </p>
+          ) : null}
         </div>
         <div className="grid gap-2">
           <Button
             type="button"
-            disabled={isSaving}
+            disabled={isSaving || !hasNonConflictedDrafts}
             onClick={onSaveNonConflicted}
           >
             Skip conflicted and save remaining

--- a/src/components/meals/meal-planning-panel.tsx
+++ b/src/components/meals/meal-planning-panel.tsx
@@ -1,0 +1,490 @@
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { parseLocalDate } from "@/lib/time-utils";
+import type { MealBoard, MealSlot, RecipeSummary } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type {
+  MealPlanningDraft,
+  MealPlanningTarget,
+} from "./meal-planning-session";
+import { formatMealType } from "./meal-type-utils";
+import { RecipeMatchList } from "./recipe-match-list";
+
+type MealPlanningRecipe = RecipeSummary & { note?: string | null };
+
+export interface MealPlanningPanelProps {
+  isOpen: boolean;
+  board: MealBoard;
+  queue: MealSlot[];
+  drafts: MealPlanningDraft[];
+  currentIndex: number;
+  recipes: MealPlanningRecipe[];
+  isSaving: boolean;
+  saveError: Error | null;
+  conflictedTargets: MealPlanningTarget[];
+  onAddDraft: (draft: MealPlanningDraft) => void;
+  onRemoveDraft: (target: MealPlanningTarget) => void;
+  onSkip: () => void;
+  onBack: () => void;
+  onReview: () => void;
+  onSave: () => void;
+  onSaveNonConflicted: () => void;
+  onKeepEditing: () => void;
+  onCancelSave: () => void;
+  onCancel: () => void;
+  onChangeDraft?: (target: MealPlanningTarget) => void;
+}
+
+function normalize(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function recipeMatchesQuery(recipe: RecipeSummary, query: string) {
+  if (!query) return true;
+
+  const normalizedTitle = normalize(recipe.title);
+  const normalizedTags = recipe.tags.map((tag) => normalize(tag));
+  return (
+    normalizedTitle.includes(query) ||
+    normalizedTags.some((tag) => tag.includes(query))
+  );
+}
+
+function sortedByFavoriteThenRecent(recipes: RecipeSummary[]) {
+  return [...recipes].sort((left, right) => {
+    if (left.favorite !== right.favorite) return left.favorite ? -1 : 1;
+    return right.updatedAt.localeCompare(left.updatedAt);
+  });
+}
+
+function targetKey(target: MealPlanningTarget) {
+  return `${target.dayIndex}:${target.mealType}`;
+}
+
+function sameTarget(left: MealPlanningTarget, right: MealPlanningTarget) {
+  return left.dayIndex === right.dayIndex && left.mealType === right.mealType;
+}
+
+function dayNameFromDate(date: string) {
+  return parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "long",
+  });
+}
+
+function dayLabelForTarget(board: MealBoard, target: MealPlanningTarget) {
+  const day = board.days.find(
+    (candidate) => candidate.dayIndex === target.dayIndex,
+  );
+  return day ? dayNameFromDate(day.date) : `Day ${target.dayIndex + 1}`;
+}
+
+function draftForTarget(
+  drafts: MealPlanningDraft[],
+  target: MealPlanningTarget | null,
+) {
+  if (!target) return null;
+  return drafts.find((draft) => sameTarget(draft.target, target)) ?? null;
+}
+
+export function MealPlanningPanel({
+  isOpen,
+  board,
+  queue,
+  drafts,
+  currentIndex,
+  recipes,
+  isSaving,
+  saveError,
+  conflictedTargets,
+  onAddDraft,
+  onRemoveDraft,
+  onSkip,
+  onBack,
+  onReview,
+  onSave,
+  onSaveNonConflicted,
+  onKeepEditing,
+  onCancelSave,
+  onCancel,
+  onChangeDraft,
+}: MealPlanningPanelProps) {
+  const [mealName, setMealName] = useState("");
+  const [showAll, setShowAll] = useState(false);
+
+  const currentSlot = queue[currentIndex] ?? null;
+  const currentTarget = currentSlot
+    ? { dayIndex: currentSlot.dayIndex, mealType: currentSlot.mealType }
+    : null;
+  const currentTargetKey = currentTarget ? targetKey(currentTarget) : "review";
+  const currentDraft = draftForTarget(drafts, currentTarget);
+  const isReviewing = currentIndex >= queue.length;
+  const query = normalize(mealName);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (currentTargetKey === "review") {
+      setMealName("");
+      setShowAll(false);
+      return;
+    }
+    if (currentDraft?.primary.sourceType === "quick") {
+      setMealName(currentDraft.displayTitle);
+    } else {
+      setMealName("");
+    }
+    setShowAll(false);
+  }, [currentDraft, currentTargetKey, isOpen]);
+
+  const favoriteRecipes = useMemo(
+    () =>
+      recipes
+        .filter((recipe) => recipe.favorite)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .slice(0, 4),
+    [recipes],
+  );
+  const recentRecipes = useMemo(
+    () =>
+      recipes
+        .filter((recipe) => !recipe.favorite)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+        .slice(0, 4),
+    [recipes],
+  );
+  const matchingRecipes = useMemo(
+    () =>
+      sortedByFavoriteThenRecent(
+        recipes.filter((recipe) => recipeMatchesQuery(recipe, query)),
+      ).slice(0, 6),
+    [recipes, query],
+  );
+  const allSortedRecipes = useMemo(
+    () =>
+      sortedByFavoriteThenRecent(
+        recipes.filter((recipe) => recipeMatchesQuery(recipe, query)),
+      ),
+    [recipes, query],
+  );
+  const recipesById = useMemo(
+    () => new Map(recipes.map((recipe) => [recipe.id, recipe])),
+    [recipes],
+  );
+
+  const progressLabel =
+    currentSlot !== null
+      ? `${dayLabelForTarget(board, currentSlot)} ${currentSlot.mealType} - ${
+          currentIndex + 1
+        } of ${queue.length}`
+      : null;
+
+  function addQuickDraft() {
+    if (!currentTarget) return;
+    const title = mealName.trim();
+    if (!title) return;
+
+    onAddDraft({
+      target: currentTarget,
+      displayTitle: title,
+      displayImageUrl: null,
+      displayNote: null,
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title,
+        imageUrl: null,
+        note: null,
+      },
+      note: null,
+    });
+  }
+
+  function addRecipeDraft(recipe: RecipeSummary) {
+    if (!currentTarget) return;
+
+    onAddDraft({
+      target: currentTarget,
+      displayTitle: recipe.title,
+      displayImageUrl: recipe.imageUrl,
+      displayNote: recipesById.get(recipe.id)?.note ?? null,
+      primary: {
+        sourceType: "recipe",
+        recipeId: recipe.id,
+        title: null,
+        imageUrl: null,
+        note: null,
+      },
+      note: null,
+    });
+  }
+
+  function changeDraft(target: MealPlanningTarget) {
+    onChangeDraft?.(target);
+  }
+
+  function renderRecipeTray() {
+    return showAll ? (
+      <RecipeMatchList
+        title="All recipes"
+        recipes={allSortedRecipes}
+        onSelectRecipe={addRecipeDraft}
+      />
+    ) : (
+      <>
+        {query ? (
+          <RecipeMatchList
+            title="Matching recipes"
+            recipes={matchingRecipes}
+            onSelectRecipe={addRecipeDraft}
+          />
+        ) : (
+          <>
+            <RecipeMatchList
+              title="Favorite recipes"
+              recipes={favoriteRecipes}
+              onSelectRecipe={addRecipeDraft}
+            />
+            <RecipeMatchList
+              title="Recent recipes"
+              recipes={recentRecipes}
+              onSelectRecipe={addRecipeDraft}
+            />
+          </>
+        )}
+
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-full justify-start"
+          onClick={() => setShowAll(true)}
+        >
+          Show all recipes
+        </Button>
+      </>
+    );
+  }
+
+  function renderDraftList() {
+    if (drafts.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          No meals are queued for this week yet.
+        </p>
+      );
+    }
+
+    return (
+      <ul aria-label="Draft meals" className="space-y-2">
+        {drafts.map((draft) => (
+          <li
+            key={targetKey(draft.target)}
+            className={cn(
+              "rounded-lg border border-border bg-card p-3",
+              conflictedTargets.some((target) =>
+                sameTarget(target, draft.target),
+              )
+                ? "border-destructive/50 bg-destructive/5"
+                : null,
+            )}
+          >
+            <div className="flex items-start gap-3">
+              {draft.displayImageUrl ? (
+                <img
+                  src={draft.displayImageUrl}
+                  alt=""
+                  className="h-12 w-12 rounded-md object-cover"
+                />
+              ) : (
+                <div className="h-12 w-12 rounded-md bg-muted" />
+              )}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-foreground">
+                  {draft.displayTitle}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {dayLabelForTarget(board, draft.target)}{" "}
+                  {formatMealType(draft.target.mealType)}
+                </p>
+                {draft.displayNote ? (
+                  <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                    {draft.displayNote}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            <div className="mt-3 grid gap-2 sm:grid-cols-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => changeDraft(draft.target)}
+              >
+                Change draft
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                aria-label={`Remove draft: ${draft.displayTitle}`}
+                onClick={() => onRemoveDraft(draft.target)}
+              >
+                Remove draft
+              </Button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  function renderConflictSummary() {
+    if (conflictedTargets.length === 0) return null;
+
+    return (
+      <section className="space-y-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">
+            Some slots changed
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {conflictedTargets.length} draft
+            {conflictedTargets.length === 1 ? "" : "s"} can no longer be saved
+            because the slot is no longer empty.
+          </p>
+        </div>
+        <div className="grid gap-2">
+          <Button
+            type="button"
+            disabled={isSaving}
+            onClick={onSaveNonConflicted}
+          >
+            Skip conflicted and save remaining
+          </Button>
+          <Button type="button" variant="outline" onClick={onKeepEditing}>
+            Keep editing
+          </Button>
+          <Button type="button" variant="ghost" onClick={onCancelSave}>
+            Cancel save
+          </Button>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <MobileSheet isOpen={isOpen} onClose={onCancel} title="Meal planning">
+      <div className="space-y-5">
+        {saveError ? (
+          <p className="text-sm text-destructive" role="alert">
+            {saveError.message}
+          </p>
+        ) : null}
+
+        {isReviewing ? (
+          <div className="space-y-5">
+            <section className="space-y-3">
+              <div>
+                <h2 className="text-base font-semibold text-foreground">
+                  {drafts.length} meals ready to add
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                  Review the local draft plan before saving it to the week.
+                </p>
+              </div>
+              {renderDraftList()}
+            </section>
+
+            {renderConflictSummary()}
+
+            <div className="grid gap-2">
+              <Button
+                type="button"
+                disabled={drafts.length === 0 || isSaving}
+                onClick={onSave}
+              >
+                {isSaving ? "Saving..." : "Save to week"}
+              </Button>
+              <Button type="button" variant="outline" onClick={onKeepEditing}>
+                Keep editing
+              </Button>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                Cancel planning
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-5">
+            <section className="space-y-3">
+              <div>
+                <p className="text-sm font-semibold text-foreground">
+                  {progressLabel}
+                </p>
+                {currentDraft ? (
+                  <p className="text-sm text-muted-foreground">
+                    Current draft: {currentDraft.displayTitle}
+                  </p>
+                ) : null}
+              </div>
+
+              <label className="block space-y-1">
+                <span className="text-sm font-semibold text-foreground">
+                  Meal name
+                </span>
+                <input
+                  value={mealName}
+                  onChange={(event) => setMealName(event.target.value)}
+                  className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+                />
+              </label>
+
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!mealName.trim()}
+                  onClick={addQuickDraft}
+                >
+                  {currentDraft ? "Update draft" : "Add quick meal draft"}
+                </Button>
+                <Button type="button" variant="secondary" onClick={onSkip}>
+                  Skip this slot
+                </Button>
+              </div>
+
+              {currentDraft ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="w-full justify-start"
+                  aria-label={`Remove draft: ${currentDraft.displayTitle}`}
+                  onClick={() => onRemoveDraft(currentDraft.target)}
+                >
+                  Remove draft
+                </Button>
+              ) : null}
+            </section>
+
+            <div className="space-y-3">{renderRecipeTray()}</div>
+
+            <div className="grid gap-2">
+              <Button type="button" onClick={onReview}>
+                Review plan
+              </Button>
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={currentIndex === 0}
+                  onClick={onBack}
+                >
+                  Back
+                </Button>
+                <Button type="button" variant="ghost" onClick={onCancel}>
+                  Cancel planning
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </MobileSheet>
+  );
+}

--- a/src/components/meals/meal-planning-scope-dialog.tsx
+++ b/src/components/meals/meal-planning-scope-dialog.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { MealPlanningScope } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+export interface MealPlanningScopeDialogProps {
+  isOpen: boolean;
+  weekLabel: string;
+  days: Array<{ dayIndex: number; label: string }>;
+  onStart: (scope: MealPlanningScope) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ScopeKind = MealPlanningScope["kind"];
+
+export function MealPlanningScopeDialog({
+  isOpen,
+  weekLabel,
+  days,
+  onStart,
+  onOpenChange,
+}: MealPlanningScopeDialogProps) {
+  const [scopeKind, setScopeKind] = useState<ScopeKind>("empty_dinners");
+  const [selectedDayIndexes, setSelectedDayIndexes] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setScopeKind("empty_dinners");
+    setSelectedDayIndexes([]);
+  }, [isOpen]);
+
+  const selectedDaysValid =
+    scopeKind !== "selected_days" || selectedDayIndexes.length > 0;
+
+  function toggleDay(dayIndex: number) {
+    setSelectedDayIndexes((current) =>
+      current.includes(dayIndex)
+        ? current.filter((candidate) => candidate !== dayIndex)
+        : [...current, dayIndex],
+    );
+  }
+
+  function startPlanning() {
+    if (!selectedDaysValid) return;
+
+    if (scopeKind === "selected_days") {
+      onStart({
+        kind: "selected_days",
+        dayIndexes: [...selectedDayIndexes].sort((a, b) => a - b),
+      });
+      return;
+    }
+
+    onStart({ kind: scopeKind });
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Fill empty slots</DialogTitle>
+          <DialogDescription>{weekLabel}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2" role="radiogroup" aria-label="Meal scope">
+            {[
+              {
+                value: "empty_dinners",
+                label: "Empty dinners",
+                description: "Plan only dinner slots that do not have meals.",
+              },
+              {
+                value: "all_empty_slots",
+                label: "All empty slots",
+                description: "Plan breakfast, lunch, and dinner gaps.",
+              },
+              {
+                value: "selected_days",
+                label: "Selected days",
+                description: "Choose the days to plan across all meal types.",
+              },
+            ].map((option) => (
+              <label
+                key={option.value}
+                className={cn(
+                  "flex gap-3 rounded-lg border border-border p-3 text-sm",
+                  scopeKind === option.value ? "bg-primary/5" : "bg-card",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="meal-planning-scope"
+                  value={option.value}
+                  aria-label={option.label}
+                  checked={scopeKind === option.value}
+                  onChange={() => setScopeKind(option.value as ScopeKind)}
+                  className="mt-1"
+                />
+                <span>
+                  <span className="block font-semibold text-foreground">
+                    {option.label}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {option.description}
+                  </span>
+                </span>
+              </label>
+            ))}
+          </div>
+
+          {scopeKind === "selected_days" ? (
+            <div className="space-y-2">
+              <p className="text-sm font-semibold text-foreground">Days</p>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {days.map((day) => (
+                  <label
+                    key={day.dayIndex}
+                    className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-medium"
+                  >
+                    <input
+                      type="checkbox"
+                      aria-label={day.label}
+                      checked={selectedDayIndexes.includes(day.dayIndex)}
+                      onChange={() => toggleDay(day.dayIndex)}
+                    />
+                    {day.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter className="flex-col sm:flex-row">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!selectedDaysValid}
+            onClick={startPlanning}
+          >
+            Start planning
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/meals/meal-planning-session.test.ts
+++ b/src/components/meals/meal-planning-session.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import type { MealEntryRequest, MealSlot } from "@/lib/types";
+import {
+  createEmptyMealsBoard,
+  createExtrasOnlyMealsBoard,
+  createOccupiedMealsBoard,
+  testWeekStartDate,
+} from "@/test/fixtures/meals";
+import {
+  applyPlanningDraftsToBoard,
+  buildPlanningQueue,
+  getConflictedDraftTargets,
+  type MealPlanningDraft,
+  toSaveMealPlanRequest,
+} from "./meal-planning-session";
+
+function slotKey(slot: Pick<MealSlot, "dayIndex" | "mealType">) {
+  return `${slot.dayIndex}:${slot.mealType}`;
+}
+
+function quickMeal(title: string): MealEntryRequest {
+  return {
+    sourceType: "quick",
+    recipeId: null,
+    title,
+    imageUrl: null,
+    note: null,
+  };
+}
+
+const recipePrimary: MealEntryRequest = {
+  sourceType: "recipe",
+  recipeId: "11111111-1111-4111-8111-111111111111",
+  title: null,
+  imageUrl: null,
+  note: null,
+};
+
+function createDraft(
+  overrides: Partial<MealPlanningDraft> = {},
+): MealPlanningDraft {
+  return {
+    target: { dayIndex: 2, mealType: "dinner" },
+    displayTitle: "Recipe Lasagna",
+    displayImageUrl: "https://example.com/lasagna.jpg",
+    displayNote: "Selected recipe note",
+    primary: recipePrimary,
+    note: "Prep the sauce ahead",
+    ...overrides,
+  };
+}
+
+describe("buildPlanningQueue", () => {
+  it("returns empty dinners in day order by default scope", () => {
+    const queue = buildPlanningQueue(createOccupiedMealsBoard(), {
+      kind: "empty_dinners",
+    });
+
+    expect(queue.map(slotKey)).toEqual([
+      "0:dinner",
+      "3:dinner",
+      "4:dinner",
+      "5:dinner",
+      "6:dinner",
+    ]);
+  });
+
+  it("returns every empty slot across the week in day and meal order", () => {
+    const queue = buildPlanningQueue(createEmptyMealsBoard(), {
+      kind: "all_empty_slots",
+    });
+
+    expect(queue).toHaveLength(21);
+    expect(queue[0]).toMatchObject({ dayIndex: 0, mealType: "breakfast" });
+    expect(queue[20]).toMatchObject({ dayIndex: 6, mealType: "dinner" });
+  });
+
+  it("returns breakfast, lunch, and dinner for selected days in day order", () => {
+    const queue = buildPlanningQueue(createEmptyMealsBoard(), {
+      kind: "selected_days",
+      dayIndexes: [2, 4],
+    });
+
+    expect(queue.map(slotKey)).toEqual([
+      "2:breakfast",
+      "2:lunch",
+      "2:dinner",
+      "4:breakfast",
+      "4:lunch",
+      "4:dinner",
+    ]);
+  });
+
+  it("excludes extras-only slots from the empty dinner queue", () => {
+    const queue = buildPlanningQueue(createExtrasOnlyMealsBoard(), {
+      kind: "empty_dinners",
+    });
+
+    expect(queue.map(slotKey)).not.toContain("4:dinner");
+    expect(queue).toHaveLength(6);
+  });
+});
+
+describe("applyPlanningDraftsToBoard", () => {
+  it("projects drafts into a new board without mutating the source", () => {
+    const board = createEmptyMealsBoard();
+    const original = structuredClone(board);
+    const draft = createDraft();
+
+    const projected = applyPlanningDraftsToBoard(board, [draft]);
+
+    expect(board).toEqual(original);
+    expect(projected).not.toBe(board);
+    expect(projected.days).not.toBe(board.days);
+    expect(projected.days[2].slots[2]).toMatchObject({
+      id: null,
+      weekStartDate: testWeekStartDate,
+      dayIndex: 2,
+      mealType: "dinner",
+      primary: {
+        id: "draft-2:dinner",
+        role: "primary",
+        sourceType: "recipe",
+        recipeId: recipePrimary.recipeId,
+        title: "Recipe Lasagna",
+        imageUrl: "https://example.com/lasagna.jpg",
+        note: "Selected recipe note",
+      },
+      extras: [],
+      note: "Prep the sauce ahead",
+    });
+  });
+});
+
+describe("toSaveMealPlanRequest", () => {
+  it("converts planning drafts to backend batch save requests", () => {
+    const drafts = [
+      createDraft({
+        target: { dayIndex: 1, mealType: "lunch" },
+        primary: quickMeal("Turkey sandwiches"),
+        displayTitle: "Turkey sandwiches",
+        displayImageUrl: null,
+        displayNote: null,
+        note: null,
+      }),
+      createDraft({
+        target: { dayIndex: 3, mealType: "dinner" },
+        note: "Serve with salad",
+      }),
+    ];
+
+    expect(toSaveMealPlanRequest(testWeekStartDate, drafts)).toEqual({
+      weekStartDate: testWeekStartDate,
+      slots: [
+        {
+          dayIndex: 1,
+          mealType: "lunch",
+          primary: quickMeal("Turkey sandwiches"),
+          extras: [],
+          note: null,
+        },
+        {
+          dayIndex: 3,
+          mealType: "dinner",
+          primary: recipePrimary,
+          extras: [],
+          note: "Serve with salad",
+        },
+      ],
+    });
+  });
+});
+
+describe("getConflictedDraftTargets", () => {
+  it("returns draft targets that are missing or no longer empty after a board refetch", () => {
+    const board = createEmptyMealsBoard();
+    board.days[0].slots[2] = {
+      ...board.days[0].slots[2],
+      id: "slot-sunday-dinner",
+      primary: {
+        id: "entry-chili",
+        role: "primary",
+        sourceType: "quick",
+        recipeId: null,
+        title: "Chili",
+        imageUrl: null,
+        note: null,
+      },
+    };
+    board.days[3].slots = board.days[3].slots.filter(
+      (slot) => slot.mealType !== "breakfast",
+    );
+
+    const conflicts = getConflictedDraftTargets(board, [
+      createDraft({ target: { dayIndex: 0, mealType: "dinner" } }),
+      createDraft({ target: { dayIndex: 3, mealType: "breakfast" } }),
+      createDraft({ target: { dayIndex: 6, mealType: "lunch" } }),
+    ]);
+
+    expect(conflicts).toEqual([
+      { dayIndex: 0, mealType: "dinner" },
+      { dayIndex: 3, mealType: "breakfast" },
+    ]);
+  });
+});

--- a/src/components/meals/meal-planning-session.test.ts
+++ b/src/components/meals/meal-planning-session.test.ts
@@ -130,6 +130,16 @@ describe("applyPlanningDraftsToBoard", () => {
       note: "Prep the sauce ahead",
     });
   });
+
+  it("does not share extras entry objects with the source board", () => {
+    const board = createOccupiedMealsBoard();
+    const projected = applyPlanningDraftsToBoard(board, []);
+    const sourceExtra = board.days[1].slots[2].extras[0];
+    const projectedExtra = projected.days[1].slots[2].extras[0];
+
+    expect(projectedExtra).toEqual(sourceExtra);
+    expect(projectedExtra).not.toBe(sourceExtra);
+  });
 });
 
 describe("toSaveMealPlanRequest", () => {
@@ -168,6 +178,37 @@ describe("toSaveMealPlanRequest", () => {
         },
       ],
     });
+  });
+
+  it("uses the latest draft when duplicate targets are converted to save requests", () => {
+    const firstDraft = createDraft({
+      target: { dayIndex: 5, mealType: "dinner" },
+      primary: quickMeal("First idea"),
+      displayTitle: "First idea",
+      displayImageUrl: null,
+      displayNote: null,
+      note: "Early note",
+    });
+    const latestDraft = createDraft({
+      target: { dayIndex: 5, mealType: "dinner" },
+      primary: quickMeal("Latest idea"),
+      displayTitle: "Latest idea",
+      displayImageUrl: null,
+      displayNote: null,
+      note: "Latest note",
+    });
+
+    expect(
+      toSaveMealPlanRequest(testWeekStartDate, [firstDraft, latestDraft]).slots,
+    ).toEqual([
+      {
+        dayIndex: 5,
+        mealType: "dinner",
+        primary: quickMeal("Latest idea"),
+        extras: [],
+        note: "Latest note",
+      },
+    ]);
   });
 });
 

--- a/src/components/meals/meal-planning-session.ts
+++ b/src/components/meals/meal-planning-session.ts
@@ -92,13 +92,15 @@ function draftPrimaryEntry(draft: MealPlanningDraft): MealSlotEntry {
   };
 }
 
+function latestDraftsByTarget(drafts: MealPlanningDraft[]) {
+  return new Map(drafts.map((draft) => [targetKey(draft.target), draft]));
+}
+
 export function applyPlanningDraftsToBoard(
   board: MealBoard,
   drafts: MealPlanningDraft[],
 ): MealBoard {
-  const draftsByTarget = new Map(
-    drafts.map((draft) => [targetKey(draft.target), draft]),
-  );
+  const draftsByTarget = latestDraftsByTarget(drafts);
 
   return {
     ...board,
@@ -109,7 +111,7 @@ export function applyPlanningDraftsToBoard(
         if (!draft) {
           return {
             ...slot,
-            extras: [...slot.extras],
+            extras: slot.extras.map((extra) => ({ ...extra })),
             primary: slot.primary ? { ...slot.primary } : null,
           };
         }
@@ -131,7 +133,7 @@ export function toSaveMealPlanRequest(
 ): SaveMealPlanRequest {
   return {
     weekStartDate,
-    slots: drafts.map((draft) => ({
+    slots: Array.from(latestDraftsByTarget(drafts).values()).map((draft) => ({
       dayIndex: draft.target.dayIndex,
       mealType: draft.target.mealType,
       primary: draft.primary,

--- a/src/components/meals/meal-planning-session.ts
+++ b/src/components/meals/meal-planning-session.ts
@@ -1,0 +1,154 @@
+import type {
+  MealBoard,
+  MealEntryRequest,
+  MealPlanningScope,
+  MealSlot,
+  MealSlotEntry,
+  MealType,
+  SaveMealPlanRequest,
+} from "@/lib/types";
+
+const MEAL_TYPES: readonly MealType[] = ["breakfast", "lunch", "dinner"];
+
+export interface MealPlanningTarget {
+  dayIndex: number;
+  mealType: MealType;
+}
+
+export interface MealPlanningDraft {
+  target: MealPlanningTarget;
+  displayTitle: string;
+  displayImageUrl: string | null;
+  displayNote: string | null;
+  primary: MealEntryRequest;
+  note: string | null;
+}
+
+function targetKey(target: MealPlanningTarget) {
+  return `${target.dayIndex}:${target.mealType}`;
+}
+
+function isEmptySlot(slot: MealSlot) {
+  return slot.primary === null && slot.extras.length === 0;
+}
+
+function findSlot(
+  board: MealBoard,
+  target: MealPlanningTarget,
+): MealSlot | undefined {
+  return board.days
+    .find((day) => day.dayIndex === target.dayIndex)
+    ?.slots.find((slot) => slot.mealType === target.mealType);
+}
+
+function sortedBoardDayIndexes(board: MealBoard) {
+  return board.days.map((day) => day.dayIndex).sort((a, b) => a - b);
+}
+
+function selectedDayIndexes(dayIndexes: number[]) {
+  return Array.from(new Set(dayIndexes)).sort((a, b) => a - b);
+}
+
+function targetsForScope(
+  board: MealBoard,
+  scope: MealPlanningScope,
+): MealPlanningTarget[] {
+  if (scope.kind === "empty_dinners") {
+    return sortedBoardDayIndexes(board).map((dayIndex) => ({
+      dayIndex,
+      mealType: "dinner",
+    }));
+  }
+
+  const dayIndexes =
+    scope.kind === "selected_days"
+      ? selectedDayIndexes(scope.dayIndexes)
+      : sortedBoardDayIndexes(board);
+
+  return dayIndexes.flatMap((dayIndex) =>
+    MEAL_TYPES.map((mealType) => ({ dayIndex, mealType })),
+  );
+}
+
+export function buildPlanningQueue(
+  board: MealBoard,
+  scope: MealPlanningScope,
+): MealSlot[] {
+  return targetsForScope(board, scope)
+    .map((target) => findSlot(board, target))
+    .filter((slot): slot is MealSlot => Boolean(slot))
+    .filter(isEmptySlot);
+}
+
+function draftPrimaryEntry(draft: MealPlanningDraft): MealSlotEntry {
+  return {
+    id: `draft-${targetKey(draft.target)}`,
+    role: "primary",
+    sourceType: draft.primary.sourceType,
+    recipeId: draft.primary.recipeId,
+    title: draft.displayTitle,
+    imageUrl: draft.displayImageUrl,
+    note: draft.displayNote,
+  };
+}
+
+export function applyPlanningDraftsToBoard(
+  board: MealBoard,
+  drafts: MealPlanningDraft[],
+): MealBoard {
+  const draftsByTarget = new Map(
+    drafts.map((draft) => [targetKey(draft.target), draft]),
+  );
+
+  return {
+    ...board,
+    days: board.days.map((day) => ({
+      ...day,
+      slots: day.slots.map((slot) => {
+        const draft = draftsByTarget.get(targetKey(slot));
+        if (!draft) {
+          return {
+            ...slot,
+            extras: [...slot.extras],
+            primary: slot.primary ? { ...slot.primary } : null,
+          };
+        }
+
+        return {
+          ...slot,
+          primary: draftPrimaryEntry(draft),
+          extras: [],
+          note: draft.note,
+        };
+      }),
+    })),
+  };
+}
+
+export function toSaveMealPlanRequest(
+  weekStartDate: string,
+  drafts: MealPlanningDraft[],
+): SaveMealPlanRequest {
+  return {
+    weekStartDate,
+    slots: drafts.map((draft) => ({
+      dayIndex: draft.target.dayIndex,
+      mealType: draft.target.mealType,
+      primary: draft.primary,
+      extras: [],
+      note: draft.note,
+    })),
+  };
+}
+
+export function getConflictedDraftTargets(
+  board: MealBoard,
+  drafts: MealPlanningDraft[],
+): MealPlanningTarget[] {
+  return drafts
+    .filter((draft) => {
+      const slot = findSlot(board, draft.target);
+      return !slot || !isEmptySlot(slot);
+    })
+    .map((draft) => draft.target);
+}

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -2,12 +2,15 @@ import { Plus } from "lucide-react";
 import { useState } from "react";
 import type { MealSlot } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import type { MealPlanningDraft } from "./meal-planning-session";
 import { formatMealType } from "./meal-type-utils";
 
 interface MealSlotCardProps {
   slot: MealSlot;
   readOnly: boolean;
   pendingRecipeId?: string | null;
+  draft?: MealPlanningDraft | null;
+  isPlanningTarget?: boolean;
   onSelectSlot: (slot: MealSlot) => void;
 }
 
@@ -15,26 +18,43 @@ export function MealSlotCard({
   slot,
   readOnly,
   pendingRecipeId = null,
+  draft = null,
+  isPlanningTarget = false,
   onSelectSlot,
 }: MealSlotCardProps) {
   const [imgFailed, setImgFailed] = useState(false);
   const label = formatMealType(slot.mealType);
+  const primary = draft
+    ? {
+        title: draft.displayTitle,
+        imageUrl: draft.displayImageUrl,
+        note: draft.displayNote,
+      }
+    : slot.primary;
 
-  if (slot.primary) {
+  if (primary) {
     return (
       <button
         type="button"
         className={cn(
           "w-full rounded-lg border border-border bg-card p-3 text-left shadow-sm transition-colors",
           readOnly ? "cursor-default" : "hover:bg-muted/50",
+          isPlanningTarget
+            ? "border-primary/70 bg-primary/5 ring-2 ring-primary/20"
+            : null,
         )}
-        aria-label={`Open ${slot.mealType}: ${slot.primary.title}`}
+        aria-current={isPlanningTarget ? "true" : undefined}
+        aria-label={
+          draft
+            ? `Draft ${slot.mealType}: ${draft.displayTitle}`
+            : `Open ${slot.mealType}: ${primary.title}`
+        }
         onClick={() => onSelectSlot(slot)}
       >
         <div className="flex items-start gap-3">
-          {slot.primary.imageUrl && !imgFailed ? (
+          {primary.imageUrl && !imgFailed ? (
             <img
-              src={slot.primary.imageUrl}
+              src={primary.imageUrl}
               alt=""
               className="h-14 w-14 rounded-md object-cover"
               onError={() => setImgFailed(true)}
@@ -48,12 +68,17 @@ export function MealSlotCard({
             <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               {label}
             </p>
+            {draft ? (
+              <span className="mt-1 inline-flex rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                Draft
+              </span>
+            ) : null}
             <p className="truncate text-sm font-semibold text-foreground">
-              {slot.primary.title}
+              {primary.title}
             </p>
-            {slot.primary.note ? (
+            {primary.note ? (
               <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-                {slot.primary.note}
+                {primary.note}
               </p>
             ) : null}
             {slot.note ? (
@@ -63,7 +88,7 @@ export function MealSlotCard({
             ) : null}
           </div>
         </div>
-        {slot.extras.length > 0 ? (
+        {!draft && slot.extras.length > 0 ? (
           <div className="mt-3 flex flex-wrap gap-1">
             {slot.extras.slice(0, 2).map((extra) => (
               <span
@@ -86,7 +111,13 @@ export function MealSlotCard({
 
   if (readOnly) {
     return (
-      <div className="rounded-lg border border-dashed border-border bg-muted/30 p-3 text-sm text-muted-foreground">
+      <div
+        className={cn(
+          "rounded-lg border border-dashed border-border bg-muted/30 p-3 text-sm text-muted-foreground",
+          isPlanningTarget ? "border-primary/70 ring-2 ring-primary/20" : null,
+        )}
+        aria-current={isPlanningTarget ? "true" : undefined}
+      >
         <span className="font-medium">{label}</span>
       </div>
     );
@@ -95,7 +126,13 @@ export function MealSlotCard({
   return (
     <button
       type="button"
-      className="flex min-h-20 w-full items-center justify-between rounded-lg border border-dashed border-border bg-background p-3 text-left transition-colors hover:border-primary/50 hover:bg-primary/5"
+      className={cn(
+        "flex min-h-20 w-full items-center justify-between rounded-lg border border-dashed border-border bg-background p-3 text-left transition-colors hover:border-primary/50 hover:bg-primary/5",
+        isPlanningTarget
+          ? "border-primary/70 bg-primary/5 ring-2 ring-primary/20"
+          : null,
+      )}
+      aria-current={isPlanningTarget ? "true" : undefined}
       aria-label={
         pendingRecipeId
           ? `Add recipe to ${slot.mealType}`

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -31,8 +31,11 @@ export function MealSlotCard({
         note: draft.displayNote,
       }
     : slot.primary;
+  const hasExtras = !draft && slot.extras.length > 0;
+  const hasExtrasOnly = !primary && hasExtras;
+  const firstExtraTitle = slot.extras[0]?.title;
 
-  if (primary) {
+  if (primary || hasExtrasOnly) {
     return (
       <button
         type="button"
@@ -47,12 +50,16 @@ export function MealSlotCard({
         aria-label={
           draft
             ? `Draft ${slot.mealType}: ${draft.displayTitle}`
-            : `Open ${slot.mealType}: ${primary.title}`
+            : primary
+              ? `Open ${slot.mealType}: ${primary.title}`
+              : firstExtraTitle
+                ? `Open ${slot.mealType}: extras - ${firstExtraTitle}`
+                : `Open ${slot.mealType}: extras`
         }
         onClick={() => onSelectSlot(slot)}
       >
         <div className="flex items-start gap-3">
-          {primary.imageUrl && !imgFailed ? (
+          {primary?.imageUrl && !imgFailed ? (
             <img
               src={primary.imageUrl}
               alt=""
@@ -74,9 +81,9 @@ export function MealSlotCard({
               </span>
             ) : null}
             <p className="truncate text-sm font-semibold text-foreground">
-              {primary.title}
+              {primary?.title ?? "Extras"}
             </p>
-            {primary.note ? (
+            {primary?.note ? (
               <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                 {primary.note}
               </p>
@@ -88,7 +95,7 @@ export function MealSlotCard({
             ) : null}
           </div>
         </div>
-        {!draft && slot.extras.length > 0 ? (
+        {hasExtras ? (
           <div className="mt-3 flex flex-wrap gap-1">
             {slot.extras.slice(0, 2).map((extra) => (
               <span

--- a/src/lib/types/meals.ts
+++ b/src/lib/types/meals.ts
@@ -54,6 +54,24 @@ export interface UpsertMealSlotRequest {
   collisionMode: MealCollisionMode | null;
 }
 
+export type MealPlanningScope =
+  | { kind: "empty_dinners" }
+  | { kind: "all_empty_slots" }
+  | { kind: "selected_days"; dayIndexes: number[] };
+
+export interface SaveMealPlanSlotRequest {
+  dayIndex: number;
+  mealType: MealType;
+  primary: MealEntryRequest;
+  extras: MealEntryRequest[];
+  note: string | null;
+}
+
+export interface SaveMealPlanRequest {
+  weekStartDate: string;
+  slots: SaveMealPlanSlotRequest[];
+}
+
 export interface MoveMealSlotRequest {
   sourceWeekStartDate: string;
   sourceDayIndex: number;

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -19,6 +19,8 @@ export {
   mealTypeSchema,
   moveMealSlotSchema,
   removeMealSlotSchema,
+  saveMealPlanSchema,
+  saveMealPlanSlotSchema,
   toMealEntryRequest,
   type UpsertMealSlotFormData,
   upsertMealSlotSchema,

--- a/src/lib/validations/meals.test.ts
+++ b/src/lib/validations/meals.test.ts
@@ -158,6 +158,13 @@ describe("meal validation", () => {
     ).toBe(false);
   });
 
+  it("exports focused meal plan schemas from the validation barrel", async () => {
+    const validations = await import(".");
+
+    expect(validations.saveMealPlanSchema).toBe(saveMealPlanSchema);
+    expect(validations.saveMealPlanSlotSchema).toBe(saveMealPlanSlotSchema);
+  });
+
   it("rejects focused meal plan saves with more than twenty-one slots", () => {
     const slot = {
       dayIndex: 0,

--- a/src/lib/validations/meals.test.ts
+++ b/src/lib/validations/meals.test.ts
@@ -5,6 +5,8 @@ import {
   mealEntrySchema,
   mealTypeSchema,
   moveMealSlotSchema,
+  saveMealPlanSchema,
+  saveMealPlanSlotSchema,
   toMealEntryRequest,
   upsertMealSlotSchema,
 } from "./meals";
@@ -143,6 +145,75 @@ describe("meal validation", () => {
       moveMealSlotSchema.safeParse({
         ...request,
         collisionMode: null,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("requires focused meal plan saves to include at least one slot", () => {
+    expect(
+      saveMealPlanSchema.safeParse({
+        weekStartDate: "2026-06-07",
+        slots: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects focused meal plan saves with more than twenty-one slots", () => {
+    const slot = {
+      dayIndex: 0,
+      mealType: "dinner",
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title: "Pasta",
+        imageUrl: null,
+        note: null,
+      },
+      extras: [],
+      note: null,
+    };
+
+    expect(
+      saveMealPlanSchema.safeParse({
+        weekStartDate: "2026-06-07",
+        slots: Array.from({ length: 22 }, () => slot),
+      }).success,
+    ).toBe(false);
+  });
+
+  it("trims quick meal titles and defaults extras for focused meal plan slots", () => {
+    const slot = saveMealPlanSlotSchema.parse({
+      dayIndex: 2,
+      mealType: "dinner",
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title: "  Tacos  ",
+        imageUrl: null,
+        note: null,
+      },
+      note: "  ",
+    });
+
+    expect(slot.primary.title).toBe("Tacos");
+    expect(slot.extras).toEqual([]);
+    expect(slot.note).toBe(null);
+  });
+
+  it("requires recipe-backed focused meal plan slots to carry a UUID recipe id", () => {
+    expect(
+      saveMealPlanSlotSchema.safeParse({
+        dayIndex: 1,
+        mealType: "lunch",
+        primary: {
+          sourceType: "recipe",
+          recipeId: "recipe-1",
+          title: null,
+          imageUrl: null,
+          note: null,
+        },
+        extras: [],
+        note: null,
       }).success,
     ).toBe(false);
   });

--- a/src/lib/validations/meals.ts
+++ b/src/lib/validations/meals.ts
@@ -78,6 +78,19 @@ export const upsertMealSlotSchema = z.object({
   collisionMode: mealCollisionModeSchema.nullable().optional().default(null),
 });
 
+export const saveMealPlanSlotSchema = z.object({
+  dayIndex: z.number().int().min(0).max(6),
+  mealType: mealTypeSchema,
+  primary: mealEntrySchema,
+  extras: z.array(mealEntrySchema).optional().default([]),
+  note: optionalTextSchema,
+});
+
+export const saveMealPlanSchema = z.object({
+  weekStartDate: localDateSchema,
+  slots: z.array(saveMealPlanSlotSchema).min(1).max(21),
+});
+
 export const moveMealSlotSchema = z.object({
   sourceWeekStartDate: localDateSchema,
   sourceDayIndex: z.number().int().min(0).max(6),

--- a/src/test/fixtures/meals.ts
+++ b/src/test/fixtures/meals.ts
@@ -94,6 +94,30 @@ export function createOccupiedMealsBoard(): MealBoard {
   return board;
 }
 
+export function createExtrasOnlyMealsBoard(): MealBoard {
+  const board = createEmptyMealsBoard();
+  board.days[4].slots[2] = {
+    id: "slot-extras-only-dinner",
+    weekStartDate: testWeekStartDate,
+    dayIndex: 4,
+    mealType: "dinner",
+    primary: null,
+    extras: [
+      {
+        id: "entry-garlic-bread",
+        role: "extra",
+        sourceType: "quick",
+        recipeId: null,
+        title: "Garlic bread",
+        imageUrl: null,
+        note: null,
+      },
+    ],
+    note: null,
+  };
+  return board;
+}
+
 export function createRecipeBackedMealsBoard(): MealBoard {
   const board = createEmptyMealsBoard();
   board.days[1].slots[2] = {

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -706,6 +706,13 @@ function resolveMealSlotPlacement(
 ): MealSlot | HttpResponse {
   const id = slot.id ?? createMockMealSlotId();
 
+  if (!slot.primary && slot.extras.length > 0) {
+    return HttpResponse.json(
+      { message: "Meal slot already has content" },
+      { status: 409 },
+    );
+  }
+
   if (slot.primary && collisionMode === null) {
     return HttpResponse.json(
       { message: "Meal slot already has a primary meal" },

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -40,6 +40,7 @@ import type {
   RemoveMealSlotRequest,
   RenameListCategoryRequest,
   ReorderListCategoriesRequest,
+  SaveMealPlanRequest,
   UpdateChoreTemplateRequest,
   UpdateCurrentPeriodCompletionRequest,
   UpdateEventRequest,
@@ -622,6 +623,10 @@ function findMealSlot(
   return slot;
 }
 
+function isMealSlotOccupied(slot: MealSlot): boolean {
+  return Boolean(slot.primary) || slot.extras.length > 0;
+}
+
 function setMealSlot(board: MealBoard, updatedSlot: MealSlot): void {
   const day = board.days[updatedSlot.dayIndex];
   day.slots = day.slots.map((slot) =>
@@ -791,6 +796,69 @@ export const handlers = [
     }
 
     return HttpResponse.json(createApiResponse(getMealsBoard(weekStartDate)));
+  }),
+
+  // POST /meals/plans - Save a focused meal planning session
+  http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
+    const body = (await request.json()) as SaveMealPlanRequest;
+    const board = getMealsBoard(body.weekStartDate);
+    const seenTargets = new Set<string>();
+    const targets: Array<{
+      slot: MealSlot;
+      requestSlot: SaveMealPlanRequest["slots"][number];
+    }> = [];
+
+    for (const requestSlot of body.slots) {
+      const targetKey = `${requestSlot.dayIndex}:${requestSlot.mealType}`;
+      if (seenTargets.has(targetKey)) {
+        return HttpResponse.json(
+          { message: "Meal plan contains duplicate target slots." },
+          { status: 400 },
+        );
+      }
+      seenTargets.add(targetKey);
+
+      const slot = findMealSlot(
+        board,
+        requestSlot.dayIndex,
+        requestSlot.mealType,
+      );
+      targets.push({ slot, requestSlot });
+    }
+
+    if (targets.some(({ slot }) => isMealSlotOccupied(slot))) {
+      return HttpResponse.json(
+        { message: "Some meal slots are no longer empty." },
+        { status: 409 },
+      );
+    }
+
+    const updates: MealSlot[] = [];
+    for (const { slot, requestSlot } of targets) {
+      const entries = snapshotRequestedEntries(
+        requestSlot.primary,
+        requestSlot.extras,
+      );
+      if (entries instanceof HttpResponse) return entries;
+
+      const updatedSlot = resolveMealSlotPlacement(
+        slot,
+        entries.primary,
+        entries.extras,
+        requestSlot.note ?? null,
+        null,
+      );
+      if (updatedSlot instanceof HttpResponse) return updatedSlot;
+      updates.push(updatedSlot);
+    }
+
+    for (const updatedSlot of updates) {
+      setMealSlot(board, updatedSlot);
+    }
+
+    return HttpResponse.json(
+      createApiResponse(board, "Meal plan saved successfully"),
+    );
   }),
 
   // PUT /meals/slots - Create or update one slot

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -50,6 +50,7 @@ import type {
   UpsertMealSlotRequest,
   UsernameCheckResponse,
 } from "@/lib/types";
+import { saveMealPlanSchema } from "@/lib/validations";
 
 // In-memory storage for mock calendar events (reset between tests)
 // Uses CalendarEventResponse (string dates) to match real API wire format
@@ -800,7 +801,25 @@ export const handlers = [
 
   // POST /meals/plans - Save a focused meal planning session
   http.post(`${API_BASE}/meals/plans`, async ({ request }) => {
-    const body = (await request.json()) as SaveMealPlanRequest;
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return HttpResponse.json(
+        { message: "Invalid meal plan request" },
+        { status: 400 },
+      );
+    }
+
+    const parsedBody = saveMealPlanSchema.safeParse(rawBody);
+    if (!parsedBody.success) {
+      return HttpResponse.json(
+        { message: "Invalid meal plan request" },
+        { status: 400 },
+      );
+    }
+
+    const body = parsedBody.data;
     const board = getMealsBoard(body.weekStartDate);
     const seenTargets = new Set<string>();
     const targets: Array<{

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -706,7 +706,7 @@ function resolveMealSlotPlacement(
 ): MealSlot | HttpResponse {
   const id = slot.id ?? createMockMealSlotId();
 
-  if (!slot.primary && slot.extras.length > 0) {
+  if (!slot.primary && slot.extras.length > 0 && collisionMode !== null) {
     return HttpResponse.json(
       { message: "Meal slot already has content" },
       { status: 409 },


### PR DESCRIPTION
## Summary

- Adds the focused `Fill empty slots` planning session inside Meals with V1 scopes, draft board projection, review/save/cancel flow, and conflict handling.
- Adds the released batch save frontend contract for `POST /api/meals/plans`, including types, Zod validation, service/hook/MSW coverage, and pure planning helpers.
- Adds Mobile Chrome released-contract E2E coverage for the focused session against `family-hub-api v1.8.0`.

Closes #262

## Work Log Contract

Before coding, I restated the execution contract from issue #262: implement FE Tasks 3-8 only in `frontend/`, use released backend `family-hub-api v1.8.0` with bare semver `BE_IMAGE_TAG=1.8.0`, do not implement backend/root planning-doc changes, preserve existing Meals behavior, and include this checklist plus released-contract E2E evidence before PR.

## Backend Release

Released-contract E2E used `BE_IMAGE_TAG=1.8.0` (`family-hub-api v1.8.0`, published 2026-07-01).

## Verification

- [x] `npm test -- --run src/api/services/meals.service.test.ts src/api/hooks/use-meals.test.tsx src/lib/validations/meals.test.ts src/components/meals/meal-planning-session.test.ts src/components/meals/meal-planning-panel.test.tsx src/components/meals-view.test.tsx` — 6 files, 97 tests passed.
- [x] `npm run lint` — exit 0; existing Biome schema/deprecation info only.
- [x] `npm test -- --run` — 133 files, 1365 tests passed.
- [x] `npm run build` — exit 0; existing Node/Vite, chunk, and Browserslist warnings only.
- [x] `BE_IMAGE_TAG=1.8.0 docker compose -f docker-compose.e2e.yml up -d --wait` — backend container healthy.
- [x] `npm run test:e2e -- --project="Mobile Chrome" e2e/mobile-meals.spec.ts` — 6 passed in 35.1s.
- [x] `BE_IMAGE_TAG=1.8.0 docker compose -f docker-compose.e2e.yml down` — backend container and network removed.

## Smoke Check

The released-contract Mobile Chrome run includes the local smoke case for drafting and saving three empty dinners (`Tacos`, `Leftovers`, `Pasta`) in one focused planning session without opening three separate slot composers. The full six-test mobile Meals spec completed in 35.1s, under the 3-minute requirement.

## Execution Contract Checklist

- [x] `Fill empty slots` only on editable current/future Meals weeks — `MealsView` gates the action; covered by `meals-view.test.tsx` current/future/past guard tests.
- [x] Scopes: `Empty dinners` default, `All empty slots`, `Selected days` — `MealPlanningScopeDialog`, `buildPlanningQueue`, and scope tests.
- [x] Draft choices stay local until `Save to week`; cancel leaves persisted data unchanged — planning session state in `MealsView`, draft projection helper, and cancel/no-mutation tests.
- [x] Reuses favorite recipes, recent recipes, recipe search, and quick meals — `MealPlanningPanel` candidate tray and panel/MealsView tests.
- [x] Shows current slot, queue progress, draft blocks, review summary, save/cancel controls — `MealPlanningPanel`, `MealSlotCard` draft/highlight rendering, and component tests.
- [x] Saves through released backend batch endpoint and handles 409 skip/keep/cancel — `saveMealPlan` service/hook/MSW plus conflict tests.
- [x] Existing Meals board/editor/recipe handoff behavior keeps passing — full Vitest plus targeted editor/move/duplicate/replace/add-extra/remove regressions.
- [x] Released-contract mobile E2E names tested semver — this PR records `BE_IMAGE_TAG=1.8.0`.

## Product Non-Negotiables Checklist

- [x] Action applies to visible week only — visible-week state feeds queue/build/save requests; covered by current/future week tests.
- [x] Current and future weeks use the same flow, including a blank future week — covered by blank future-week component and E2E assertions.
- [x] Past weeks are review-only and do not allow planning sessions — covered by past-week guard tests and E2E.
- [x] `Empty dinners` targets only empty dinner slots and is default — queue helper and scope picker tests.
- [x] `All empty slots` targets empty breakfast/lunch/dinner slots across the visible week — queue helper and scope picker tests.
- [x] `Selected days` targets all empty breakfast/lunch/dinner slots for chosen days — scope picker and queue tests.
- [x] Planning queue targets only empty slots; filled slots remain visible context — draft board projection and board rendering tests.
- [x] Empty target means no persisted primary and no persisted extras; extras-only slots are non-empty and excluded — helper tests plus extras-only editor/placement regressions.
- [x] Draft blocks can be added, skipped, removed, changed, reviewed, saved, or canceled without writing before save — `MealPlanningPanel` and `MealsView` tests.
- [x] V1 drafts are primary-meal only; extras stay in normal one-slot editor — planning request conversion sends no planning extras; editor extras behavior is unchanged and covered.
- [x] Quick meals and recipe-backed meals both work in session — panel tests and Mobile Chrome E2E.
- [x] Save-time conflicts detected before overwrite; no planning-save replace/add-as-extra — conflict diffing and conflict-summary tests.
- [x] Conflict options: skip conflicted, keep editing, cancel save without discarding session — `MealsView` and panel conflict tests.
- [x] Meal tray remains available across multiple slot choices — `MealPlanningPanel` tray persistence test.
- [x] User can add at least three meals without opening three slot composers — Mobile Chrome focused-session smoke/E2E.
- [x] Normal one-slot editing, recipe handoff, move, duplicate, replace, add-extra, remove, mobile layout, and past-week review keep passing — full test suite plus released-contract E2E.

## Out Of Scope Confirmation

No grocery generation, pantry/inventory, nutrition, AI planning, automatic assignment, per-person planning, copy-week/templates, recurring meals, theme-night defaults, calendar hints, meal status, saved multi-session drafts, or planning-save replace/add-as-extra behavior was added.