### PR TITLE
perf(build): split vendor deps out of the entry chunk + CI size budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.e2e.yml down
       - run: npm run build
+      - name: Check bundle size budget
+        run: npm run check:bundle
       - name: Collect Lighthouse reports
         run: npx lhci collect
       - name: Assert Lighthouse thresholds

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "analyze": "ANALYZE=true npm run build && echo 'Bundle analysis available at .analyze/stats.html'",
+    "check:bundle": "node scripts/check-bundle-size.js",
     "lighthouse": "npm run build && lhci autorun"
   },
   "lint-staged": {

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -19,23 +19,31 @@ export const MAX_ENTRY_GZIP_BYTES = 92160; // 90 * 1024
  * @returns {string}
  */
 export function resolveEntryChunk(html) {
-  const matches = [
+  const moduleScriptTags = [
     ...html.matchAll(/<script\b[^>]*\btype=["']module["'][^>]*>/gi),
-  ]
-    .map((m) => /\bsrc=["']([^"']+)["']/i.exec(m[0])?.[1])
-    .filter((src) => typeof src === "string");
+  ].map((m) => m[0]);
 
-  if (matches.length === 0) {
+  if (moduleScriptTags.length === 0) {
     throw new Error(
       "check-bundle-size: no module-script tag found in index.html",
     );
   }
-  if (matches.length > 1) {
+  if (moduleScriptTags.length > 1) {
+    const srcs = moduleScriptTags.map(
+      (tag) => /\bsrc=["']([^"']+)["']/i.exec(tag)?.[1] ?? "<inline>",
+    );
     throw new Error(
-      `check-bundle-size: expected one module-script tag, found multiple module-script tags: ${matches.join(", ")}`,
+      `check-bundle-size: expected one module-script tag, found multiple module-script tags: ${srcs.join(", ")}`,
     );
   }
-  return /** @type {string} */ (matches[0]);
+
+  const entry = /\bsrc=["']([^"']+)["']/i.exec(moduleScriptTags[0])?.[1];
+  if (!entry) {
+    throw new Error(
+      "check-bundle-size: module-script tag is missing src in index.html",
+    );
+  }
+  return entry;
 }
 
 /**

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,0 +1,83 @@
+// @ts-check
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { gzipSync } from "node:zlib";
+
+// Budget for the entry chunk, gzipped. Baseline measured 2026-07-02: the fixed
+// build's entry is ~77 kB gzip (77,158 bytes). 90 kB gives ~15% headroom while
+// still catching a regression such as React leaking back into the entry (which
+// would push it toward ~135 kB). See the spec: gate the ENTRY chunk, not total
+// initial JS — a React leak moves bytes between chunks without changing the total.
+export const MAX_ENTRY_GZIP_BYTES = 92160; // 90 * 1024
+
+/**
+ * Extract the single ES-module entry chunk path from built index.html.
+ * Fails closed if there is not exactly one module-script tag.
+ * @param {string} html
+ * @returns {string}
+ */
+export function resolveEntryChunk(html) {
+  const matches = [
+    ...html.matchAll(/<script\b[^>]*\btype=["']module["'][^>]*>/gi),
+  ]
+    .map((m) => /\bsrc=["']([^"']+)["']/i.exec(m[0])?.[1])
+    .filter((src) => typeof src === "string");
+
+  if (matches.length === 0) {
+    throw new Error(
+      "check-bundle-size: no module-script tag found in index.html",
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `check-bundle-size: expected one module-script tag, found multiple module-script tags: ${matches.join(", ")}`,
+    );
+  }
+  return /** @type {string} */ (matches[0]);
+}
+
+/**
+ * Compare a chunk's gzipped size to a byte budget.
+ * @param {Buffer} gzipped
+ * @param {number} budgetBytes
+ */
+export function checkGzipBudget(gzipped, budgetBytes) {
+  return {
+    ok: gzipped.length <= budgetBytes,
+    gzipBytes: gzipped.length,
+    budgetBytes,
+  };
+}
+
+function main() {
+  const distDir = join(dirname(fileURLToPath(import.meta.url)), "..", "dist");
+  const html = readFileSync(join(distDir, "index.html"), "utf8");
+  const entry = resolveEntryChunk(html);
+  const file = join(distDir, entry.replace(/^\//, ""));
+  const gzipped = gzipSync(readFileSync(file));
+  const { ok, gzipBytes, budgetBytes } = checkGzipBudget(
+    gzipped,
+    MAX_ENTRY_GZIP_BYTES,
+  );
+
+  const kb = (n) => (n / 1024).toFixed(1);
+  console.log(`Entry chunk: ${entry}`);
+  console.log(`Gzip size:   ${kb(gzipBytes)} kB (${gzipBytes} bytes)`);
+  console.log(`Budget:      ${kb(budgetBytes)} kB (${budgetBytes} bytes)`);
+
+  if (!ok) {
+    console.error(
+      `\n❌ Entry chunk exceeds budget by ${kb(gzipBytes - budgetBytes)} kB. ` +
+        `Investigate what landed in the entry (npm run analyze) before raising MAX_ENTRY_GZIP_BYTES.`,
+    );
+    process.exit(1);
+  }
+  console.log("\n✅ Entry chunk within budget.");
+}
+
+// Run only when invoked directly (not when imported by the test).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/src/test/check-bundle-size.test.ts
+++ b/src/test/check-bundle-size.test.ts
@@ -30,6 +30,13 @@ describe("resolveEntryChunk", () => {
       <script type="module" src="/assets/b.js"></script>`;
     expect(() => resolveEntryChunk(html)).toThrow(/multiple module-script/i);
   });
+
+  it("throws when an inline module script is present alongside the entry", () => {
+    const html = `
+      <script type="module">console.log("inline module")</script>
+      <script type="module" src="/assets/index-ABC123.js"></script>`;
+    expect(() => resolveEntryChunk(html)).toThrow(/multiple module-script/i);
+  });
 });
 
 describe("checkGzipBudget", () => {

--- a/src/test/check-bundle-size.test.ts
+++ b/src/test/check-bundle-size.test.ts
@@ -1,0 +1,55 @@
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  checkGzipBudget,
+  resolveEntryChunk,
+} from "../../scripts/check-bundle-size.js";
+
+describe("resolveEntryChunk", () => {
+  it("returns the single module-script src", () => {
+    const html = `<!doctype html><html><head>
+      <script type="module" crossorigin src="/assets/index-ABC123.js"></script>
+      <link rel="modulepreload" crossorigin href="/assets/vendor-XYZ.js">
+      </head><body></body></html>`;
+    expect(resolveEntryChunk(html)).toBe("/assets/index-ABC123.js");
+  });
+
+  it("is filename-agnostic (does not rely on the index- prefix)", () => {
+    const html = `<script type="module" src="/assets/main-DEADBEEF.js"></script>`;
+    expect(resolveEntryChunk(html)).toBe("/assets/main-DEADBEEF.js");
+  });
+
+  it("throws when there is no module-script tag (fail closed)", () => {
+    const html = `<script src="/assets/legacy.js"></script>`;
+    expect(() => resolveEntryChunk(html)).toThrow(/no module-script/i);
+  });
+
+  it("throws when there are multiple module-script tags (fail closed)", () => {
+    const html = `
+      <script type="module" src="/assets/a.js"></script>
+      <script type="module" src="/assets/b.js"></script>`;
+    expect(() => resolveEntryChunk(html)).toThrow(/multiple module-script/i);
+  });
+});
+
+describe("checkGzipBudget", () => {
+  const budget = 100; // bytes, for the test
+
+  it("passes when gzipped size is under budget", () => {
+    const small = gzipSync(Buffer.alloc(10, "a"));
+    const result = checkGzipBudget(small, budget);
+    expect(result.ok).toBe(true);
+    expect(result.gzipBytes).toBe(small.length);
+  });
+
+  it("fails when gzipped size exceeds budget", () => {
+    // Incompressible random bytes so the gzip output reliably exceeds 100 bytes.
+    const big = gzipSync(
+      Buffer.from(
+        Array.from({ length: 5000 }, () => Math.floor(Math.random() * 256)),
+      ),
+    );
+    const result = checkGzipBudget(big, budget);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -109,18 +109,17 @@ export default defineConfig(() => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks: {
-            "react-vendor": ["react", "react-dom"],
-            "query-vendor": ["@tanstack/react-query"],
-            "date-vendor": ["date-fns", "react-day-picker"],
-            "radix-vendor": [
-              "@radix-ui/react-dialog",
-              "@radix-ui/react-popover",
-              "@radix-ui/react-scroll-area",
-              "@radix-ui/react-tabs",
-              "@radix-ui/react-slot",
-              "@radix-ui/react-label",
-            ],
+          manualChunks(id: string) {
+            if (!id.includes("/node_modules/")) return undefined;
+            // React is a pure leaf (imports nothing) so isolating it never
+            // forms a circular chunk. Every other dependency goes into a
+            // single `vendor` chunk — splitting them further (radix/query/date
+            // groups) produces circular-chunk warnings because a general
+            // vendor module and a specific group import each other.
+            if (/\/node_modules\/(react|react-dom|scheduler)\//.test(id)) {
+              return "react-vendor";
+            }
+            return "vendor";
           },
         },
       },


### PR DESCRIPTION
Closes #270

Fixes the silently-dead `react-vendor` split (it was a **0 kB chunk** — React had leaked into the app entry chunk) and adds a zero-dependency CI guard so the entry chunk can't re-bloat unnoticed.

## What changed

- **`vite.config.ts`** — replaced the broken object-form `manualChunks` with a two-way function split: `react-vendor` for `react`/`react-dom`/`scheduler` (matched via `/node_modules/<pkg>/` regex), a single `vendor` chunk for all other `node_modules`, and `undefined` for app source. No per-library groups (those were tested during spec/plan review and produce circular-chunk warnings — React is the only safe leaf to isolate).
- **`scripts/check-bundle-size.js`** — zero-dep ESM script with pure helpers `resolveEntryChunk` (reads the single `<script type="module">` src from `dist/index.html`, filename-agnostic, fails closed on zero/multiple module tags) + `checkGzipBudget`. Gates the **entry chunk** gzip at 90 kB (`MAX_ENTRY_GZIP_BYTES = 92160`).
- **`src/test/check-bundle-size.test.ts`** — unit tests: under-budget pass, over-budget fail, and zero/multiple module-tag fail-closed.
- **`package.json`** — `check:bundle` script.
- **`.github/workflows/ci.yml`** — runs `check:bundle` immediately after `npm run build`.

## Measured (gzip)

| Chunk | Before | After |
|-------|--------|-------|
| entry `index` | **195 kB** | **~77 kB** (−60%) |
| `react-vendor` | 0 kB (dead) | ~59 kB (real, long-cached) |
| `vendor` | — | ~115 kB (all other node_modules) |
| circular-chunk warnings | — | **none** |

Local pre-flight (this branch): entry **77,236 bytes gzip** — well under the 90 kB budget; `check:bundle` exits 0; no circular warnings.

Note: total first-visit JS is ~unchanged (~250 kB) — the win is **caching** (React + vendor stop re-downloading on every FE deploy) and repairing the dead split, not fewer first-load bytes. Family Hub is an installed PWA that updates often, so the caching win is felt on every post-update launch.

## Verification

- [x] `react-vendor` non-zero (~59 kB gzip); entry ~77 kB gzip; no circular warnings
- [x] `check:bundle` gates the entry chunk (90 kB budget) and runs in CI after build
- [x] bundle-check unit test covers under/over budget + zero/multiple module-tag fail-closed
- [x] `npm run lint`, `npx vitest run` (1371 tests), `npm run build && npm run check:bundle` all green locally
- [x] No application-source or runtime behavior change — only `vite.config.ts`, the new script + test, `package.json`, and `ci.yml`; app-shell boot verified in preview with zero console errors

Spec: joe-bor/family-hub `docs/superpowers/specs/2026-07-02-frontend-bundle-splitting-design.md`
Plan: joe-bor/family-hub `docs/superpowers/plans/2026-07-02-frontend-bundle-splitting.md`

Please merge with a **regular merge commit** (not squash) per the release-please setup.
