### PR TITLE
feat: quick-capture friction fixes (lists multi-add, time picker, location)

### DIFF
--- a/e2e/google-calendar.spec.ts
+++ b/e2e/google-calendar.spec.ts
@@ -53,16 +53,16 @@ test.describe("Google Calendar Integration", () => {
     await expect(page.getByText(/add an email/i)).toBeVisible();
   });
 
-  test("event form has collapsible description field", async ({ page }) => {
+  test("event form has collapsible details field", async ({ page }) => {
     // Open add event modal
     await page.getByRole("button", { name: /add event/i }).click();
 
-    // Description should be collapsed
-    await expect(page.getByText(/add description/i)).toBeVisible();
+    // Details should be collapsed
+    await expect(page.getByText(/add details/i)).toBeVisible();
     await expect(page.getByLabel(/description/i)).not.toBeVisible();
 
     // Expand it
-    await page.getByText(/add description/i).click();
+    await page.getByText(/add details/i).click();
     await expect(page.getByLabel(/description/i)).toBeVisible();
   });
 });

--- a/e2e/mobile-lists.spec.ts
+++ b/e2e/mobile-lists.spec.ts
@@ -211,8 +211,11 @@ test.describe("Mobile Lists", () => {
       addItemSheet.locator("option", { hasText: "Documents" }),
     ).toBeAttached();
 
-    // Save the item (draft text still present)
+    // Save the item (draft text still present). Multi-add keeps the create
+    // sheet open after a successful add, so dismiss it via the "Done" label
+    // that replaces "Cancel" once an item has been added this session.
     await addItemSheet.getByRole("button", { name: "Save item" }).click();
+    await addItemSheet.getByRole("button", { name: "Done" }).click();
     await expect(addItemSheet).toBeHidden();
 
     // Item is visible

--- a/e2e/mobile-lists.spec.ts
+++ b/e2e/mobile-lists.spec.ts
@@ -59,14 +59,34 @@ test.describe("Mobile Lists", () => {
     await expect(optionsSheet).toBeHidden();
 
     await page.getByRole("button", { name: "Add item" }).click();
-    await page.getByLabel("Item text").fill("Bananas");
-    await page
-      .getByRole("combobox", { name: "Category" })
-      .selectOption({ label: "Produce" });
-    await page.getByRole("button", { name: "Save item" }).click();
+    const addItemSheet = page.getByRole("dialog", { name: "Add Item" });
+    await waitForSheetSettled(addItemSheet);
+    const itemTextInput = addItemSheet.getByLabel("Item text");
+    const itemCategorySelect = addItemSheet.getByRole("combobox", {
+      name: "Category",
+    });
+    await itemCategorySelect.selectOption({ label: "Produce" });
 
+    for (const itemText of ["Bananas", "Apples", "Carrots"]) {
+      await itemTextInput.fill(itemText);
+      await addItemSheet.getByRole("button", { name: "Save item" }).click();
+      await expect(addItemSheet).toBeVisible();
+      await expect(itemTextInput).toHaveValue("");
+      await expect(itemTextInput).toBeFocused();
+      await expect(itemCategorySelect.locator("option:checked")).toHaveText(
+        "Produce",
+      );
+      await expect(
+        addItemSheet.getByRole("button", { name: "Done" }),
+      ).toBeVisible();
+    }
+
+    await addItemSheet.getByRole("button", { name: "Done" }).click();
+    await expect(addItemSheet).toBeHidden();
     await expect(page.getByRole("heading", { name: "Produce" })).toBeVisible();
     await expect(page.getByText("Bananas")).toBeVisible();
+    await expect(page.getByText("Apples")).toBeVisible();
+    await expect(page.getByText("Carrots")).toBeVisible();
 
     // Switch the category mode immediately — the item create may still be in
     // flight, so the list-level PATCH response must not clobber the new item.

--- a/e2e/quick-capture.spec.ts
+++ b/e2e/quick-capture.spec.ts
@@ -100,8 +100,11 @@ test.describe("Quick Capture Friction", () => {
     // Open the event's detail view and confirm the location renders.
     const eventCard = page.getByRole("button", { name: /swim class/i }).first();
     await safeClick(eventCard);
-    await expect(page.getByRole("dialog")).toBeVisible();
+    // Scope to the detail dialog: the calendar event card also renders the
+    // location, so a page-wide getByText would be strict-mode ambiguous.
+    const detailDialog = page.getByRole("dialog");
+    await expect(detailDialog).toBeVisible();
 
-    await expect(page.getByText("YMCA pool")).toBeVisible();
+    await expect(detailDialog.getByText("YMCA pool")).toBeVisible();
   });
 });

--- a/e2e/quick-capture.spec.ts
+++ b/e2e/quick-capture.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForCalendarReady,
+  waitForHydration,
+  waitForSheetSettled,
+} from "./helpers/test-helpers";
+
+test.describe("Quick Capture Friction", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("adds three grocery items in one sheet session", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "QC Family",
+      members: [{ name: "Joe", color: "teal" }],
+    });
+    await seedBrowserAuth(page, registration);
+
+    await page.reload();
+    await waitForHydration(page);
+
+    const nav = page.getByRole("navigation", { name: /primary/i });
+    await nav.getByRole("button", { name: "Lists" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Lists", level: 1, exact: true }),
+    ).toBeVisible();
+
+    // Create a Grocery list — creating it navigates straight into its detail view.
+    await page.getByRole("button", { name: "Create list" }).click();
+    const createDialog = page.getByRole("dialog", { name: "New List" });
+    await waitForSheetSettled(createDialog);
+    await createDialog.getByLabel("List name").fill("Groceries");
+    await createDialog.getByRole("radio", { name: "Grocery" }).click();
+    await createDialog.getByRole("button", { name: "Create list" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Groceries" }),
+    ).toBeVisible();
+
+    // Open the Add Item sheet and add three items in one session.
+    await page.getByRole("button", { name: "Add item" }).click();
+    const addItemSheet = page.getByRole("dialog", { name: "Add Item" });
+    await waitForSheetSettled(addItemSheet);
+    const itemTextInput = addItemSheet.getByLabel("Item text");
+
+    for (const itemText of ["Milk", "Eggs", "Bananas"]) {
+      await itemTextInput.fill(itemText);
+      await addItemSheet.getByRole("button", { name: "Save item" }).click();
+      // Multi-add sync point: the input clears and refocuses, and the sheet
+      // stays open for the next item instead of closing.
+      await expect(itemTextInput).toHaveValue("");
+      await expect(addItemSheet).toBeVisible();
+    }
+
+    // After the first successful save the dismiss label flips to "Done".
+    await addItemSheet.getByRole("button", { name: "Done" }).click();
+    await expect(addItemSheet).toBeHidden();
+
+    await expect(page.getByText("Milk")).toBeVisible();
+    await expect(page.getByText("Eggs")).toBeVisible();
+    await expect(page.getByText("Bananas")).toBeVisible();
+  });
+
+  test("creates an event with a location and shows it in the detail view", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "QC Family 2",
+      members: [{ name: "Joe", color: "teal" }],
+    });
+    await seedBrowserAuth(page, registration);
+
+    await page.reload();
+    await waitForHydration(page);
+    await waitForCalendarReady(page);
+
+    // Create an event with a location revealed behind "Add details".
+    await safeClick(page.getByRole("button", { name: "Add event" }));
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel("Event Name").fill("Swim class");
+    await dialog.getByRole("button", { name: /add details/i }).click();
+    await dialog.getByLabel("Location").fill("YMCA pool");
+
+    await dialog.getByRole("button", { name: /^add event$/i }).click();
+    await expect(dialog).toBeHidden();
+
+    // Open the event's detail view and confirm the location renders.
+    const eventCard = page.getByRole("button", { name: /swim class/i }).first();
+    await safeClick(eventCard);
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    await expect(page.getByText("YMCA pool")).toBeVisible();
+  });
+});

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -1043,10 +1043,10 @@ describe("EventForm", () => {
         />,
       );
       expect(screen.queryByLabelText(/description/i)).not.toBeInTheDocument();
-      expect(screen.getByText(/add description/i)).toBeInTheDocument();
+      expect(screen.getByText(/add details/i)).toBeInTheDocument();
     });
 
-    it("shows description textarea when 'Add description' is clicked", async () => {
+    it("shows description textarea when 'Add details' is clicked", async () => {
       const { user } = renderWithUser(
         <EventForm
           mode="add"
@@ -1055,7 +1055,7 @@ describe("EventForm", () => {
         />,
       );
 
-      await user.click(screen.getByText(/add description/i));
+      await user.click(screen.getByText(/add details/i));
       expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
     });
 
@@ -1155,6 +1155,70 @@ describe("EventForm", () => {
           screen.getByRole("button", { name: member.name }),
         ).toBeInTheDocument();
       }
+    });
+  });
+
+  describe("location field", () => {
+    it("reveals Location and Description behind Add details", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{ memberId: testMembers[0].id }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+      await waitForMemberSelected(testMembers[0].name);
+
+      expect(screen.queryByLabelText("Location")).not.toBeInTheDocument();
+      await user.click(screen.getByRole("button", { name: /add details/i }));
+      expect(screen.getByLabelText("Location")).toBeInTheDocument();
+      expect(screen.getByLabelText("Description")).toBeInTheDocument();
+    });
+
+    it("submits the entered location", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="add"
+          defaultValues={{ memberId: testMembers[0].id, title: "Swim class" }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+      await waitForMemberSelected(testMembers[0].name);
+
+      await user.click(screen.getByRole("button", { name: /add details/i }));
+      await user.type(screen.getByLabelText("Location"), "YMCA pool");
+      await user.click(screen.getByRole("button", { name: /add event/i }));
+
+      await waitFor(
+        () => {
+          expect(mockOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({ location: "YMCA pool" }),
+          );
+        },
+        { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+      );
+    });
+
+    it("starts expanded in edit mode when location is present", async () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={{
+            memberId: testMembers[0].id,
+            title: "Dentist",
+            date: "2026-07-01",
+            startTime: "09:30",
+            endTime: "10:30",
+            location: "Smile Dental",
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      expect(screen.getByLabelText("Location")).toHaveValue("Smile Dental");
     });
   });
 });

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -10,8 +10,22 @@ import {
   typeAndWait,
   waitFor,
   waitForMemberSelected,
+  within,
 } from "@/test/test-utils";
 import { EventForm } from "./event-form";
+
+type TestUser = ReturnType<typeof renderWithUser>["user"];
+
+function getWheelColumn(index: number) {
+  const wheelColumns = document.body.querySelectorAll(".scrollbar-hide");
+  const wheelColumn = wheelColumns[index];
+
+  if (!wheelColumn) {
+    throw new Error(`Time picker wheel column ${index} was not rendered`);
+  }
+
+  return wheelColumn as HTMLElement;
+}
 
 describe("EventForm", () => {
   const mockOnSubmit = vi.fn();
@@ -19,11 +33,56 @@ describe("EventForm", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    class ResizeObserverMock {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
     seedFamilyStore({
       name: "Test Family",
       members: testMembers,
     });
   });
+
+  const timedEvent = (
+    overrides: Partial<Parameters<typeof EventForm>[0]["defaultValues"]> = {},
+  ) => ({
+    title: "Existing Meeting",
+    date: "2026-01-15",
+    startTime: "09:00",
+    endTime: "10:00",
+    memberId: testMembers[0].id,
+    ...overrides,
+  });
+
+  async function changeHourWithTimePicker(
+    user: TestUser,
+    triggerName: RegExp,
+    hourLabel: string,
+  ) {
+    await user.click(screen.getAllByRole("button", { name: triggerName })[0]);
+    await user.click(
+      within(getWheelColumn(0)).getAllByRole("button", {
+        name: hourLabel,
+      })[0],
+    );
+    await user.click(screen.getByRole("button", { name: "OK" }));
+  }
+
+  async function submitEditForm(user: TestUser) {
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(
+      () => {
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      },
+      { timeout: TEST_TIMEOUTS.FORM_SUBMIT },
+    );
+
+    return mockOnSubmit.mock.calls[0][0];
+  }
 
   describe("Add Mode", () => {
     it("renders with smart defaults", () => {
@@ -176,6 +235,182 @@ describe("EventForm", () => {
           memberId: testMembers[1].id,
         }),
       );
+    });
+  });
+
+  describe("Time Changes", () => {
+    it("preserves duration when changing the start time with the picker", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent()}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await changeHourWithTimePicker(user, /9:00 AM/i, "11");
+
+      expect(
+        screen.getByRole("button", { name: /11:00 AM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /12:00 PM/i }),
+      ).toBeInTheDocument();
+
+      await expect(submitEditForm(user)).resolves.toEqual(
+        expect.objectContaining({
+          startTime: "11:00",
+          endTime: "12:00",
+        }),
+      );
+    });
+
+    it("clamps the preserved end time to 23:59 when changing the start time", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent({
+            startTime: "21:00",
+            endTime: "22:30",
+          })}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await changeHourWithTimePicker(user, /9:00 PM/i, "11");
+
+      expect(
+        screen.getByRole("button", { name: /11:00 PM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /11:59 PM/i }),
+      ).toBeInTheDocument();
+
+      await expect(submitEditForm(user)).resolves.toEqual(
+        expect.objectContaining({
+          startTime: "23:00",
+          endTime: "23:59",
+        }),
+      );
+    });
+
+    it.each([
+      { endTime: "09:00", state: "equal to start" },
+      { endTime: "08:30", state: "before start" },
+    ])("uses a one-hour duration when the current end time is $state", async ({
+      endTime,
+    }) => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent({ endTime })}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await changeHourWithTimePicker(user, /9:00 AM/i, "11");
+
+      expect(
+        screen.getByRole("button", { name: /11:00 AM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /12:00 PM/i }),
+      ).toBeInTheDocument();
+
+      await expect(submitEditForm(user)).resolves.toEqual(
+        expect.objectContaining({
+          startTime: "11:00",
+          endTime: "12:00",
+        }),
+      );
+    });
+
+    it("shifts both start and end times when nudging the start later", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent()}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Start time later by 15 minutes",
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", { name: /9:15 AM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /10:15 AM/i }),
+      ).toBeInTheDocument();
+
+      await expect(submitEditForm(user)).resolves.toEqual(
+        expect.objectContaining({
+          startTime: "09:15",
+          endTime: "10:15",
+        }),
+      );
+    });
+
+    it("shifts only the end time when nudging the end later", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent()}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "End time later by 15 minutes",
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", { name: /9:00 AM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /10:15 AM/i }),
+      ).toBeInTheDocument();
+
+      await expect(submitEditForm(user)).resolves.toEqual(
+        expect.objectContaining({
+          startTime: "09:00",
+          endTime: "10:15",
+        }),
+      );
+    });
+
+    it("renders accessible 44px nudge controls for both time fields", () => {
+      render(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent()}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      for (const label of [
+        "Start time earlier by 15 minutes",
+        "Start time later by 15 minutes",
+        "End time earlier by 15 minutes",
+        "End time later by 15 minutes",
+      ]) {
+        const button = screen.getByRole("button", { name: label });
+
+        expect(button.className).toContain("h-11");
+        expect(button.className).toContain("w-11");
+      }
     });
   });
 

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -27,6 +27,11 @@ function getWheelColumn(index: number) {
   return wheelColumn as HTMLElement;
 }
 
+function timeToMinutes(time: string) {
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours * 60 + minutes;
+}
+
 describe("EventForm", () => {
   const mockOnSubmit = vi.fn();
   const mockOnCancel = vi.fn();
@@ -356,6 +361,45 @@ describe("EventForm", () => {
           startTime: "09:15",
           endTime: "10:15",
         }),
+      );
+    });
+
+    it("does not let a start nudge create equal times near midnight", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent({
+            startTime: "23:45",
+            endTime: "23:59",
+          })}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Start time later by 15 minutes",
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", { name: /11:45 PM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /11:59 PM/i }),
+      ).toBeInTheDocument();
+
+      const submitted = await submitEditForm(user);
+
+      expect(submitted).toEqual(
+        expect.objectContaining({
+          startTime: "23:45",
+          endTime: "23:59",
+        }),
+      );
+      expect(timeToMinutes(submitted.endTime)).toBeGreaterThan(
+        timeToMinutes(submitted.startTime),
       );
     });
 

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -301,6 +301,41 @@ describe("EventForm", () => {
       );
     });
 
+    it("does not let an off-grid start picker change create equal times near midnight", async () => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent({
+            startTime: "22:59",
+            endTime: "23:59",
+          })}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await changeHourWithTimePicker(user, /10:59 PM/i, "11");
+
+      expect(
+        screen.getByRole("button", { name: /10:59 PM/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /11:59 PM/i }),
+      ).toBeInTheDocument();
+
+      const submitted = await submitEditForm(user);
+
+      expect(submitted).toEqual(
+        expect.objectContaining({
+          startTime: "22:59",
+          endTime: "23:59",
+        }),
+      );
+      expect(timeToMinutes(submitted.endTime)).toBeGreaterThan(
+        timeToMinutes(submitted.startTime),
+      );
+    });
+
     it.each([
       { endTime: "09:00", state: "equal to start" },
       { endTime: "08:30", state: "before start" },

--- a/src/components/calendar/components/event-form.test.tsx
+++ b/src/components/calendar/components/event-form.test.tsx
@@ -434,6 +434,63 @@ describe("EventForm", () => {
       );
     });
 
+    it.each([
+      {
+        startTime: "09:00",
+        endTime: "09:15",
+        startDisplay: /9:00 AM/i,
+        endDisplay: /9:15 AM/i,
+      },
+      {
+        startTime: "23:45",
+        endTime: "23:59",
+        startDisplay: /11:45 PM/i,
+        endDisplay: /11:59 PM/i,
+      },
+    ])("does not let an end nudge move $endTime at or before $startTime", async ({
+      startTime,
+      endTime,
+      startDisplay,
+      endDisplay,
+    }) => {
+      const { user } = renderWithUser(
+        <EventForm
+          mode="edit"
+          defaultValues={timedEvent({
+            startTime,
+            endTime,
+          })}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />,
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "End time earlier by 15 minutes",
+        }),
+      );
+
+      expect(
+        screen.getByRole("button", { name: startDisplay }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: endDisplay }),
+      ).toBeInTheDocument();
+
+      const submitted = await submitEditForm(user);
+
+      expect(submitted).toEqual(
+        expect.objectContaining({
+          startTime,
+          endTime,
+        }),
+      );
+      expect(timeToMinutes(submitted.endTime)).toBeGreaterThan(
+        timeToMinutes(submitted.startTime),
+      );
+    });
+
     it("renders accessible 44px nudge controls for both time fields", () => {
       render(
         <EventForm

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -64,16 +64,6 @@ function getDurationMinutes(startTime?: string, endTime?: string): number {
   return endMinutes - startMinutes;
 }
 
-function shiftTimeByMinutes(
-  time: string | undefined,
-  deltaMinutes: number,
-): string | undefined {
-  const minutes = parseTimeToMinutes(time);
-  if (minutes === null) return undefined;
-
-  return formatMinutesToTime(minutes + deltaMinutes);
-}
-
 function EventForm({
   mode,
   defaultValues,
@@ -188,10 +178,17 @@ function EventForm({
   };
 
   const handleEndTimeNudge = (deltaMinutes: number) => {
-    const nextEndTime = shiftTimeByMinutes(endTimeValue, deltaMinutes);
-    if (!nextEndTime) return;
+    const startMinutes = parseTimeToMinutes(startTimeValue);
+    const endMinutes = parseTimeToMinutes(endTimeValue);
+    if (startMinutes === null || endMinutes === null) return;
 
-    setValue("endTime", nextEndTime);
+    const nextEndMinutes = Math.max(
+      0,
+      Math.min(endMinutes + deltaMinutes, LAST_MINUTE_OF_DAY),
+    );
+    if (nextEndMinutes <= startMinutes) return;
+
+    setValue("endTime", formatMinutesToTime(nextEndMinutes));
   };
 
   const toggleAllDay = () => {

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -169,10 +169,22 @@ function EventForm({
   };
 
   const handleStartTimeNudge = (deltaMinutes: number) => {
-    const nextStartTime = shiftTimeByMinutes(startTimeValue, deltaMinutes);
-    if (!nextStartTime) return;
+    const startMinutes = parseTimeToMinutes(startTimeValue);
+    if (startMinutes === null) return;
 
-    handleStartTimeChange(nextStartTime);
+    const durationMinutes = getDurationMinutes(startTimeValue, endTimeValue);
+    const nextStartMinutes = Math.max(
+      0,
+      Math.min(startMinutes + deltaMinutes, LAST_MINUTE_OF_DAY),
+    );
+    const nextEndMinutes = Math.min(
+      nextStartMinutes + durationMinutes,
+      LAST_MINUTE_OF_DAY,
+    );
+
+    if (nextEndMinutes <= nextStartMinutes) return;
+
+    handleStartTimeChange(formatMinutesToTime(nextStartMinutes));
   };
 
   const handleEndTimeNudge = (deltaMinutes: number) => {

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -150,12 +150,16 @@ function EventForm({
   const handleStartTimeChange = (time: string) => {
     const startMinutes = parseTimeToMinutes(time);
     const durationMinutes = getDurationMinutes(startTimeValue, endTimeValue);
+    if (startMinutes === null) return;
+
+    const nextEndMinutes = Math.min(
+      startMinutes + durationMinutes,
+      LAST_MINUTE_OF_DAY,
+    );
+    if (nextEndMinutes <= startMinutes) return;
 
     setValue("startTime", time);
-
-    if (startMinutes !== null) {
-      setValue("endTime", formatMinutesToTime(startMinutes + durationMinutes));
-    }
+    setValue("endTime", formatMinutesToTime(nextEndMinutes));
   };
 
   const handleStartTimeNudge = (deltaMinutes: number) => {

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -166,17 +166,12 @@ function EventForm({
     const startMinutes = parseTimeToMinutes(startTimeValue);
     if (startMinutes === null) return;
 
-    const durationMinutes = getDurationMinutes(startTimeValue, endTimeValue);
+    // Only clamp the new start here; handleStartTimeChange re-derives the
+    // duration from the same current times and applies the end-clamp + guard.
     const nextStartMinutes = Math.max(
       0,
       Math.min(startMinutes + deltaMinutes, LAST_MINUTE_OF_DAY),
     );
-    const nextEndMinutes = Math.min(
-      nextStartMinutes + durationMinutes,
-      LAST_MINUTE_OF_DAY,
-    );
-
-    if (nextEndMinutes <= nextStartMinutes) return;
 
     handleStartTimeChange(formatMinutesToTime(nextStartMinutes));
   };
@@ -430,24 +425,26 @@ function EventForm({
               />
               <FormError message={errors.location?.message} />
             </div>
-            <Label htmlFor="description">Description</Label>
-            <textarea
-              id="description"
-              {...register("description")}
-              placeholder="Add notes or details..."
-              className={cn(
-                "flex min-h-[88px] w-full resize-y rounded-lg border border-input bg-input px-3 py-2 text-[15px] leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
-                errors.description && "border-destructive",
+            <div className="space-y-2">
+              <Label htmlFor="description">Description</Label>
+              <textarea
+                id="description"
+                {...register("description")}
+                placeholder="Add notes or details..."
+                className={cn(
+                  "flex min-h-[88px] w-full resize-y rounded-lg border border-input bg-input px-3 py-2 text-[15px] leading-5 placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+                  errors.description && "border-destructive",
+                )}
+                maxLength={2000}
+                aria-invalid={!!errors.description}
+              />
+              {descriptionValue && descriptionValue.length > 1900 && (
+                <p className="text-xs text-muted-foreground text-right">
+                  {descriptionValue.length}/2000
+                </p>
               )}
-              maxLength={2000}
-              aria-invalid={!!errors.description}
-            />
-            {descriptionValue && descriptionValue.length > 1900 && (
-              <p className="text-xs text-muted-foreground text-right">
-                {descriptionValue.length}/2000
-              </p>
-            )}
-            <FormError message={errors.description?.message} />
+              <FormError message={errors.description?.message} />
+            </div>
           </>
         )}
       </div>

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -114,7 +114,7 @@ function EventForm({
     defaultValues: initialValues,
   });
 
-  const [showDescription, setShowDescription] = useState(false);
+  const [showDetails, setShowDetails] = useState(false);
 
   // Watch values for controlled components
   const dateValue = watch("date");
@@ -135,12 +135,12 @@ function EventForm({
     reset(initialValues);
   }, [initialValues, reset]);
 
-  // Auto-expand description if initial value has content
+  // Auto-expand details if initial value has description or location content
   useEffect(() => {
-    if (initialValues.description) {
-      setShowDescription(true);
+    if (initialValues.description || initialValues.location) {
+      setShowDetails(true);
     }
-  }, [initialValues.description]);
+  }, [initialValues.description, initialValues.location]);
 
   const handleFormSubmit = (data: EventFormData) => {
     if (isPending) return;
@@ -402,19 +402,34 @@ function EventForm({
         <FormError message={errors.memberId?.message} />
       </div>
 
-      {/* Description (collapsible) */}
+      {/* Details: Location + Description (collapsible) */}
       <div className="space-y-2">
-        {!showDescription ? (
+        {!showDetails ? (
           <button
             type="button"
-            onClick={() => setShowDescription(true)}
+            onClick={() => setShowDetails(true)}
             className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
             <ChevronDown className="w-3.5 h-3.5" />
-            Add description
+            Add details
           </button>
         ) : (
           <>
+            <div className="space-y-2">
+              <Label htmlFor="location">Location</Label>
+              <Input
+                id="location"
+                {...register("location")}
+                placeholder="Where?"
+                className={cn(
+                  "bg-input",
+                  errors.location && "border-destructive",
+                )}
+                maxLength={255}
+                aria-invalid={!!errors.location}
+              />
+              <FormError message={errors.location?.message} />
+            </div>
             <Label htmlFor="description">Description</Label>
             <textarea
               id="description"

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, Minus, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { useFamilyMembers } from "@/api";
@@ -25,6 +25,53 @@ interface EventFormProps {
   isPending?: boolean;
   showRecurrencePicker?: boolean;
   hideCancelButton?: boolean;
+}
+
+const DEFAULT_DURATION_MINUTES = 60;
+const LAST_MINUTE_OF_DAY = 23 * 60 + 59;
+const NUDGE_MINUTES = 15;
+const TIME_PATTERN = /^([01]?[0-9]|2[0-3]):([0-5][0-9])$/;
+
+function parseTimeToMinutes(time?: string): number | null {
+  if (!time) return null;
+
+  const match = TIME_PATTERN.exec(time);
+  if (!match) return null;
+
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+function formatMinutesToTime(minutes: number): string {
+  const clampedMinutes = Math.max(0, Math.min(minutes, LAST_MINUTE_OF_DAY));
+  const hours = Math.floor(clampedMinutes / 60);
+  const mins = clampedMinutes % 60;
+
+  return `${hours.toString().padStart(2, "0")}:${mins.toString().padStart(2, "0")}`;
+}
+
+function getDurationMinutes(startTime?: string, endTime?: string): number {
+  const startMinutes = parseTimeToMinutes(startTime);
+  const endMinutes = parseTimeToMinutes(endTime);
+
+  if (
+    startMinutes === null ||
+    endMinutes === null ||
+    endMinutes <= startMinutes
+  ) {
+    return DEFAULT_DURATION_MINUTES;
+  }
+
+  return endMinutes - startMinutes;
+}
+
+function shiftTimeByMinutes(
+  time: string | undefined,
+  deltaMinutes: number,
+): string | undefined {
+  const minutes = parseTimeToMinutes(time);
+  if (minutes === null) return undefined;
+
+  return formatMinutesToTime(minutes + deltaMinutes);
 }
 
 function EventForm({
@@ -108,6 +155,31 @@ function EventForm({
   const handleFormSubmit = (data: EventFormData) => {
     if (isPending) return;
     onSubmit(data);
+  };
+
+  const handleStartTimeChange = (time: string) => {
+    const startMinutes = parseTimeToMinutes(time);
+    const durationMinutes = getDurationMinutes(startTimeValue, endTimeValue);
+
+    setValue("startTime", time);
+
+    if (startMinutes !== null) {
+      setValue("endTime", formatMinutesToTime(startMinutes + durationMinutes));
+    }
+  };
+
+  const handleStartTimeNudge = (deltaMinutes: number) => {
+    const nextStartTime = shiftTimeByMinutes(startTimeValue, deltaMinutes);
+    if (!nextStartTime) return;
+
+    handleStartTimeChange(nextStartTime);
+  };
+
+  const handleEndTimeNudge = (deltaMinutes: number) => {
+    const nextEndTime = shiftTimeByMinutes(endTimeValue, deltaMinutes);
+    if (!nextEndTime) return;
+
+    setValue("endTime", nextEndTime);
   };
 
   const toggleAllDay = () => {
@@ -235,25 +307,71 @@ function EventForm({
 
       {/* Start/End Time */}
       {!isAllDayValue && (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
           <div className="space-y-2">
             <Label>Start Time</Label>
-            <TimePicker
-              value={startTimeValue}
-              onChange={(time) => setValue("startTime", time)}
-              placeholder="Start time"
-              error={!!errors.startTime}
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-11 w-11 shrink-0 bg-input"
+                aria-label="Start time earlier by 15 minutes"
+                onClick={() => handleStartTimeNudge(-NUDGE_MINUTES)}
+              >
+                <Minus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+              <TimePicker
+                value={startTimeValue}
+                onChange={handleStartTimeChange}
+                placeholder="Start time"
+                error={!!errors.startTime}
+                className="h-11 min-w-0 flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-11 w-11 shrink-0 bg-input"
+                aria-label="Start time later by 15 minutes"
+                onClick={() => handleStartTimeNudge(NUDGE_MINUTES)}
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
             <FormError message={errors.startTime?.message} />
           </div>
           <div className="space-y-2">
             <Label>End Time</Label>
-            <TimePicker
-              value={endTimeValue}
-              onChange={(time) => setValue("endTime", time)}
-              placeholder="End time"
-              error={!!errors.endTime}
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-11 w-11 shrink-0 bg-input"
+                aria-label="End time earlier by 15 minutes"
+                onClick={() => handleEndTimeNudge(-NUDGE_MINUTES)}
+              >
+                <Minus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+              <TimePicker
+                value={endTimeValue}
+                onChange={(time) => setValue("endTime", time)}
+                placeholder="End time"
+                error={!!errors.endTime}
+                className="h-11 min-w-0 flex-1"
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon-lg"
+                className="h-11 w-11 shrink-0 bg-input"
+                aria-label="End time later by 15 minutes"
+                onClick={() => handleEndTimeNudge(NUDGE_MINUTES)}
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            </div>
             <FormError message={errors.endTime?.message} />
           </div>
         </div>

--- a/src/components/lists-view.test.tsx
+++ b/src/components/lists-view.test.tsx
@@ -357,6 +357,13 @@ describe("ListsView hub", () => {
 
     expect(await screen.findByText("Popcorn")).toBeInTheDocument();
 
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Add Item" }),
+      ).not.toBeInTheDocument();
+    });
+
     await user.click(screen.getByRole("button", { name: "Edit" }));
     await user.clear(screen.getByLabelText("Item text"));
     await typeAndWait(user, screen.getByLabelText("Item text"), "Kettle corn");

--- a/src/components/lists/list-item-sheet.test.tsx
+++ b/src/components/lists/list-item-sheet.test.tsx
@@ -27,6 +27,7 @@
  */
 
 import { HttpResponse, http } from "msw";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useList } from "@/api";
 import type { ListDetail } from "@/lib/types";
@@ -222,6 +223,179 @@ function renderSheet(
     />,
   );
 }
+
+function ControlledCacheSheet({
+  initialList,
+  mode,
+  item,
+  onOpenChange,
+}: {
+  initialList: ListDetail;
+  mode: "create" | "edit";
+  item: typeof baseItem | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <CacheConnectedSheet
+      initialList={initialList}
+      open={open}
+      mode={mode}
+      item={item}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen);
+        setOpen(nextOpen);
+      }}
+    />
+  );
+}
+
+function renderControlledSheet({
+  mode = "create",
+  list = makeList(),
+  item = null,
+  onOpenChange = vi.fn(),
+  convergeCategories = true,
+}: {
+  mode?: "create" | "edit";
+  list?: ListDetail;
+  item?: typeof baseItem | null;
+  onOpenChange?: (open: boolean) => void;
+  convergeCategories?: boolean;
+} = {}) {
+  if (convergeCategories) {
+    seedMockLists([list]);
+    installConvergingCategoryHandlers(list);
+  }
+  return renderWithUser(
+    <ControlledCacheSheet
+      initialList={list}
+      mode={mode}
+      item={item}
+      onOpenChange={onOpenChange}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item create multi-add flow
+// ---------------------------------------------------------------------------
+
+describe("item create multi-add flow", () => {
+  it("keeps create sheet open after successful create, clears/refocuses text, preserves category, and flips Cancel to Done", async () => {
+    const onOpenChange = vi.fn();
+    const { user } = renderControlledSheet({ onOpenChange });
+
+    const textInput = await screen.findByRole("textbox", {
+      name: /item text/i,
+    });
+    await user.type(textInput, "Spinach");
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /category/i }),
+      CAT_A_ID,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save item/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /item text/i })).toHaveValue(
+        "",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /item text/i })).toHaveFocus();
+    });
+
+    const select = screen.getByRole("combobox", { name: /category/i });
+    expect((select as HTMLSelectElement).value).toBe(CAT_A_ID);
+    expect(select.querySelector("option:checked")?.textContent).toBe("Produce");
+    expect(screen.getByRole("dialog", { name: "Add Item" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Add Item" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps typed text and selected category after failed create", async () => {
+    const list = makeList();
+    seedMockLists([list]);
+    server.use(
+      http.post(`${API_BASE}/lists/${LIST_ID}/items`, () =>
+        HttpResponse.json({ message: "Server error" }, { status: 500 }),
+      ),
+    );
+
+    const onOpenChange = vi.fn();
+    const { user } = renderControlledSheet({
+      list,
+      onOpenChange,
+      convergeCategories: false,
+    });
+
+    await user.type(
+      await screen.findByRole("textbox", { name: /item text/i }),
+      "Bread",
+    );
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: /category/i }),
+      CAT_B_ID,
+    );
+
+    await user.click(screen.getByRole("button", { name: /save item/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/server error/i);
+    });
+    expect(screen.getByRole("textbox", { name: /item text/i })).toHaveValue(
+      "Bread",
+    );
+    expect(screen.getByRole("combobox", { name: /category/i })).toHaveValue(
+      CAT_B_ID,
+    );
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Done" }),
+    ).not.toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("still closes edit sheet after successful save", async () => {
+    const list = makeList({ items: [baseItem] });
+    const onOpenChange = vi.fn();
+    const { user } = renderControlledSheet({
+      mode: "edit",
+      list,
+      item: baseItem,
+      onOpenChange,
+    });
+
+    await user.clear(
+      await screen.findByRole("textbox", { name: /item text/i }),
+    );
+    await user.type(
+      screen.getByRole("textbox", { name: /item text/i }),
+      "Kiwi",
+    );
+    await user.click(screen.getByRole("button", { name: /save item/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Edit Item" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Category selection for all list kinds

--- a/src/components/lists/list-item-sheet.test.tsx
+++ b/src/components/lists/list-item-sheet.test.tsx
@@ -51,6 +51,22 @@ vi.mock("@/hooks", async (importOriginal) => {
   return { ...actual, useOnlineStatus: () => online };
 });
 
+const mobileSheetCancelLabels = vi.hoisted(
+  () => [] as Array<string | undefined>,
+);
+
+vi.mock("../ui/mobile-sheet", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../ui/mobile-sheet")>();
+  const React = await import("react");
+  return {
+    ...actual,
+    MobileSheet: (props: Parameters<typeof actual.MobileSheet>[0]) => {
+      mobileSheetCancelLabels.push(props.cancelLabel);
+      return React.createElement(actual.MobileSheet, props);
+    },
+  };
+});
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -277,6 +293,47 @@ function renderControlledSheet({
   );
 }
 
+function ReopenableCreateSheet({
+  initialList,
+  onOpenChange,
+}: {
+  initialList: ListDetail;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open add item sheet
+      </button>
+      <CacheConnectedSheet
+        initialList={initialList}
+        open={open}
+        mode="create"
+        item={null}
+        onOpenChange={(nextOpen) => {
+          onOpenChange(nextOpen);
+          setOpen(nextOpen);
+        }}
+      />
+    </>
+  );
+}
+
+function renderReopenableCreateSheet({
+  list = makeList(),
+  onOpenChange = vi.fn(),
+}: {
+  list?: ListDetail;
+  onOpenChange?: (open: boolean) => void;
+} = {}) {
+  seedMockLists([list]);
+  installConvergingCategoryHandlers(list);
+  return renderWithUser(
+    <ReopenableCreateSheet initialList={list} onOpenChange={onOpenChange} />,
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Item create multi-add flow
 // ---------------------------------------------------------------------------
@@ -324,6 +381,37 @@ describe("item create multi-add flow", () => {
       ).not.toBeInTheDocument();
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("reopens a completed create cycle with Cancel on the first reopened render", async () => {
+    const { user } = renderReopenableCreateSheet();
+
+    await user.type(
+      await screen.findByRole("textbox", { name: /item text/i }),
+      "Spinach",
+    );
+    await user.click(screen.getByRole("button", { name: /save item/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: "Done" }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Add Item" }),
+      ).not.toBeInTheDocument();
+    });
+
+    mobileSheetCancelLabels.length = 0;
+    await user.click(
+      screen.getByRole("button", { name: "Open add item sheet" }),
+    );
+
+    expect(mobileSheetCancelLabels[0]).toBeUndefined();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Done" }),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps typed text and selected category after failed create", async () => {

--- a/src/components/lists/list-item-sheet.tsx
+++ b/src/components/lists/list-item-sheet.tsx
@@ -71,6 +71,7 @@ export function ListItemSheet({
   const [inlineName, setInlineName] = useState("");
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlinePending, setInlinePending] = useState(false);
+  const [hasCreatedItemThisCycle, setHasCreatedItemThisCycle] = useState(false);
 
   // Recovery error lives in React state so async updates trigger re-renders
   // properly in all environments (including test). form.setError alone may not
@@ -80,6 +81,7 @@ export function ListItemSheet({
 
   // Track the previous value of `open` to detect new item cycles.
   const prevOpenRef = useRef(open);
+  const prevModeRef = useRef(mode);
   useEffect(() => {
     const wasOpen = prevOpenRef.current;
     prevOpenRef.current = open;
@@ -89,8 +91,17 @@ export function ListItemSheet({
       setInlineName("");
       setInlineError(null);
       setRecoveryError(null);
+      setHasCreatedItemThisCycle(false);
     }
   }, [open]);
+
+  useEffect(() => {
+    const previousMode = prevModeRef.current;
+    prevModeRef.current = mode;
+    if (open && previousMode !== mode) {
+      setHasCreatedItemThisCycle(false);
+    }
+  }, [mode, open]);
 
   useEffect(() => {
     if (open) {
@@ -261,7 +272,14 @@ export function ListItemSheet({
         categoryId: values.categoryId ?? null,
       },
       {
-        onSuccess: () => onOpenChange(false),
+        onSuccess: () => {
+          setHasCreatedItemThisCycle(true);
+          form.reset({
+            text: "",
+            categoryId: selectedCategoryId,
+          });
+          window.setTimeout(() => form.setFocus("text"), 0);
+        },
         onError: handleItemError,
       },
     );
@@ -271,6 +289,9 @@ export function ListItemSheet({
     <MobileSheet
       isOpen={open}
       onClose={() => onOpenChange(false)}
+      cancelLabel={
+        mode === "create" && hasCreatedItemThisCycle ? "Done" : undefined
+      }
       title={mode === "edit" ? "Edit Item" : "Add Item"}
       initialHeight="half"
       headerRight={

--- a/src/components/lists/list-item-sheet.tsx
+++ b/src/components/lists/list-item-sheet.tsx
@@ -115,6 +115,11 @@ export function ListItemSheet({
   const isPending =
     createItem.isPending || updateItem.isPending || inlinePending;
 
+  function closeSheet() {
+    setHasCreatedItemThisCycle(false);
+    onOpenChange(false);
+  }
+
   // ---------------------------------------------------------------------------
   // Inline category create handler
   // ---------------------------------------------------------------------------
@@ -288,7 +293,7 @@ export function ListItemSheet({
   return (
     <MobileSheet
       isOpen={open}
-      onClose={() => onOpenChange(false)}
+      onClose={closeSheet}
       cancelLabel={
         mode === "create" && hasCreatedItemThisCycle ? "Done" : undefined
       }

--- a/src/components/ui/mobile-sheet.test.tsx
+++ b/src/components/ui/mobile-sheet.test.tsx
@@ -96,6 +96,29 @@ describe("MobileSheet", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("uses a custom header dismiss label when provided", async () => {
+    const onClose = vi.fn();
+    const { user } = renderWithUser(
+      <MobileSheet
+        isOpen
+        onClose={onClose}
+        title="Test sheet"
+        cancelLabel="Done"
+      >
+        <button type="button">Inside</button>
+      </MobileSheet>,
+    );
+
+    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Cancel" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   // ---------------------------------------------------------------------------
   // Task 11: new optional props — must not break existing callers
   // ---------------------------------------------------------------------------

--- a/src/components/ui/mobile-sheet.tsx
+++ b/src/components/ui/mobile-sheet.tsx
@@ -20,6 +20,7 @@ export interface MobileSheetProps {
   isOpen: boolean;
   onClose: () => void;
   onCancel?: () => void;
+  cancelLabel?: string;
   title: string;
   /**
    * When provided, `onPointerDownOutside` calls `e.preventDefault()` while the
@@ -77,6 +78,7 @@ export function MobileSheet({
   isOpen,
   onClose,
   onCancel,
+  cancelLabel = "Cancel",
   title,
   headerRight,
   children,
@@ -238,7 +240,7 @@ export function MobileSheet({
               onClick={onCancel ?? onClose}
               className="rounded-lg px-1 py-1 text-sm font-semibold text-primary"
             >
-              Cancel
+              {cancelLabel}
             </button>
             <Drawer.Title
               ref={(el) => {

--- a/src/components/ui/time-picker.test.tsx
+++ b/src/components/ui/time-picker.test.tsx
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, userEvent, within } from "@/test/test-utils";
+import { TimePicker } from "./time-picker";
+
+function getMinuteWheel() {
+  const wheelColumns = document.body.querySelectorAll(".scrollbar-hide");
+  const minuteWheel = wheelColumns[1];
+
+  if (!minuteWheel) {
+    throw new Error("Minute wheel was not rendered");
+  }
+
+  return minuteWheel as HTMLElement;
+}
+
+function getUniqueMinuteLabels() {
+  const minuteButtons = within(getMinuteWheel()).getAllByRole("button");
+  return Array.from(
+    new Set(minuteButtons.map((button) => button.textContent ?? "")),
+  ).sort((a, b) => Number(a) - Number(b));
+}
+
+describe("TimePicker", () => {
+  beforeEach(() => {
+    class ResizeObserverMock {
+      observe = vi.fn();
+      unobserve = vi.fn();
+      disconnect = vi.fn();
+    }
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  it("renders 12 five-minute choices for an on-grid value", async () => {
+    const user = userEvent.setup();
+
+    render(<TimePicker value="09:00" onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /9:00 AM/i }));
+
+    expect(getUniqueMinuteLabels()).toEqual([
+      "00",
+      "05",
+      "10",
+      "15",
+      "20",
+      "25",
+      "30",
+      "35",
+      "40",
+      "45",
+      "50",
+      "55",
+    ]);
+  });
+
+  it("shows an off-grid minute as the only extra choice and confirms it unchanged", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TimePicker value="09:47" onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: /9:47 AM/i }));
+
+    expect(getUniqueMinuteLabels()).toEqual([
+      "00",
+      "05",
+      "10",
+      "15",
+      "20",
+      "25",
+      "30",
+      "35",
+      "40",
+      "45",
+      "47",
+      "50",
+      "55",
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "OK" }));
+
+    expect(onChange).toHaveBeenCalledWith("09:47");
+  });
+});

--- a/src/components/ui/time-picker.tsx
+++ b/src/components/ui/time-picker.tsx
@@ -18,7 +18,7 @@ interface TimePickerProps {
 }
 
 const HOURS = Array.from({ length: 12 }, (_, i) => i + 1); // 1-12
-const MINUTES = Array.from({ length: 60 }, (_, i) => i); // 0-59
+const MINUTES = Array.from({ length: 12 }, (_, i) => i * 5); // 0-55, every 5 minutes
 const PERIODS = ["AM", "PM"] as const;
 
 const ITEM_HEIGHT = 40;
@@ -307,6 +307,14 @@ function TimePicker({
   const [minute, setMinute] = useState(parsed.minute);
   const [period, setPeriod] = useState<"AM" | "PM">(parsed.period);
 
+  const minuteOptions = useMemo(() => {
+    if (!open || MINUTES.includes(parsed.minute)) {
+      return MINUTES;
+    }
+
+    return [...MINUTES, parsed.minute].sort((a, b) => a - b);
+  }, [open, parsed.minute]);
+
   // Sync internal state when value prop changes
   useEffect(() => {
     if (value) {
@@ -371,7 +379,7 @@ function TimePicker({
           {/* Minutes */}
           <WheelColumn
             key={`minute-${mountKey}`}
-            items={MINUTES}
+            items={minuteOptions}
             value={minute}
             onChange={setMinute}
             formatItem={(m) => m.toString().padStart(2, "0")}


### PR DESCRIPTION
Closes #271.

Removes the repeat-tax from the three highest-frequency phone capture flows: list item entry, event time selection, and event location. Frontend-only — no backend, API-contract, or schema changes (`location` already existed end-to-end; only the form input was missing).

## Execution contract → code + tests

| # | Non-negotiable | Code | Tests |
|---|----------------|------|-------|
| 1 | Multi-add is create-mode only: sheet stays open, text clears, input refocuses, category persists, header flips `Cancel`→`Done` after first add; edit still closes on save; failed create keeps text; no toast | `list-item-sheet.tsx` (keep-open `onSuccess`, `hasCreatedItemThisCycle`, `form.reset({text:""})` + `setFocus`), `mobile-sheet.tsx` (additive `cancelLabel` prop, default `"Cancel"`) | `list-item-sheet.test.tsx` (multi-add session), `mobile-sheet.test.tsx` (custom label), E2E `quick-capture.spec.ts` |
| 2 | Minute wheel 0–55 step 5; off-grid current value (e.g. 9:47) renders as an extra position and is emitted unchanged if untouched — never silently rounded | `time-picker.tsx` (`MINUTES` = 12×5; off-grid value injected + sorted for the open cycle) | `time-picker.test.tsx` (on-grid steps, off-grid extra position, preserved-when-untouched) |
| 3 | Duration preservation: any start change shifts end by the same delta (clamped 23:59); inverted/equal mid-edit → 1h; end-only changes never move start | `event-form.tsx` (`handleStartTimeChange`) | `event-form.test.tsx` (duration preservation, near-midnight clamps) |
| 4 | ±15 nudge buttons per time field, ≥44px, aria-labels; start nudge routes through the duration-preserving handler | `event-form.tsx` (nudge row, `aria-label`s, start→`handleStartTimeChange`) | `event-form.test.tsx` (start nudge shifts both, end nudge shifts end only) |
| 5 | Location field with Description behind the `Add details` expander; auto-expands in edit mode when location or description present; placeholder "Where?", maxLength 255; no new validation | `event-form.tsx` (`showDetails`, Location `Input` above Description) | `event-form.test.tsx` (reveal behind Add details, submits location, edit-mode auto-expand), E2E `quick-capture.spec.ts` |
| 6 | FE-only — no backend / contract / schema changes | diff touches only `src/components/**` + tests + `e2e/**`; Zod schema, request types, and payload mapping unchanged | — |

## Acceptance checklist

- [x] Add 3 items to a list in one sheet session; `Done` closes it; all 3 persist — **E2E (live real-BE run: passed)**
- [x] Edit-mode item save still closes the sheet — `list-item-sheet.test.tsx`
- [x] Minute wheel shows 12 positions; opening on 9:47 shows and preserves 47 when confirmed untouched — `time-picker.test.tsx`
- [x] Start 9:00→11:00 on a 9:00–10:00 event → 11:00–12:00; 21:00→23:00 on 21:00–22:30 clamps end to 11:59 PM — `event-form.test.tsx`
- [x] ±15 nudges: start nudge shifts both times; end nudge shifts only end — `event-form.test.tsx`
- [x] Create event with location via `Add details`; location renders in detail view — **E2E (live real-BE run: passed)**
- [x] Edit form starts expanded when the event has a location or description — `event-form.test.tsx`
- [x] `npm run lint`, `npm test -- --run`, `npm run build` all pass

## Testing

- **Unit/integration:** `npm test -- --run` → **1395 passed** (136 files)
- **E2E:** `e2e/quick-capture.spec.ts` run live against the real backend (`family-hub-api:1.8.0`) on the Mobile Chrome project → **2 passed** (grocery multi-add; event-with-location)
- **Gate:** `npm run lint` clean, `npm run build` (tsc -b + Vite + PWA) succeeds

## Out of scope

Meals plan-sheet changes, tap-empty-slot / drag-to-create, inline list composer, any backend change.
