### PR TITLE
Meals: add reviewed recipe ingredients to a grocery list

### DIFF
--- a/e2e/helpers/api-helpers.ts
+++ b/e2e/helpers/api-helpers.ts
@@ -1,6 +1,10 @@
 import type { APIRequestContext, Page } from "@playwright/test";
 import type { CreateEventRequest } from "../../src/lib/types/calendar";
 import type { FamilyColor } from "../../src/lib/types/family";
+import type {
+  MealType,
+  UpsertMealSlotRequest,
+} from "../../src/lib/types/meals";
 import type { CreateRecipeRequest } from "../../src/lib/types/recipes";
 
 const API_BASE = "http://127.0.0.1:8080/api";
@@ -118,4 +122,56 @@ export async function createRecipe(
 
   const json = await response.json();
   return json.data;
+}
+
+/**
+ * Plan a meal into a specific slot of a week via the real backend
+ * `PUT /meals/slots` (the same endpoint the composer/planning UI drives).
+ *
+ * Seeding meals through the API keeps the ingredients-to-grocery E2E focused on
+ * the review → append journey rather than re-walking the multi-step planning
+ * flow (already covered by mobile-meals.spec.ts). `dayIndex` is 0=Sunday..6=Sat,
+ * matching the board contract and the weekday labels in the review sheet.
+ */
+export async function planMealSlot(
+  request: APIRequestContext,
+  token: string,
+  slot: {
+    weekStartDate: string;
+    dayIndex: number;
+    mealType: MealType;
+    /** recipe-backed when recipeId is set; a quick meal otherwise. */
+    recipeId?: string;
+    title: string;
+  },
+): Promise<void> {
+  const body: UpsertMealSlotRequest = {
+    weekStartDate: slot.weekStartDate,
+    dayIndex: slot.dayIndex,
+    mealType: slot.mealType,
+    primary: {
+      sourceType: slot.recipeId ? "recipe" : "quick",
+      recipeId: slot.recipeId ?? null,
+      title: slot.title,
+      imageUrl: null,
+      note: null,
+    },
+    extras: [],
+    note: null,
+    collisionMode: null,
+  };
+
+  const response = await request.put(`${API_BASE}/meals/slots`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    data: body,
+  });
+
+  if (!response.ok()) {
+    const responseBody = await response.text();
+    throw new Error(
+      `Plan meal slot failed (${response.status()}): ${responseBody}`,
+    );
+  }
 }

--- a/e2e/meals-ingredients.spec.ts
+++ b/e2e/meals-ingredients.spec.ts
@@ -1,0 +1,259 @@
+import { expect, type Page, test } from "@playwright/test";
+import { formatLocalDate, getWeekStartSunday } from "../src/lib/time-utils";
+import {
+  createRecipe,
+  planMealSlot,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+  waitForSheetSettled,
+} from "./helpers/test-helpers";
+
+/**
+ * Released-contract E2E for Meals → "Add ingredients to grocery list".
+ *
+ * Exercises the whole journey against the published backend release (resolved
+ * by CI; `BE_IMAGE_TAG=1.9.0` locally, which exposes
+ * `POST /api/lists/{listId}/items/bulk`):
+ *   1. Two recipe-backed dinners + one quick dinner planned in the current week.
+ *   2. Open "Add ingredients": rows grouped per meal with VERBATIM ingredient
+ *      text, and the quick meal under "No recipe ingredients".
+ *   3. Edit one ingredient row, remove another.
+ *   4. No grocery list exists yet → create one in-flow.
+ *   5. Confirm "Add to list" exactly once → success + "View list".
+ *   6. Open the grocery list and assert the selected/edited rows are present.
+ *      The bulk response preserves request order, but same-batch items can tie
+ *      on createdAt, so this asserts membership only — never a strict read-back
+ *      order.
+ */
+
+// The board is keyed by the current week's Sunday start, computed exactly as
+// MealsView does, so the API-seeded slots land on the week the board opens to.
+const CURRENT_WEEK_START = formatLocalDate(getWeekStartSunday(new Date()));
+
+// Fixed day indexes (0=Sunday) keep the review-sheet weekday labels
+// deterministic regardless of which day the suite runs on. All three sit in
+// the current (editable) week, so the "Add ingredients" action is offered.
+const MONDAY = 1;
+const WEDNESDAY = 3;
+const FRIDAY = 5;
+
+const PASTA_RECIPE = {
+  title: "Weeknight Pasta",
+  ingredients: ["1 lb spaghetti", "2 cups marinara sauce", "1/4 cup parmesan"],
+};
+const TACO_RECIPE = {
+  title: "Sheet Pan Tacos",
+  ingredients: ["1 lb ground beef", "8 corn tortillas", "1 lime"],
+};
+const QUICK_MEAL_TITLE = "Order Pizza";
+
+const GROCERY_LIST_NAME = "This Week's Groceries";
+
+// Group labels are "<Weekday> · <Meal> — <title>" (meal-ingredient-extraction).
+const PASTA_GROUP = `Monday · Dinner — ${PASTA_RECIPE.title}`;
+const TACO_GROUP = `Wednesday · Dinner — ${TACO_RECIPE.title}`;
+const QUICK_GROUP = `Friday · Dinner — ${QUICK_MEAL_TITLE}`;
+
+/**
+ * Navigate to the weekly Meals board via the bottom-nav "More" sheet. Mirrors
+ * mobile-meals.spec.ts — the active view is not persisted across reloads.
+ */
+async function openMealsBoard(page: Page) {
+  const nav = page.getByRole("navigation", { name: /primary/i });
+  await safeClick(nav.getByRole("button", { name: "More" }));
+  const moreSheet = page.getByRole("dialog", { name: "More" });
+  await waitForSheetSettled(moreSheet);
+  await safeClick(moreSheet.getByRole("button", { name: "Meals" }));
+  await expect(moreSheet).toBeHidden();
+  await expect(
+    page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+  ).toBeVisible();
+}
+
+test.describe("Meals ingredients → grocery list", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    // The "Add ingredients" flow renders in a MobileSheet, so this is a
+    // mobile-only journey like the other meals specs.
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("adds reviewed recipe ingredients from planned dinners to a grocery list", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(90_000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Ingredients To Grocery Family",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    // Two recipes that store ingredients, planned as recipe-backed dinners, plus
+    // one quick-meal dinner — all in the current week, all seeded via the real
+    // API so the UI journey below starts from a realistic board.
+    const pasta = await createRecipe(request, registration.token, {
+      title: PASTA_RECIPE.title,
+      ingredients: PASTA_RECIPE.ingredients,
+      instructions: ["Boil pasta. Simmer sauce. Combine."],
+      tags: ["Dinner"],
+      favorite: false,
+    });
+    const tacos = await createRecipe(request, registration.token, {
+      title: TACO_RECIPE.title,
+      ingredients: TACO_RECIPE.ingredients,
+      instructions: ["Roast on a sheet pan. Assemble tacos."],
+      tags: ["Dinner"],
+      favorite: false,
+    });
+
+    await planMealSlot(request, registration.token, {
+      weekStartDate: CURRENT_WEEK_START,
+      dayIndex: MONDAY,
+      mealType: "dinner",
+      recipeId: pasta.id,
+      title: pasta.title,
+    });
+    await planMealSlot(request, registration.token, {
+      weekStartDate: CURRENT_WEEK_START,
+      dayIndex: WEDNESDAY,
+      mealType: "dinner",
+      recipeId: tacos.id,
+      title: tacos.title,
+    });
+    await planMealSlot(request, registration.token, {
+      weekStartDate: CURRENT_WEEK_START,
+      dayIndex: FRIDAY,
+      mealType: "dinner",
+      title: QUICK_MEAL_TITLE,
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    await openMealsBoard(page);
+
+    // ---- Open the review sheet --------------------------------------------
+    await safeClick(page.getByRole("button", { name: "Add ingredients" }));
+    const sheet = page.getByRole("dialog", {
+      name: "Add ingredients to grocery list",
+    });
+    await waitForSheetSettled(sheet);
+
+    // Recipe detail fetches resolve, then the review model renders.
+    await expect(sheet.getByText("Loading recipe ingredients…")).toBeHidden();
+
+    // ---- Rows grouped per meal, verbatim ingredient text ------------------
+    await expect(
+      sheet.getByRole("heading", { name: PASTA_GROUP }),
+    ).toBeVisible();
+    await expect(
+      sheet.getByRole("heading", { name: TACO_GROUP }),
+    ).toBeVisible();
+
+    // Every verbatim ingredient appears as an editable, pre-selected row.
+    for (const ingredient of [
+      ...PASTA_RECIPE.ingredients,
+      ...TACO_RECIPE.ingredients,
+    ]) {
+      const rowInput = sheet.getByRole("textbox", {
+        name: `Edit ${ingredient}`,
+      });
+      await expect(rowInput).toHaveValue(ingredient);
+      await expect(
+        sheet.getByRole("checkbox", { name: `Include ${ingredient}` }),
+      ).toBeChecked();
+    }
+
+    // ---- Quick meal lands under "No recipe ingredients" -------------------
+    await expect(
+      sheet.getByRole("heading", { name: "No recipe ingredients" }),
+    ).toBeVisible();
+    await expect(sheet.getByText(QUICK_GROUP)).toBeVisible();
+    // Its only affordance is a manual add; it contributes no ingredient rows.
+    await expect(
+      sheet.getByRole("button", { name: `Add item for ${QUICK_GROUP}` }),
+    ).toBeVisible();
+
+    // ---- Edit one row, remove another -------------------------------------
+    const EDITED_FROM = "2 cups marinara sauce";
+    const EDITED_TO = "3 cups marinara sauce";
+    const REMOVED = "1 lime";
+
+    const editInput = sheet.getByRole("textbox", {
+      name: `Edit ${EDITED_FROM}`,
+    });
+    await editInput.fill(EDITED_TO);
+    // The row's accessible name tracks its text, so it re-labels after editing.
+    await expect(
+      sheet.getByRole("textbox", { name: `Edit ${EDITED_TO}` }),
+    ).toHaveValue(EDITED_TO);
+
+    await safeClick(sheet.getByRole("button", { name: `Remove ${REMOVED}` }));
+    await expect(
+      sheet.getByRole("textbox", { name: `Edit ${REMOVED}` }),
+    ).toBeHidden();
+
+    // ---- No grocery list yet → create one in-flow -------------------------
+    // Confirm is blocked until a target grocery list exists.
+    const addToListButton = sheet.getByRole("button", { name: "Add to list" });
+    await expect(addToListButton).toBeDisabled();
+
+    await sheet.getByLabel("Grocery list name").fill(GROCERY_LIST_NAME);
+    await safeClick(sheet.getByRole("button", { name: "Create grocery list" }));
+
+    // Once the list is created it becomes the sole target ("Adding to <name>.")
+    // and the confirm unlocks.
+    await expect(
+      sheet.getByText(GROCERY_LIST_NAME, { exact: false }),
+    ).toBeVisible();
+    await expect(addToListButton).toBeEnabled();
+
+    // ---- Confirm the append exactly once ----------------------------------
+    await safeClick(addToListButton);
+
+    // ---- Success + View list ----------------------------------------------
+    await expect(
+      sheet.getByText("Ingredients added to your grocery list."),
+    ).toBeVisible();
+    const viewListButton = sheet.getByRole("button", { name: "View list" });
+    await expect(viewListButton).toBeVisible();
+
+    // ---- Open the grocery list and assert the selected rows are present ----
+    await safeClick(viewListButton);
+    await expect(sheet).toBeHidden();
+
+    await expect(
+      page.getByRole("heading", { name: GROCERY_LIST_NAME }),
+    ).toBeVisible();
+
+    // Kept rows (including the edited one) landed in the list. Membership only —
+    // same-batch createdAt ties mean read-back order is not guaranteed.
+    const expectedItems = [
+      "1 lb spaghetti",
+      EDITED_TO,
+      "1/4 cup parmesan",
+      "1 lb ground beef",
+      "8 corn tortillas",
+    ];
+    for (const itemText of expectedItems) {
+      await expect(page.getByText(itemText, { exact: true })).toBeVisible();
+    }
+
+    // The removed ingredient and the un-edited original must NOT be present.
+    await expect(page.getByText(REMOVED, { exact: true })).toHaveCount(0);
+    await expect(page.getByText(EDITED_FROM, { exact: true })).toHaveCount(0);
+    // The quick meal contributed no manual rows, so its title is not an item.
+    await expect(page.getByText(QUICK_MEAL_TITLE, { exact: true })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/src/api/hooks/index.ts
+++ b/src/api/hooks/index.ts
@@ -63,6 +63,7 @@ export {
 
 export {
   listsKeys,
+  useBulkCreateListItems,
   useClearCompleted,
   useCreateList,
   useCreateListCategory,

--- a/src/api/hooks/use-lists.test.tsx
+++ b/src/api/hooks/use-lists.test.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/test/mocks/server";
 import {
   listsKeys,
+  useBulkCreateListItems,
   useClearCompleted,
   useCreateList,
   useCreateListCategory,
@@ -655,6 +656,145 @@ describe("useLists", () => {
         )?.data.items,
       ).toEqual([]);
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // useBulkCreateListItems
+  // ---------------------------------------------------------------------------
+
+  it("appends bulk-created items after existing items and refreshes the hub", async () => {
+    const seededList: ListDetail = {
+      ...groceryList,
+      items: [
+        {
+          id: "00000000-0000-4000-8000-000000009101",
+          text: "Existing item 1",
+          completed: false,
+          completedAt: null,
+          categoryId: null,
+          createdAt: "2026-05-06T09:00:00",
+          updatedAt: "2026-05-06T09:00:00",
+        },
+        {
+          id: "00000000-0000-4000-8000-000000009102",
+          text: "Existing item 2",
+          completed: false,
+          completedAt: null,
+          categoryId: null,
+          createdAt: "2026-05-06T09:00:00",
+          updatedAt: "2026-05-06T09:00:00",
+        },
+      ],
+    };
+    seedMockLists([seededList]);
+    queryClient.setQueryData(listsKeys.detail(seededList.id), {
+      data: seededList,
+    } satisfies ApiResponse<ListDetail>);
+    // Seed the hub query so it exists in the cache and its invalidation can be observed.
+    queryClient.setQueryData(listsKeys.hub(), {
+      data: [
+        {
+          id: seededList.id,
+          name: seededList.name,
+          kind: seededList.kind,
+          totalItems: seededList.items.length,
+          completedItems: 0,
+        },
+      ],
+    });
+
+    const createdItems: ListItem[] = [
+      {
+        id: "00000000-0000-4000-8000-000000009103",
+        text: "2 eggs",
+        completed: false,
+        completedAt: null,
+        categoryId: null,
+        createdAt: "2026-05-06T09:30:00",
+        updatedAt: "2026-05-06T09:30:00",
+      },
+      {
+        id: "00000000-0000-4000-8000-000000009104",
+        text: "1 cup flour",
+        completed: false,
+        completedAt: null,
+        categoryId: null,
+        createdAt: "2026-05-06T09:30:00",
+        updatedAt: "2026-05-06T09:30:00",
+      },
+    ];
+    server.use(
+      http.post(`${API_BASE}/lists/:id/items/bulk`, () => {
+        return HttpResponse.json({
+          data: createdItems,
+          message: "List items added successfully",
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useBulkCreateListItems(seededList.id), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      items: [{ text: "2 eggs" }, { text: "1 cup flour" }],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const detail = queryClient.getQueryData<ApiResponse<ListDetail>>(
+      listsKeys.detail(seededList.id),
+    );
+    expect(detail?.data.items.map((item) => item.text)).toEqual([
+      "Existing item 1",
+      "Existing item 2",
+      "2 eggs",
+      "1 cup flour",
+    ]);
+
+    expect(queryClient.getQueryState(listsKeys.hub())?.isInvalidated).toBe(
+      true,
+    );
+  });
+
+  it("rejects offline without calling the service or touching the detail cache", async () => {
+    seedMockLists([groceryList]);
+    queryClient.setQueryData(listsKeys.detail(groceryList.id), {
+      data: groceryList,
+    } satisfies ApiResponse<ListDetail>);
+
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const createSpy = vi.spyOn(listsService, "createItemsBulk");
+
+    try {
+      const { result } = renderHook(
+        () => useBulkCreateListItems(groceryList.id),
+        { wrapper: createWrapper() },
+      );
+
+      result.current.mutate({ items: [{ text: "2 eggs" }] });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(createSpy).not.toHaveBeenCalled();
+      expect(
+        queryClient.getQueryData<ApiResponse<ListDetail>>(
+          listsKeys.detail(groceryList.id),
+        )?.data.items,
+      ).toEqual([]);
+    } finally {
+      // Restore online state even if an assertion throws, so later tests in
+      // this suite (whose afterEach does not reset navigator.onLine) are not
+      // left offline.
+      Object.defineProperty(navigator, "onLine", {
+        configurable: true,
+        value: true,
+      });
+      vi.restoreAllMocks();
+    }
   });
 
   // ---------------------------------------------------------------------------

--- a/src/api/hooks/use-lists.ts
+++ b/src/api/hooks/use-lists.ts
@@ -8,6 +8,7 @@ import { listsService } from "@/api/services";
 import { useOnlineStatus } from "@/hooks/use-online-status";
 import { assertOnlineForWrite } from "@/lib/offline/read-only-guard";
 import type {
+  BulkCreateListItemsRequest,
   CreateListCategoryRequest,
   CreateListItemRequest,
   CreateListRequest,
@@ -211,6 +212,33 @@ export function useCreateListItem(listId: string) {
           updateDetailItems(previous, (items) =>
             replaceCreatedItem(items, context?.temporaryId, response.data),
           ),
+      );
+      queryClient.invalidateQueries({ queryKey: listsKeys.hub() });
+    },
+  });
+}
+
+/**
+ * Append a batch of items to a list from a single confirmed action (e.g.
+ * "add reviewed recipe ingredients to a grocery list"). Unlike
+ * {@link useCreateListItem}, there is no optimistic `onMutate` — the request
+ * already represents user-reviewed, final rows, so the cache is updated from
+ * the authoritative response instead of an interim optimistic guess.
+ */
+export function useBulkCreateListItems(listId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: BulkCreateListItemsRequest) => {
+      // Read-only offline: reject before any cache change.
+      assertOnlineForWrite();
+      return listsService.createItemsBulk(listId, request);
+    },
+    onSuccess: (response) => {
+      queryClient.setQueryData<ListDetailApiResponse>(
+        listsKeys.detail(listId),
+        (current) =>
+          updateDetailItems(current, (items) => [...items, ...response.data]),
       );
       queryClient.invalidateQueries({ queryKey: listsKeys.hub() });
     },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,7 @@ export {
   syncFamilyFromStorage,
   TEMP_MEMBER_ID_PREFIX,
   useAddMember,
+  useBulkCreateListItems,
   useCalendarEvent,
   useCalendarEvents,
   useCheckUsername,

--- a/src/api/services/lists.service.test.ts
+++ b/src/api/services/lists.service.test.ts
@@ -1,0 +1,41 @@
+import { HttpResponse, http } from "msw";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { API_BASE, server } from "@/test/mocks/server";
+import { listsService } from "./lists.service";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("listsService.createItemsBulk", () => {
+  it("posts selected rows to /lists/:id/items/bulk", async () => {
+    const captured = { url: "", body: "" };
+    server.use(
+      http.post(`${API_BASE}/lists/list-1/items/bulk`, async ({ request }) => {
+        captured.url = request.url;
+        captured.body = await request.text();
+        return HttpResponse.json({
+          data: [
+            {
+              id: "i1",
+              text: "2 eggs",
+              completed: false,
+              completedAt: null,
+              categoryId: null,
+              createdAt: "",
+              updatedAt: "",
+            },
+          ],
+          message: "List items added successfully",
+        });
+      }),
+    );
+
+    await listsService.createItemsBulk("list-1", {
+      items: [{ text: "2 eggs" }],
+    });
+
+    expect(new URL(captured.url).pathname).toBe("/api/lists/list-1/items/bulk");
+    expect(JSON.parse(captured.body)).toEqual({ items: [{ text: "2 eggs" }] });
+  });
+});

--- a/src/api/services/lists.service.ts
+++ b/src/api/services/lists.service.ts
@@ -1,5 +1,6 @@
 import { httpClient } from "@/api/client";
 import type {
+  BulkCreateListItemsRequest,
   CategoryDeleteResultApiResponse,
   ClearCompletedApiResponse,
   CreateListCategoryRequest,
@@ -9,6 +10,7 @@ import type {
   ListCategoryManagementEntryApiResponse,
   ListDetailApiResponse,
   ListItemApiResponse,
+  ListItemsApiResponse,
   ListKind,
   ListPreferencesApiResponse,
   ListSummariesApiResponse,
@@ -56,6 +58,16 @@ export const listsService = {
   ): Promise<ListItemApiResponse> {
     return httpClient.patch<ListItemApiResponse>(
       `/lists/${listId}/items/${itemId}`,
+      request,
+    );
+  },
+
+  createItemsBulk(
+    listId: string,
+    request: BulkCreateListItemsRequest,
+  ): Promise<ListItemsApiResponse> {
+    return httpClient.post<ListItemsApiResponse>(
+      `/lists/${listId}/items/bulk`,
       request,
     );
   },

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -2287,4 +2287,49 @@ describe("MealsView", () => {
     expect(createCalls).toBe(1);
     expect(bulkTargets).toEqual(["list-grocery-new", "list-grocery-new"]);
   });
+
+  it("blocks an over-cap append (>100 items) with an honest error and fires no request", async () => {
+    // A recipe with 101 ingredients: the review model selects one row each, so
+    // the built payload exceeds the shared schema's 100-item cap.
+    const overCapIngredients = Array.from(
+      { length: 101 },
+      (_, index) => `Ingredient ${index + 1}`,
+    );
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([{ ...testRecipeDetail, ingredients: overCapIngredients }]);
+    seedMockLists([groceryList()]);
+
+    let bulkCalls = 0;
+    server.use(
+      http.post(`${API_BASE}/lists/:id/items/bulk`, () => {
+        bulkCalls += 1;
+        return HttpResponse.json({ data: [], message: "ok" }, { status: 201 });
+      }),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+    // Confirm the review model actually loaded the over-cap ingredient set.
+    expect(
+      await screen.findByDisplayValue("Ingredient 101"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    // The client-side guard surfaces the honest cap message.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /up to 100 items at once/i,
+    );
+    // No request left the client, and no success affordance appeared.
+    expect(bulkCalls).toBe(0);
+    expect(
+      screen.queryByRole("button", { name: /view list/i }),
+    ).not.toBeInTheDocument();
+    // The selection is retained and the action stays retryable.
+    expect(screen.getByDisplayValue("Ingredient 101")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add to list/i })).toBeEnabled();
+  });
 });

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -148,6 +148,14 @@ function withExtrasOnlyDinnerSlot(
   };
 }
 
+function setNavigatorOnline(value: boolean): void {
+  Object.defineProperty(navigator, "onLine", {
+    configurable: true,
+    value,
+  });
+  window.dispatchEvent(new Event(value ? "online" : "offline"));
+}
+
 function withSavedMealPlan(
   board: MealBoard,
   request: SaveMealPlanRequest,
@@ -175,6 +183,7 @@ describe("MealsView", () => {
   });
 
   afterEach(() => {
+    setNavigatorOnline(true);
     vi.unstubAllGlobals();
   });
 
@@ -2174,6 +2183,54 @@ describe("MealsView", () => {
     expect(
       await screen.findByRole("button", { name: /view list/i }),
     ).toBeInTheDocument();
+  });
+
+  it("disables grocery list creation while offline and sends no create request", async () => {
+    setNavigatorOnline(false);
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    seedMockLists([]);
+
+    let createCalls = 0;
+    server.use(
+      http.post(`${API_BASE}/lists`, () => {
+        createCalls += 1;
+        return HttpResponse.json(
+          {
+            data: groceryList({ id: "list-grocery-new" }),
+            message: "created",
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    await user.type(
+      await screen.findByLabelText(/grocery list name/i),
+      "Weekly groceries",
+    );
+
+    const createButton = screen.getByRole("button", {
+      name: /create grocery list/i,
+    });
+    expect(createButton).toBeDisabled();
+    expect(
+      screen.getByText(
+        "You're offline. Review your ingredients now and add them to your list when you're back online.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(createButton);
+    expect(createCalls).toBe(0);
   });
 
   it("does not present a failed append as success", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -3,7 +3,12 @@ import { HttpResponse, http } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mealsKeys } from "@/api";
 import { formatLocalDate, getWeekStartSunday } from "@/lib/time-utils";
-import type { ApiResponse, MealBoard, SaveMealPlanRequest } from "@/lib/types";
+import type {
+  ApiResponse,
+  ListDetail,
+  MealBoard,
+  SaveMealPlanRequest,
+} from "@/lib/types";
 import { useAppStore } from "@/stores/app-store";
 import {
   createEmptyMealsBoard,
@@ -19,6 +24,7 @@ import {
 import {
   API_BASE,
   getMockMealsBoard,
+  seedMockLists,
   seedMockMealsBoard,
   seedMockRecipes,
   server,
@@ -1854,5 +1860,431 @@ describe("MealsView", () => {
         updated.days[4].slots[1].extras.map((extra) => extra.title),
       ).toEqual(["Salad"]);
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Task 6: "Add ingredients" → grocery-list picker/create + bulk append
+  // ---------------------------------------------------------------------------
+
+  function groceryList(overrides: Partial<ListDetail> = {}): ListDetail {
+    return {
+      id: "list-grocery-1",
+      name: "Groceries",
+      kind: "grocery",
+      categoryDisplayMode: "flat",
+      showCompletedOverride: null,
+      categories: [],
+      items: [],
+      createdAt: "2026-06-01T00:00:00",
+      updatedAt: "2026-06-01T00:00:00",
+      ...overrides,
+    };
+  }
+
+  function toDoList(overrides: Partial<ListDetail> = {}): ListDetail {
+    return {
+      id: "list-todo-1",
+      name: "Errands",
+      kind: "to-do",
+      categoryDisplayMode: "flat",
+      showCompletedOverride: null,
+      categories: [],
+      items: [],
+      createdAt: "2026-06-01T00:00:00",
+      updatedAt: "2026-06-01T00:00:00",
+      ...overrides,
+    };
+  }
+
+  it("shows Add ingredients on an editable week with a recipe-backed meal and hides it on past weeks", async () => {
+    // Current week (editable) with a recipe-backed dinner.
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    // Past week board so navigating back is review-only.
+    seedMockMealsBoard(createEmptyMealsBoard("2026-05-31"));
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(<MealsView />);
+
+    // Editable week: the action is present alongside Fill empty slots.
+    expect(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fill empty slots" }),
+    ).toBeInTheDocument();
+
+    // Navigate to a past week: review-only, so Add ingredients disappears.
+    await user.click(screen.getByRole("button", { name: "Previous week" }));
+    expect(await screen.findByText("Review only")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add ingredients" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides Add ingredients when the visible week has no recipe-backed meals", async () => {
+    // Only a quick meal + empty slots: nothing recipe-backed to extract.
+    seedMockMealsBoard(
+      withOccupiedDinnerSlot(createEmptyMealsBoard(), 1, "Leftovers"),
+    );
+    renderWithUser(<MealsView />);
+
+    // The board renders (quick meal visible) but the action is absent.
+    expect(await screen.findByText("Leftovers")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add ingredients" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("defaults to the only grocery list and appends selected rows once, then offers View list", async () => {
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    // Exactly one grocery list (plus a to-do list that must never be offered).
+    seedMockLists([groceryList(), toDoList()]);
+
+    const bulkRequests: Array<{ id: string; texts: string[] }> = [];
+    server.use(
+      http.post(
+        `${API_BASE}/lists/:id/items/bulk`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as {
+            items: Array<{ text: string }>;
+          };
+          bulkRequests.push({
+            id: params.id as string,
+            texts: body.items.map((i) => i.text),
+          });
+          const createdItems = body.items.map((row, index) => ({
+            id: `created-${index}`,
+            text: row.text,
+            completed: false,
+            completedAt: null,
+            categoryId: null,
+            createdAt: "2026-06-07T00:00:00",
+            updatedAt: "2026-06-07T00:00:00",
+          }));
+          return HttpResponse.json(
+            { data: createdItems, message: "ok" },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: 0 },
+        mutations: { retry: false },
+      },
+    });
+    // Prime the list-detail cache as if the user had opened this list before,
+    // so the bulk hook's write-through cache update is exercised and observable.
+    queryClient.setQueryData(["lists", "detail", "list-grocery-1"], {
+      data: groceryList(),
+      message: "ok",
+    });
+    const { user } = renderWithUser(<MealsView />, { queryClient });
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+
+    // The review sheet resolves the recipe's verbatim ingredient rows.
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    // Exactly one bulk POST, targeting the only grocery list, with the rows.
+    await waitFor(() => expect(bulkRequests).toHaveLength(1));
+    expect(bulkRequests[0].id).toBe("list-grocery-1");
+    expect(bulkRequests[0].texts).toEqual([
+      "Salmon fillets",
+      "Asparagus",
+      "Lemon",
+    ]);
+
+    // Success surfaces a "View list" affordance.
+    const viewList = await screen.findByRole("button", { name: /view list/i });
+    expect(viewList).toBeInTheDocument();
+
+    // The list-detail cache gained the appended items.
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<ApiResponse<ListDetail>>([
+        "lists",
+        "detail",
+        "list-grocery-1",
+      ]);
+      expect(cached?.data.items.map((i) => i.text)).toEqual([
+        "Salmon fillets",
+        "Asparagus",
+        "Lemon",
+      ]);
+    });
+
+    // Clicking View list navigates to that list.
+    await user.click(viewList);
+    expect(useAppStore.getState().activeModule).toBe("lists");
+    expect(useAppStore.getState().consumeListDetailIntent()).toBe(
+      "list-grocery-1",
+    );
+  });
+
+  it("appends to the grocery list the user picks when several exist", async () => {
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    // Several grocery lists → no auto-select; the picker drives the target.
+    seedMockLists([
+      groceryList({ id: "list-grocery-1", name: "Groceries" }),
+      groceryList({ id: "list-grocery-2", name: "Costco run" }),
+    ]);
+
+    const bulkRequests: Array<{ id: string; texts: string[] }> = [];
+    server.use(
+      http.post(
+        `${API_BASE}/lists/:id/items/bulk`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as {
+            items: Array<{ text: string }>;
+          };
+          bulkRequests.push({
+            id: params.id as string,
+            texts: body.items.map((i) => i.text),
+          });
+          return HttpResponse.json(
+            { data: [], message: "ok" },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    // With several lists a picker renders (no auto-select). "Add to list" is
+    // blocked until a target is chosen.
+    const picker = await screen.findByRole("combobox", {
+      name: /grocery list/i,
+    });
+    expect(screen.getByRole("button", { name: /add to list/i })).toBeDisabled();
+
+    // Pick the SECOND grocery list.
+    await user.selectOptions(picker, "list-grocery-2");
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    // Exactly one bulk POST, targeting the user's chosen (second) list.
+    await waitFor(() => expect(bulkRequests).toHaveLength(1));
+    expect(bulkRequests[0].id).toBe("list-grocery-2");
+    expect(bulkRequests[0].texts).toEqual([
+      "Salmon fillets",
+      "Asparagus",
+      "Lemon",
+    ]);
+    expect(
+      await screen.findByRole("button", { name: /view list/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("lets the user create a grocery list when none exists, then append into it", async () => {
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    // No grocery lists at all (only a to-do list, which is not a valid target).
+    seedMockLists([toDoList()]);
+
+    const createRequests: Array<{ name: string; kind: string }> = [];
+    const bulkRequests: Array<{ id: string; texts: string[] }> = [];
+    server.use(
+      http.post(`${API_BASE}/lists`, async ({ request }) => {
+        const body = (await request.json()) as { name: string; kind: string };
+        createRequests.push(body);
+        const created = groceryList({
+          id: "list-grocery-new",
+          name: body.name,
+        });
+        return HttpResponse.json(
+          { data: created, message: "created" },
+          { status: 201 },
+        );
+      }),
+      http.post(
+        `${API_BASE}/lists/:id/items/bulk`,
+        async ({ params, request }) => {
+          const body = (await request.json()) as {
+            items: Array<{ text: string }>;
+          };
+          bulkRequests.push({
+            id: params.id as string,
+            texts: body.items.map((i) => i.text),
+          });
+          const createdItems = body.items.map((row, index) => ({
+            id: `created-${index}`,
+            text: row.text,
+            completed: false,
+            completedAt: null,
+            categoryId: null,
+            createdAt: "2026-06-07T00:00:00",
+            updatedAt: "2026-06-07T00:00:00",
+          }));
+          return HttpResponse.json(
+            { data: createdItems, message: "ok" },
+            { status: 201 },
+          );
+        },
+      ),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+
+    // With no grocery list, the sheet offers a create-grocery-list affordance.
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+    const nameField = await screen.findByLabelText(/grocery list name/i);
+    await user.type(nameField, "Weekly groceries");
+    await user.click(
+      screen.getByRole("button", { name: /create grocery list/i }),
+    );
+
+    // The grocery list was created with the right kind.
+    await waitFor(() => expect(createRequests).toHaveLength(1));
+    expect(createRequests[0]).toMatchObject({
+      name: "Weekly groceries",
+      kind: "grocery",
+    });
+
+    // Then the bulk append targets the freshly created list.
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() => expect(bulkRequests).toHaveLength(1));
+    expect(bulkRequests[0].id).toBe("list-grocery-new");
+    expect(bulkRequests[0].texts).toEqual([
+      "Salmon fillets",
+      "Asparagus",
+      "Lemon",
+    ]);
+    expect(
+      await screen.findByRole("button", { name: /view list/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not present a failed append as success", async () => {
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    seedMockLists([groceryList()]);
+
+    let bulkCalls = 0;
+    server.use(
+      http.post(`${API_BASE}/lists/:id/items/bulk`, () => {
+        bulkCalls += 1;
+        return HttpResponse.json(
+          { message: "Could not add items" },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    // The failure is surfaced.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not add items|couldn't add|failed/i,
+    );
+    // No success affordance.
+    expect(
+      screen.queryByRole("button", { name: /view list/i }),
+    ).not.toBeInTheDocument();
+    // The reviewed selection is retained (rows still present, retryable).
+    expect(screen.getByDisplayValue("Salmon fillets")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /add to list/i })).toBeEnabled();
+    expect(bulkCalls).toBe(1);
+  });
+
+  it("create-then-fail keeps the created list selected and retries into it without re-creating", async () => {
+    seedMockMealsBoard(createRecipeBackedMealsBoard());
+    seedMockRecipes([testRecipeDetail]);
+    seedMockLists([]); // no grocery list yet → create path
+
+    let createCalls = 0;
+    const bulkTargets: string[] = [];
+    server.use(
+      // The created list intentionally is NOT added to the GET /lists mock; the
+      // append target is driven by createList.onSuccess (selectedListId), not a
+      // hub refetch. This is what lets the retry reuse the created list without
+      // re-creating it.
+      http.post(`${API_BASE}/lists`, async ({ request }) => {
+        createCalls += 1;
+        const body = (await request.json()) as { name: string; kind: string };
+        return HttpResponse.json(
+          {
+            data: groceryList({ id: "list-grocery-new", name: body.name }),
+            message: "created",
+          },
+          { status: 201 },
+        );
+      }),
+      http.post(`${API_BASE}/lists/:id/items/bulk`, async ({ params }) => {
+        bulkTargets.push(params.id as string);
+        // First append fails; the retry (second) succeeds.
+        if (bulkTargets.length === 1) {
+          return HttpResponse.json(
+            { message: "Could not add items" },
+            { status: 500 },
+          );
+        }
+        return HttpResponse.json({ data: [], message: "ok" }, { status: 201 });
+      }),
+    );
+
+    const { user } = renderWithUser(<MealsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: "Add ingredients" }),
+    );
+    await screen.findByDisplayValue("Salmon fillets");
+    await user.type(
+      await screen.findByLabelText(/grocery list name/i),
+      "Weekly groceries",
+    );
+    await user.click(
+      screen.getByRole("button", { name: /create grocery list/i }),
+    );
+    await waitFor(() => expect(createCalls).toBe(1));
+
+    // First append fails.
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /could not add items|couldn't add|failed/i,
+    );
+    expect(
+      screen.queryByRole("button", { name: /view list/i }),
+    ).not.toBeInTheDocument();
+
+    // Retry: same created list is targeted, no second list is created.
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /view list/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(createCalls).toBe(1);
+    expect(bulkTargets).toEqual(["list-grocery-new", "list-grocery-new"]);
   });
 });

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMealsBoard, useRecipes, useSaveMealPlan } from "@/api";
 import { ApiException } from "@/api/client";
+import { AddIngredientsContainer } from "@/components/meals/add-ingredients-container";
 import {
   MealComposerSheet,
   type MealSlotSelection,
@@ -11,6 +12,7 @@ import {
   type MealSlotId,
 } from "@/components/meals/meal-editor-sheet";
 import { MealGrid } from "@/components/meals/meal-grid";
+import { hasRecipeBackedEntry } from "@/components/meals/meal-ingredient-extraction";
 import { MealPlanningPanel } from "@/components/meals/meal-planning-panel";
 import { MealPlanningScopeDialog } from "@/components/meals/meal-planning-scope-dialog";
 import {
@@ -134,6 +136,7 @@ export function MealsView() {
   const [placementDraft, setPlacementDraft] =
     useState<MealPlacementDraft | null>(null);
   const [scopeOpen, setScopeOpen] = useState(false);
+  const [addIngredientsOpen, setAddIngredientsOpen] = useState(false);
   const [planningScope, setPlanningScope] = useState<MealPlanningScope | null>(
     null,
   );
@@ -163,6 +166,12 @@ export function MealsView() {
   const readOnly = isPastWeek(visibleWeekStartDate);
   const showGrid = useMediaQuery("(min-width: 1024px)");
   const persistedBoard = board.data?.data ?? null;
+  // "Add ingredients" is offered only when the visible, editable week has at
+  // least one recipe-backed planned meal to extract ingredients from.
+  const canAddIngredients =
+    !readOnly &&
+    persistedBoard !== null &&
+    hasRecipeBackedEntry(persistedBoard);
   const planningActive = planningScope !== null;
   const currentPlanningTarget =
     planningActive && currentPlanningIndex < planningQueue.length
@@ -468,12 +477,22 @@ export function MealsView() {
             setVisibleWeekStartDate(weekStartDate);
             setSelectedSlot(null);
             setEditingSlotId(null);
+            setAddIngredientsOpen(false);
             resetPlanningSession();
           }}
         />
 
         {persistedBoard && !readOnly ? (
-          <div className="flex justify-end">
+          <div className="flex flex-wrap justify-end gap-2">
+            {canAddIngredients ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setAddIngredientsOpen(true)}
+              >
+                Add ingredients
+              </Button>
+            ) : null}
             <Button
               type="button"
               variant="outline"
@@ -588,6 +607,14 @@ export function MealsView() {
         onStart={startPlanningSession}
         onOpenChange={setScopeOpen}
       />
+
+      {persistedBoard ? (
+        <AddIngredientsContainer
+          isOpen={addIngredientsOpen}
+          board={persistedBoard}
+          onOpenChange={setAddIngredientsOpen}
+        />
+      ) : null}
 
       {planningActive && persistedBoard ? (
         <MealPlanningPanel

--- a/src/components/meals/add-ingredients-container.tsx
+++ b/src/components/meals/add-ingredients-container.tsx
@@ -3,6 +3,7 @@ import { useBulkCreateListItems, useCreateList, useLists } from "@/api";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useOnlineStatus } from "@/hooks/use-online-status";
 import type { BulkCreateListItemsRequest, MealBoard } from "@/lib/types";
 import { bulkCreateListItemsSchema } from "@/lib/validations";
 import { useAppStore } from "@/stores";
@@ -41,6 +42,7 @@ export function AddIngredientsContainer({
 }: AddIngredientsContainerProps) {
   const openListDetail = useAppStore((state) => state.openListDetail);
   const lists = useLists();
+  const online = useOnlineStatus();
 
   const groceryLists = useMemo(
     () => (lists.data?.data ?? []).filter((list) => list.kind === "grocery"),
@@ -181,14 +183,17 @@ export function AddIngredientsContainer({
                 type="button"
                 variant="outline"
                 disabled={
-                  newListName.trim().length === 0 || createList.isPending
+                  !online ||
+                  newListName.trim().length === 0 ||
+                  createList.isPending
                 }
-                onClick={() =>
+                onClick={() => {
+                  if (!online) return;
                   createList.mutate({
                     name: newListName.trim(),
                     kind: "grocery",
-                  })
-                }
+                  });
+                }}
               >
                 Create grocery list
               </Button>

--- a/src/components/meals/add-ingredients-container.tsx
+++ b/src/components/meals/add-ingredients-container.tsx
@@ -4,8 +4,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import type { BulkCreateListItemsRequest, MealBoard } from "@/lib/types";
+import { bulkCreateListItemsSchema } from "@/lib/validations";
 import { useAppStore } from "@/stores";
 import { AddIngredientsSheet } from "./add-ingredients-sheet";
+
+// Mirrors the shared schema's `.max(100)` cap so we can surface honest,
+// cap-specific copy before firing the request (the BE enforces the same bound).
+const MAX_BULK_ITEMS = 100;
+const CAP_ERROR = `You can add up to ${MAX_BULK_ITEMS} items at once. Deselect some rows and try again.`;
 
 interface AddIngredientsContainerProps {
   isOpen: boolean;
@@ -46,6 +52,9 @@ export function AddIngredientsContainer({
   // The list a successful append landed in. Presence of this is the ONLY
   // success signal — set exclusively from the mutation's success path.
   const [appendedListId, setAppendedListId] = useState<string | null>(null);
+  // Client-side guard failure (e.g. the >100-item cap) surfaced BEFORE any
+  // request fires. Retained across renders until the user retries.
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   // Default to the only grocery list once lists resolve. Never override an
   // explicit user pick or a just-created list.
@@ -63,6 +72,7 @@ export function AddIngredientsContainer({
     setSelectedListId(null);
     setNewListName("");
     setAppendedListId(null);
+    setValidationError(null);
   }, [isOpen]);
 
   const createList = useCreateList({
@@ -85,6 +95,21 @@ export function AddIngredientsContainer({
     if (appendedListId !== null) return;
     if (!selectedListId) return;
     if (request.items.length === 0) return;
+
+    // Client-side guard with the SHARED schema (BE enforces the same bound):
+    // reject before any network call so an over-cap payload never leaves the
+    // client. The dominant real failure is the >100-item cap on a fully
+    // recipe-planned week; give honest, actionable copy for it.
+    const parsed = bulkCreateListItemsSchema.safeParse(request);
+    if (!parsed.success) {
+      setValidationError(
+        request.items.length > MAX_BULK_ITEMS
+          ? CAP_ERROR
+          : "Some items couldn't be added. Check your rows and try again.",
+      );
+      return;
+    }
+    setValidationError(null);
 
     bulkCreate.mutate(request, {
       onSuccess: () => {
@@ -120,16 +145,24 @@ export function AddIngredientsContainer({
       );
     }
 
+    // The client-side guard failure takes precedence over a prior request
+    // error — it's the reason nothing was sent this time.
+    const errorMessage = validationError
+      ? validationError
+      : bulkCreate.isError
+        ? bulkCreate.error instanceof Error
+          ? bulkCreate.error.message
+          : "Couldn't add ingredients to your list. Try again."
+        : null;
+
     return (
       <div className="space-y-3">
-        {bulkCreate.isError ? (
+        {errorMessage ? (
           <p
             className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
             role="alert"
           >
-            {bulkCreate.error instanceof Error
-              ? bulkCreate.error.message
-              : "Couldn't add ingredients to your list. Try again."}
+            {errorMessage}
           </p>
         ) : null}
 

--- a/src/components/meals/add-ingredients-container.tsx
+++ b/src/components/meals/add-ingredients-container.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from "react";
+import { useBulkCreateListItems, useCreateList, useLists } from "@/api";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { BulkCreateListItemsRequest, MealBoard } from "@/lib/types";
+import { useAppStore } from "@/stores";
+import { AddIngredientsSheet } from "./add-ingredients-sheet";
+
+interface AddIngredientsContainerProps {
+  isOpen: boolean;
+  board: MealBoard;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Task 6 orchestration container. Owns the grocery-list picker/create, the bulk
+ * append mutation, and the success (View list) / failure state, and composes the
+ * presentational {@link AddIngredientsSheet} via its `listPicker` / `onConfirm` /
+ * `isSubmitting` seam. The sheet keeps its own review model (rows, edits,
+ * selections); this container never reaches into it.
+ *
+ * Contract highlights:
+ *   - Only grocery lists are offered (never to-do / general).
+ *   - Exactly ONE `POST /lists/{id}/items/bulk` per confirmed action.
+ *   - A failed append is never presented as success. On failure the sheet stays
+ *     open with the reviewed selection intact and the action is retryable.
+ *   - Create-then-fail: a just-created grocery list stays selected so a retry
+ *     targets it without re-creating.
+ */
+export function AddIngredientsContainer({
+  isOpen,
+  board,
+  onOpenChange,
+}: AddIngredientsContainerProps) {
+  const openListDetail = useAppStore((state) => state.openListDetail);
+  const lists = useLists();
+
+  const groceryLists = useMemo(
+    () => (lists.data?.data ?? []).filter((list) => list.kind === "grocery"),
+    [lists.data?.data],
+  );
+
+  const [selectedListId, setSelectedListId] = useState<string | null>(null);
+  const [newListName, setNewListName] = useState("");
+  // The list a successful append landed in. Presence of this is the ONLY
+  // success signal — set exclusively from the mutation's success path.
+  const [appendedListId, setAppendedListId] = useState<string | null>(null);
+
+  // Default to the only grocery list once lists resolve. Never override an
+  // explicit user pick or a just-created list.
+  useEffect(() => {
+    if (selectedListId !== null) return;
+    if (groceryLists.length === 1) {
+      setSelectedListId(groceryLists[0].id);
+    }
+  }, [groceryLists, selectedListId]);
+
+  // Reset transient orchestration state each time the sheet reopens so a prior
+  // success/selection never leaks into a fresh review.
+  useEffect(() => {
+    if (isOpen) return;
+    setSelectedListId(null);
+    setNewListName("");
+    setAppendedListId(null);
+  }, [isOpen]);
+
+  const createList = useCreateList({
+    onSuccess: (response) => {
+      // Keep the freshly created list selected so a retry (create-then-fail)
+      // targets it without creating another list.
+      setSelectedListId(response.data.id);
+      setNewListName("");
+    },
+  });
+
+  // Rules of Hooks: the mutation hook must run every render, so pass a stable
+  // empty id when no target is chosen yet. `handleConfirm` guards against ever
+  // firing without a real target.
+  const targetListId = selectedListId ?? "";
+  const bulkCreate = useBulkCreateListItems(targetListId);
+
+  function handleConfirm(request: BulkCreateListItemsRequest) {
+    // Never double-append: once an append has succeeded, ignore further clicks.
+    if (appendedListId !== null) return;
+    if (!selectedListId) return;
+    if (request.items.length === 0) return;
+
+    bulkCreate.mutate(request, {
+      onSuccess: () => {
+        setAppendedListId(selectedListId);
+      },
+    });
+  }
+
+  const isSubmitting = bulkCreate.isPending;
+
+  const listPicker = (() => {
+    if (appendedListId !== null) {
+      return (
+        <div
+          className="space-y-2 rounded-lg border border-primary/30 bg-primary/5 p-3"
+          role="status"
+        >
+          <p className="text-sm font-medium text-foreground">
+            Ingredients added to your grocery list.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={() => {
+              openListDetail(appendedListId);
+              onOpenChange(false);
+            }}
+          >
+            View list
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-3">
+        {bulkCreate.isError ? (
+          <p
+            className="rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            {bulkCreate.error instanceof Error
+              ? bulkCreate.error.message
+              : "Couldn't add ingredients to your list. Try again."}
+          </p>
+        ) : null}
+
+        {groceryLists.length === 0 ? (
+          <div className="space-y-2">
+            <Label htmlFor="new-grocery-list-name">Grocery list name</Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="new-grocery-list-name"
+                value={newListName}
+                placeholder="e.g. Weekly groceries"
+                autoComplete="off"
+                onChange={(event) => setNewListName(event.target.value)}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={
+                  newListName.trim().length === 0 || createList.isPending
+                }
+                onClick={() =>
+                  createList.mutate({
+                    name: newListName.trim(),
+                    kind: "grocery",
+                  })
+                }
+              >
+                Create grocery list
+              </Button>
+            </div>
+            {createList.isError ? (
+              <p className="text-sm text-destructive" role="alert">
+                {createList.error instanceof Error
+                  ? createList.error.message
+                  : "Couldn't create the list. Try again."}
+              </p>
+            ) : null}
+          </div>
+        ) : groceryLists.length === 1 ? (
+          <p className="text-sm text-muted-foreground">
+            Adding to{" "}
+            <span className="font-medium">{groceryLists[0].name}</span>.
+          </p>
+        ) : (
+          <div className="space-y-1">
+            <Label htmlFor="grocery-list-picker">Grocery list</Label>
+            <select
+              id="grocery-list-picker"
+              className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+              value={selectedListId ?? ""}
+              onChange={(event) =>
+                setSelectedListId(event.target.value || null)
+              }
+            >
+              <option value="" disabled>
+                Choose a grocery list
+              </option>
+              {groceryLists.map((list) => (
+                <option key={list.id} value={list.id}>
+                  {list.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+    );
+  })();
+
+  return (
+    <AddIngredientsSheet
+      isOpen={isOpen}
+      board={board}
+      onOpenChange={onOpenChange}
+      onConfirm={handleConfirm}
+      isSubmitting={isSubmitting}
+      // Block the confirm until a grocery list exists to target, and after a
+      // successful append (the success panel's View list takes over).
+      confirmDisabled={selectedListId === null || appendedListId !== null}
+      listPicker={listPicker}
+    />
+  );
+}

--- a/src/components/meals/add-ingredients-sheet.test.tsx
+++ b/src/components/meals/add-ingredients-sheet.test.tsx
@@ -422,4 +422,57 @@ describe("AddIngredientsSheet", () => {
     // Only the recipe ingredients — the blank manual row is dropped.
     expect(texts).toEqual(["Salmon fillets", "Asparagus", "Lemon"]);
   });
+
+  it("starts a fresh review model each time the sheet opens", async () => {
+    const board = boardWithRecipeAndQuick();
+    const onConfirm = vi.fn();
+    const onOpenChange = vi.fn();
+    const { user, rerender } = renderWithUser(
+      <AddIngredientsSheet
+        isOpen
+        board={board}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    const salmon = await screen.findByDisplayValue("Salmon fillets");
+    await user.clear(salmon);
+    await user.type(salmon, "2 salmon fillets");
+
+    const asparagusRow = screen
+      .getByDisplayValue("Asparagus")
+      .closest("li") as HTMLElement;
+    await user.click(
+      within(asparagusRow).getByRole("button", { name: /remove/i }),
+    );
+
+    expect(screen.getByDisplayValue("2 salmon fillets")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Asparagus")).not.toBeInTheDocument();
+
+    rerender(
+      <AddIngredientsSheet
+        isOpen={false}
+        board={board}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+    rerender(
+      <AddIngredientsSheet
+        isOpen
+        board={board}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+      />,
+    );
+
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Asparagus")).toBeInTheDocument();
+    expect(
+      screen.queryByDisplayValue("2 salmon fillets"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/meals/add-ingredients-sheet.test.tsx
+++ b/src/components/meals/add-ingredients-sheet.test.tsx
@@ -1,0 +1,425 @@
+import { HttpResponse, http } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MealBoard, MealSlotEntry, RecipeDetail } from "@/lib/types";
+import { createEmptyMealsBoard } from "@/test/fixtures/meals";
+import {
+  API_BASE,
+  seedMockRecipes,
+  server,
+  setupMswServer,
+} from "@/test/mocks/server";
+import { renderWithUser, screen, waitFor, within } from "@/test/test-utils";
+import { AddIngredientsSheet } from "./add-ingredients-sheet";
+
+// testWeekStartDate (2026-06-07) is a Sunday, so dayIndex 1 = Monday.
+
+const recipeDinner: RecipeDetail = {
+  id: "recipe-1",
+  title: "Sheet Pan Salmon",
+  imageUrl: null,
+  ingredients: ["Salmon fillets", "Asparagus", "Lemon"],
+  instructions: ["Roast"],
+  note: null,
+  sourceUrl: null,
+  tags: ["dinner"],
+  favorite: false,
+  updatedAt: "2026-06-04T09:00:00",
+};
+
+function recipeEntry(
+  id: string,
+  recipeId: string,
+  title: string,
+): MealSlotEntry {
+  return {
+    id,
+    role: "primary",
+    sourceType: "recipe",
+    recipeId,
+    title,
+    imageUrl: null,
+    note: null,
+  };
+}
+
+function quickEntry(id: string, title: string): MealSlotEntry {
+  return {
+    id,
+    role: "primary",
+    sourceType: "quick",
+    recipeId: null,
+    title,
+    imageUrl: null,
+    note: null,
+  };
+}
+
+/** Board: Monday dinner = recipe (recipeDinner), Wednesday dinner = quick "Leftovers". */
+function boardWithRecipeAndQuick(): MealBoard {
+  const board = createEmptyMealsBoard();
+  board.days[1].slots[2].primary = recipeEntry(
+    "entry-recipe",
+    recipeDinner.id,
+    "Sheet Pan Salmon",
+  );
+  board.days[3].slots[2].primary = quickEntry("entry-quick", "Leftovers");
+  return board;
+}
+
+function setOnline(value: boolean): void {
+  Object.defineProperty(navigator, "onLine", { configurable: true, value });
+}
+
+function renderSheet(
+  board: MealBoard,
+  overrides: {
+    onConfirm?: ReturnType<typeof vi.fn>;
+    onOpenChange?: ReturnType<typeof vi.fn>;
+    isSubmitting?: boolean;
+  } = {},
+) {
+  const onConfirm = overrides.onConfirm ?? vi.fn();
+  const onOpenChange = overrides.onOpenChange ?? vi.fn();
+  return {
+    onConfirm,
+    onOpenChange,
+    ...renderWithUser(
+      <AddIngredientsSheet
+        isOpen
+        board={board}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        isSubmitting={overrides.isSubmitting}
+      />,
+    ),
+  };
+}
+
+describe("AddIngredientsSheet", () => {
+  setupMswServer();
+
+  beforeEach(() => {
+    setOnline(true);
+    seedMockRecipes([recipeDinner]);
+  });
+
+  it("groups verbatim ingredient rows by meal and lists quick meals under 'No recipe ingredients'", async () => {
+    renderSheet(boardWithRecipeAndQuick());
+
+    // Recipe group header for the Monday dinner recipe meal.
+    expect(
+      await screen.findByText(/Monday · Dinner — Sheet Pan Salmon/),
+    ).toBeInTheDocument();
+
+    // Verbatim ingredient rows appear as editable inputs.
+    expect(screen.getByDisplayValue("Salmon fillets")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Asparagus")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Lemon")).toBeInTheDocument();
+
+    // The quick meal appears under the "No recipe ingredients" heading with an Add item control.
+    expect(screen.getByText("No recipe ingredients")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Wednesday · Dinner — Leftovers/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /add item/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("edits and removes rows before append", async () => {
+    const { user, onConfirm } = renderSheet(boardWithRecipeAndQuick());
+
+    const salmon = await screen.findByDisplayValue("Salmon fillets");
+    await user.clear(salmon);
+    await user.type(salmon, "2 salmon fillets");
+
+    // Remove the "Asparagus" row.
+    const asparagusRow = screen
+      .getByDisplayValue("Asparagus")
+      .closest("li") as HTMLElement;
+    await user.click(
+      within(asparagusRow).getByRole("button", { name: /remove/i }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const request = onConfirm.mock.calls[0][0];
+    const texts = request.items.map((i: { text: string }) => i.text);
+    expect(texts).toContain("2 salmon fillets");
+    expect(texts).toContain("Lemon");
+    expect(texts).not.toContain("Asparagus");
+    expect(texts).not.toContain("Salmon fillets");
+  });
+
+  it("deselects a row so it is excluded from the append", async () => {
+    const { user, onConfirm } = renderSheet(boardWithRecipeAndQuick());
+
+    const lemonRow = (await screen.findByDisplayValue("Lemon")).closest(
+      "li",
+    ) as HTMLElement;
+    await user.click(within(lemonRow).getByRole("checkbox"));
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const texts = onConfirm.mock.calls[0][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    expect(texts).not.toContain("Lemon");
+    expect(texts).toContain("Salmon fillets");
+  });
+
+  it("does not auto-generate rows for quick meals", async () => {
+    const { user, onConfirm } = renderSheet(boardWithRecipeAndQuick());
+
+    // Wait for resolution; the quick meal contributes no row until Add item.
+    await screen.findByDisplayValue("Salmon fillets");
+    expect(screen.queryByDisplayValue("Leftovers")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const texts = onConfirm.mock.calls[0][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    // Only the 3 recipe ingredients — nothing from the quick meal.
+    expect(texts).toEqual(["Salmon fillets", "Asparagus", "Lemon"]);
+
+    // Clicking Add item appends an editable, selected manual row scoped to that meal.
+    const quickRow = screen
+      .getByText(/Wednesday · Dinner — Leftovers/)
+      .closest("li") as HTMLElement;
+    await user.click(
+      within(quickRow).getByRole("button", { name: /add item/i }),
+    );
+    const manualInput = within(quickRow).getByRole("textbox");
+    await user.type(manualInput, "Paper towels");
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(2));
+    const secondTexts = onConfirm.mock.calls[1][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    expect(secondTexts).toContain("Paper towels");
+  });
+
+  it("shows a retryable error row for a non-404 recipe fetch failure and excludes it from append", async () => {
+    // Two recipe meals + one 404 recipe meal.
+    const okRecipe: RecipeDetail = { ...recipeDinner, id: "recipe-ok" };
+    const failRecipe: RecipeDetail = {
+      ...recipeDinner,
+      id: "recipe-fail",
+      ingredients: ["Should not appear"],
+    };
+    seedMockRecipes([okRecipe, failRecipe]);
+    // recipe-fail → 500 (error); recipe-missing is never seeded → 404 (missing).
+    server.use(
+      http.get(`${API_BASE}/recipes/recipe-fail`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const board = createEmptyMealsBoard();
+    board.days[1].slots[2].primary = recipeEntry(
+      "entry-ok",
+      okRecipe.id,
+      "Good Recipe",
+    );
+    board.days[2].slots[2].primary = recipeEntry(
+      "entry-fail",
+      failRecipe.id,
+      "Broken Recipe",
+    );
+    board.days[3].slots[2].primary = recipeEntry(
+      "entry-missing",
+      "recipe-missing",
+      "Deleted Recipe",
+    );
+
+    const { user, onConfirm } = renderSheet(board);
+
+    // The good recipe resolves to verbatim rows.
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    // The failed recipe shows a per-meal error row with a Retry control.
+    const errorRow = screen
+      .getByText(/Tuesday · Dinner — Broken Recipe/)
+      .closest("li") as HTMLElement;
+    expect(
+      within(errorRow).getByRole("button", { name: /retry/i }),
+    ).toBeInTheDocument();
+
+    // The 404 recipe is treated as "no recipe ingredients", not an error.
+    expect(screen.getByText("No recipe ingredients")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Wednesday · Dinner — Deleted Recipe/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const texts = onConfirm.mock.calls[0][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    expect(texts).not.toContain("Should not appear");
+    expect(texts).toContain("Salmon fillets");
+  });
+
+  it("disables Add to list while offline with honest copy", async () => {
+    setOnline(false);
+    renderSheet(boardWithRecipeAndQuick());
+
+    expect(
+      await screen.findByDisplayValue("Salmon fillets"),
+    ).toBeInTheDocument();
+
+    const addButton = screen.getByRole("button", { name: /add to list/i });
+    expect(addButton).toBeDisabled();
+    expect(
+      screen.getByText(
+        "You're offline. Review your ingredients now and add them to your list when you're back online.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("retrying a failed recipe recovers its rows without discarding edits in other groups", async () => {
+    const okRecipe: RecipeDetail = { ...recipeDinner, id: "recipe-ok" };
+    const recovered: RecipeDetail = {
+      ...recipeDinner,
+      id: "recipe-fail",
+      ingredients: ["Recovered ingredient"],
+    };
+    seedMockRecipes([okRecipe, recovered]);
+
+    // recipe-fail: 500 on first fetch, then 200 (recovered detail) on retry.
+    let failCount = 0;
+    server.use(
+      http.get(`${API_BASE}/recipes/recipe-fail`, () => {
+        failCount += 1;
+        if (failCount === 1) {
+          return HttpResponse.json({ message: "boom" }, { status: 500 });
+        }
+        return HttpResponse.json({ data: recovered });
+      }),
+    );
+
+    const board = createEmptyMealsBoard();
+    board.days[1].slots[2].primary = recipeEntry(
+      "entry-ok",
+      okRecipe.id,
+      "Good Recipe",
+    );
+    board.days[2].slots[2].primary = recipeEntry(
+      "entry-fail",
+      recovered.id,
+      "Broken Recipe",
+    );
+
+    const { user, onConfirm } = renderSheet(board);
+
+    // Good recipe resolves; edit one row and deselect another in ITS group.
+    const salmon = await screen.findByDisplayValue("Salmon fillets");
+    await user.clear(salmon);
+    await user.type(salmon, "2 salmon fillets");
+
+    const lemonRow = screen
+      .getByDisplayValue("Lemon")
+      .closest("li") as HTMLElement;
+    await user.click(within(lemonRow).getByRole("checkbox"));
+
+    // The other meal is in an error state; retry it.
+    const errorRow = screen
+      .getByText(/Tuesday · Dinner — Broken Recipe/)
+      .closest("li") as HTMLElement;
+    await user.click(within(errorRow).getByRole("button", { name: /retry/i }));
+
+    // The recovered recipe's row now renders.
+    expect(
+      await screen.findByDisplayValue("Recovered ingredient"),
+    ).toBeInTheDocument();
+
+    // CRITICAL: the edit and deselection in the good-recipe group SURVIVED.
+    expect(screen.getByDisplayValue("2 salmon fillets")).toBeInTheDocument();
+    expect(
+      screen.queryByDisplayValue("Salmon fillets"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const texts = onConfirm.mock.calls[0][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    expect(texts).toContain("2 salmon fillets");
+    expect(texts).toContain("Recovered ingredient");
+    // Deselected row stayed out; pre-edit text did not resurrect.
+    expect(texts).not.toContain("Lemon");
+    expect(texts).not.toContain("Salmon fillets");
+  });
+
+  it("renders only error rows and disables Add to list when every recipe errors", async () => {
+    const failA: RecipeDetail = { ...recipeDinner, id: "fail-a" };
+    const failB: RecipeDetail = { ...recipeDinner, id: "fail-b" };
+    seedMockRecipes([failA, failB]);
+    server.use(
+      http.get(`${API_BASE}/recipes/fail-a`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+      http.get(`${API_BASE}/recipes/fail-b`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 503 }),
+      ),
+    );
+
+    const board = createEmptyMealsBoard();
+    board.days[1].slots[2].primary = recipeEntry(
+      "entry-a",
+      failA.id,
+      "Recipe A",
+    );
+    board.days[2].slots[2].primary = recipeEntry(
+      "entry-b",
+      failB.id,
+      "Recipe B",
+    );
+
+    renderSheet(board);
+
+    // Both meals surface as retryable error rows.
+    expect(
+      await screen.findByText(/Monday · Dinner — Recipe A/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Tuesday · Dinner — Recipe B/)).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /retry/i })).toHaveLength(2);
+
+    // No ingredient rows and no "No recipe ingredients" section.
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.queryByText("No recipe ingredients")).not.toBeInTheDocument();
+
+    // Nothing is selectable, so Add to list is disabled.
+    expect(screen.getByRole("button", { name: /add to list/i })).toBeDisabled();
+  });
+
+  it("excludes a blank manual row from the confirmed payload", async () => {
+    const { user, onConfirm } = renderSheet(boardWithRecipeAndQuick());
+
+    await screen.findByDisplayValue("Salmon fillets");
+
+    // Add a manual row but leave it blank.
+    const quickRow = screen
+      .getByText(/Wednesday · Dinner — Leftovers/)
+      .closest("li") as HTMLElement;
+    await user.click(
+      within(quickRow).getByRole("button", { name: /add item/i }),
+    );
+    expect(within(quickRow).getByRole("textbox")).toHaveValue("");
+
+    await user.click(screen.getByRole("button", { name: /add to list/i }));
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1));
+    const texts = onConfirm.mock.calls[0][0].items.map(
+      (i: { text: string }) => i.text,
+    );
+    // Only the recipe ingredients — the blank manual row is dropped.
+    expect(texts).toEqual(["Salmon fillets", "Asparagus", "Lemon"]);
+  });
+});

--- a/src/components/meals/add-ingredients-sheet.tsx
+++ b/src/components/meals/add-ingredients-sheet.tsx
@@ -31,6 +31,12 @@ interface AddIngredientsSheetProps {
   /** Task 6 seam: reflects the append mutation being in flight. */
   isSubmitting?: boolean;
   /**
+   * Task 6 seam: an extra disable condition owned by the container (e.g. no
+   * target grocery list chosen yet). OR-ed with the sheet's own guards
+   * (offline / nothing selected / submitting). Purely presentational.
+   */
+  confirmDisabled?: boolean;
+  /**
    * Task 6 seam: an optional slot for the list picker/create affordance the
    * next task renders above the confirm action.
    */
@@ -111,6 +117,7 @@ export function AddIngredientsSheet({
   onOpenChange,
   onConfirm,
   isSubmitting = false,
+  confirmDisabled = false,
   listPicker,
 }: AddIngredientsSheetProps) {
   const queryClient = useQueryClient();
@@ -250,7 +257,8 @@ export function AddIngredientsSheet({
   }
 
   const anySelected = hasSelectedRow(model);
-  const addDisabled = !online || isSubmitting || !anySelected;
+  const addDisabled =
+    !online || isSubmitting || confirmDisabled || !anySelected;
 
   function handleConfirm() {
     // Belt-and-suspenders: the button is disabled when nothing is selected, but

--- a/src/components/meals/add-ingredients-sheet.tsx
+++ b/src/components/meals/add-ingredients-sheet.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { recipesKeys } from "@/api/hooks/use-recipes";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -138,13 +138,27 @@ export function AddIngredientsSheet({
   const [model, setModel] = useState<ReviewModel>(() =>
     buildReviewModel(board, resolutionsById),
   );
-  const [syncedKey, setSyncedKey] = useState(resolutionKey);
-  if (!isLoading && resolutionKey !== syncedKey) {
-    setModel((current) =>
-      mergeReviewModel(current, buildReviewModel(board, resolutionsById)),
-    );
-    setSyncedKey(resolutionKey);
-  }
+  const [syncedKey, setSyncedKey] = useState<string | null>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      wasOpenRef.current = false;
+      return;
+    }
+    if (isLoading) return;
+
+    const isFreshOpen = !wasOpenRef.current;
+    const resolutionChanged = syncedKey !== resolutionKey;
+    if (isFreshOpen || resolutionChanged) {
+      const freshModel = buildReviewModel(board, resolutionsById);
+      setModel((current) =>
+        isFreshOpen ? freshModel : mergeReviewModel(current, freshModel),
+      );
+      setSyncedKey(resolutionKey);
+    }
+    wasOpenRef.current = true;
+  }, [board, isLoading, isOpen, resolutionKey, resolutionsById, syncedKey]);
 
   function editRecipeRow(groupKey: string, rowId: string, text: string) {
     setModel((current) => ({

--- a/src/components/meals/add-ingredients-sheet.tsx
+++ b/src/components/meals/add-ingredients-sheet.tsx
@@ -1,0 +1,434 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { type ReactNode, useMemo, useState } from "react";
+import { recipesKeys } from "@/api/hooks/use-recipes";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { MobileSheet } from "@/components/ui/mobile-sheet";
+import { useOnlineStatus } from "@/hooks/use-online-status";
+import type { BulkCreateListItemsRequest, MealBoard } from "@/lib/types";
+import {
+  buildReviewModel,
+  distinctRecipeIds,
+  type ReviewModel,
+  type ReviewRow,
+  toBulkItemsRequest,
+} from "./meal-ingredient-extraction";
+import { useRecipeDetails } from "./use-recipe-details";
+
+const OFFLINE_COPY =
+  "You're offline. Review your ingredients now and add them to your list when you're back online.";
+
+interface AddIngredientsSheetProps {
+  isOpen: boolean;
+  board: MealBoard;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Task 6 seam: invoked by "Add to list" with the reviewed rows. Task 6 wires
+   * this to the grocery-list picker/create + `useBulkCreateListItems`. Task 5
+   * only owns the review UI and the local {@link ReviewModel}.
+   */
+  onConfirm: (request: BulkCreateListItemsRequest) => void;
+  /** Task 6 seam: reflects the append mutation being in flight. */
+  isSubmitting?: boolean;
+  /**
+   * Task 6 seam: an optional slot for the list picker/create affordance the
+   * next task renders above the confirm action.
+   */
+  listPicker?: ReactNode;
+}
+
+let manualRowSeq = 0;
+function nextManualRowId(): string {
+  manualRowSeq += 1;
+  return `manual-${manualRowSeq}`;
+}
+
+function hasSelectedRow(model: ReviewModel): boolean {
+  const anyRecipe = model.recipeGroups.some((group) =>
+    group.rows.some((row) => row.selected && row.text.trim().length > 0),
+  );
+  if (anyRecipe) return true;
+  return model.noIngredientGroups.some((group) =>
+    group.manualRows.some((row) => row.selected && row.text.trim().length > 0),
+  );
+}
+
+type GroupStatus = "recipe" | "none" | "error";
+
+/** Map every group key in a model to its resolution bucket. */
+function statusByKey(model: ReviewModel): Map<string, GroupStatus> {
+  const map = new Map<string, GroupStatus>();
+  for (const group of model.recipeGroups) map.set(group.key, "recipe");
+  for (const group of model.noIngredientGroups) map.set(group.key, "none");
+  for (const group of model.errorGroups) map.set(group.key, "error");
+  return map;
+}
+
+/**
+ * Merge a freshly-built review model into the current (possibly edited) one.
+ *
+ * A meal's group appears in exactly one bucket per model. For each group in the
+ * fresh model, if the SAME key had the SAME bucket in the current model, we keep
+ * the current group verbatim — preserving the user's edits, removals,
+ * deselections, and appended manual rows. Only groups whose resolution actually
+ * changed (e.g. error → recipe after a successful Retry) or that are newly
+ * present adopt the freshly-built group. This is what lets Retry recover one
+ * meal's rows without discarding edits in every other meal.
+ */
+function mergeReviewModel(
+  current: ReviewModel,
+  fresh: ReviewModel,
+): ReviewModel {
+  const currentStatus = statusByKey(current);
+  const currentRecipe = new Map(current.recipeGroups.map((g) => [g.key, g]));
+  const currentNone = new Map(
+    current.noIngredientGroups.map((g) => [g.key, g]),
+  );
+  const currentError = new Map(current.errorGroups.map((g) => [g.key, g]));
+
+  return {
+    recipeGroups: fresh.recipeGroups.map((group) =>
+      currentStatus.get(group.key) === "recipe"
+        ? (currentRecipe.get(group.key) ?? group)
+        : group,
+    ),
+    noIngredientGroups: fresh.noIngredientGroups.map((group) =>
+      currentStatus.get(group.key) === "none"
+        ? (currentNone.get(group.key) ?? group)
+        : group,
+    ),
+    errorGroups: fresh.errorGroups.map((group) =>
+      currentStatus.get(group.key) === "error"
+        ? (currentError.get(group.key) ?? group)
+        : group,
+    ),
+  };
+}
+
+export function AddIngredientsSheet({
+  isOpen,
+  board,
+  onOpenChange,
+  onConfirm,
+  isSubmitting = false,
+  listPicker,
+}: AddIngredientsSheetProps) {
+  const queryClient = useQueryClient();
+  const online = useOnlineStatus();
+
+  const recipeIds = useMemo(() => distinctRecipeIds(board), [board]);
+  const { resolutionsById, isLoading } = useRecipeDetails(recipeIds);
+
+  // Re-sync the local review model when the underlying resolutions change
+  // (initial load, or a retry moving a meal out of the error state). Crucially
+  // we MERGE rather than rebuild: only the group(s) whose resolution actually
+  // changed (or are newly present) adopt freshly-built rows; every other group
+  // keeps the user's in-progress edits/removals/deselections and manual rows.
+  // Between resolution changes the local model is authoritative.
+  const resolutionKey = recipeIds
+    .map((id) => `${id}:${resolutionsById[id]?.status ?? "pending"}`)
+    .join("|");
+  const [model, setModel] = useState<ReviewModel>(() =>
+    buildReviewModel(board, resolutionsById),
+  );
+  const [syncedKey, setSyncedKey] = useState(resolutionKey);
+  if (!isLoading && resolutionKey !== syncedKey) {
+    setModel((current) =>
+      mergeReviewModel(current, buildReviewModel(board, resolutionsById)),
+    );
+    setSyncedKey(resolutionKey);
+  }
+
+  function editRecipeRow(groupKey: string, rowId: string, text: string) {
+    setModel((current) => ({
+      ...current,
+      recipeGroups: current.recipeGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              rows: group.rows.map((row) =>
+                row.id === rowId ? { ...row, text } : row,
+              ),
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function toggleRecipeRow(groupKey: string, rowId: string) {
+    setModel((current) => ({
+      ...current,
+      recipeGroups: current.recipeGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              rows: group.rows.map((row) =>
+                row.id === rowId ? { ...row, selected: !row.selected } : row,
+              ),
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function removeRecipeRow(groupKey: string, rowId: string) {
+    setModel((current) => ({
+      ...current,
+      recipeGroups: current.recipeGroups.map((group) =>
+        group.key === groupKey
+          ? { ...group, rows: group.rows.filter((row) => row.id !== rowId) }
+          : group,
+      ),
+    }));
+  }
+
+  function addManualRow(groupKey: string) {
+    setModel((current) => ({
+      ...current,
+      noIngredientGroups: current.noIngredientGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              manualRows: [
+                ...group.manualRows,
+                { id: nextManualRowId(), text: "", selected: true },
+              ],
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function editManualRow(groupKey: string, rowId: string, text: string) {
+    setModel((current) => ({
+      ...current,
+      noIngredientGroups: current.noIngredientGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              manualRows: group.manualRows.map((row) =>
+                row.id === rowId ? { ...row, text } : row,
+              ),
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function toggleManualRow(groupKey: string, rowId: string) {
+    setModel((current) => ({
+      ...current,
+      noIngredientGroups: current.noIngredientGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              manualRows: group.manualRows.map((row) =>
+                row.id === rowId ? { ...row, selected: !row.selected } : row,
+              ),
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function removeManualRow(groupKey: string, rowId: string) {
+    setModel((current) => ({
+      ...current,
+      noIngredientGroups: current.noIngredientGroups.map((group) =>
+        group.key === groupKey
+          ? {
+              ...group,
+              manualRows: group.manualRows.filter((row) => row.id !== rowId),
+            }
+          : group,
+      ),
+    }));
+  }
+
+  function retryRecipe(recipeId: string) {
+    queryClient.invalidateQueries({ queryKey: recipesKeys.detail(recipeId) });
+  }
+
+  const anySelected = hasSelectedRow(model);
+  const addDisabled = !online || isSubmitting || !anySelected;
+
+  function handleConfirm() {
+    // Belt-and-suspenders: the button is disabled when nothing is selected, but
+    // never emit an empty append even if that invariant is bypassed.
+    if (!anySelected) return;
+    onConfirm(toBulkItemsRequest(model));
+  }
+
+  return (
+    <MobileSheet
+      isOpen={isOpen}
+      onClose={() => onOpenChange(false)}
+      title="Add ingredients to grocery list"
+      initialHeight="full"
+    >
+      {isLoading ? (
+        <p className="text-sm text-muted-foreground" role="status">
+          Loading recipe ingredients…
+        </p>
+      ) : (
+        <div className="space-y-6">
+          {model.errorGroups.length > 0 ? (
+            <ul className="space-y-2">
+              {model.errorGroups.map((group) => (
+                <li
+                  key={group.key}
+                  className="flex items-center justify-between gap-3 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-semibold text-foreground">
+                      {group.label}
+                    </p>
+                    <p className="text-xs text-destructive">
+                      Couldn't load this recipe's ingredients.
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    aria-label={`Retry loading ${group.label}`}
+                    onClick={() => retryRecipe(group.recipeId)}
+                  >
+                    Retry
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+
+          {model.recipeGroups.map((group) => (
+            <section key={group.key} className="space-y-2">
+              <h3 className="text-sm font-semibold text-foreground">
+                {group.label}
+              </h3>
+              <ul className="space-y-2">
+                {group.rows.map((row) => (
+                  <RowEditor
+                    key={row.id}
+                    row={row}
+                    ariaLabel={row.text || "Ingredient"}
+                    onToggle={() => toggleRecipeRow(group.key, row.id)}
+                    onEdit={(text) => editRecipeRow(group.key, row.id, text)}
+                    onRemove={() => removeRecipeRow(group.key, row.id)}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))}
+
+          {model.noIngredientGroups.length > 0 ? (
+            <section className="space-y-3">
+              <h3 className="text-sm font-semibold text-foreground">
+                No recipe ingredients
+              </h3>
+              <ul className="space-y-3">
+                {model.noIngredientGroups.map((group) => (
+                  <li key={group.key} className="space-y-2">
+                    <p className="text-sm text-muted-foreground">
+                      {group.label}
+                    </p>
+                    {group.manualRows.length > 0 ? (
+                      <ul className="space-y-2">
+                        {group.manualRows.map((row) => (
+                          <RowEditor
+                            key={row.id}
+                            row={row}
+                            ariaLabel="Manual item"
+                            placeholder="Add an item"
+                            onToggle={() => toggleManualRow(group.key, row.id)}
+                            onEdit={(text) =>
+                              editManualRow(group.key, row.id, text)
+                            }
+                            onRemove={() => removeManualRow(group.key, row.id)}
+                          />
+                        ))}
+                      </ul>
+                    ) : null}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="justify-start"
+                      aria-label={`Add item for ${group.label}`}
+                      onClick={() => addManualRow(group.key)}
+                    >
+                      + Add item
+                    </Button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {/* Task 6 seam: grocery-list picker / create affordance. */}
+          {listPicker}
+
+          {!online ? (
+            <p className="text-sm text-muted-foreground" role="status">
+              {OFFLINE_COPY}
+            </p>
+          ) : null}
+
+          <Button
+            type="button"
+            className="w-full"
+            disabled={addDisabled}
+            onClick={handleConfirm}
+          >
+            Add to list
+          </Button>
+        </div>
+      )}
+    </MobileSheet>
+  );
+}
+
+interface RowEditorProps {
+  row: ReviewRow;
+  ariaLabel: string;
+  placeholder?: string;
+  onToggle: () => void;
+  onEdit: (text: string) => void;
+  onRemove: () => void;
+}
+
+function RowEditor({
+  row,
+  ariaLabel,
+  placeholder,
+  onToggle,
+  onEdit,
+  onRemove,
+}: RowEditorProps) {
+  return (
+    <li className="flex items-center gap-2">
+      <input
+        type="checkbox"
+        checked={row.selected}
+        onChange={onToggle}
+        aria-label={`Include ${ariaLabel}`}
+        className="h-4 w-4 shrink-0 accent-primary"
+      />
+      <Input
+        value={row.text}
+        placeholder={placeholder}
+        aria-label={`Edit ${ariaLabel}`}
+        onChange={(event) => onEdit(event.target.value)}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        aria-label={`Remove ${ariaLabel}`}
+        onClick={onRemove}
+      >
+        Remove
+      </Button>
+    </li>
+  );
+}

--- a/src/components/meals/meal-ingredient-extraction.test.ts
+++ b/src/components/meals/meal-ingredient-extraction.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import type { MealBoard, RecipeDetail } from "@/lib/types";
+import {
+  buildReviewModel,
+  distinctRecipeIds,
+  hasRecipeBackedEntry,
+  toBulkItemsRequest,
+} from "./meal-ingredient-extraction";
+
+function board(): MealBoard {
+  // Wed(3) dinner recipe r1; Thu(4) dinner recipe r1 (same recipe); Fri(5) dinner quick.
+  const empty = (dayIndex: number) => ({
+    date: "",
+    dayIndex,
+    slots: (["breakfast", "lunch", "dinner"] as const).map((mealType) => ({
+      id: null,
+      weekStartDate: "2026-07-05",
+      dayIndex,
+      mealType,
+      primary: null,
+      extras: [],
+      note: null,
+    })),
+  });
+  const b: MealBoard = {
+    weekStartDate: "2026-07-05",
+    days: [0, 1, 2, 3, 4, 5, 6].map(empty),
+  };
+  b.days[3].slots[2].primary = {
+    id: "e1",
+    role: "primary",
+    sourceType: "recipe",
+    recipeId: "r1",
+    title: "Sheet Pan Chicken",
+    imageUrl: null,
+    note: null,
+  };
+  b.days[4].slots[2].primary = {
+    id: "e2",
+    role: "primary",
+    sourceType: "recipe",
+    recipeId: "r1",
+    title: "Sheet Pan Chicken",
+    imageUrl: null,
+    note: null,
+  };
+  b.days[5].slots[2].primary = {
+    id: "e3",
+    role: "primary",
+    sourceType: "quick",
+    recipeId: null,
+    title: "Taco night",
+    imageUrl: null,
+    note: null,
+  };
+  return b;
+}
+
+const recipeR1: RecipeDetail = {
+  id: "r1",
+  title: "Sheet Pan Chicken",
+  imageUrl: null,
+  favorite: false,
+  tags: [],
+  updatedAt: "",
+  ingredients: ["2 chicken breasts", "1 tbsp olive oil"],
+  instructions: [],
+  note: null,
+  sourceUrl: null,
+};
+
+describe("hasRecipeBackedEntry", () => {
+  it("is true when any slot has a recipe-backed entry", () => {
+    expect(hasRecipeBackedEntry(board())).toBe(true);
+  });
+  it("is false for a board with only quick/empty slots", () => {
+    const b = board();
+    b.days[3].slots[2].primary = null;
+    b.days[4].slots[2].primary = null;
+    expect(hasRecipeBackedEntry(b)).toBe(false);
+  });
+});
+
+describe("distinctRecipeIds", () => {
+  it("dedupes recipe fetch ids across meals", () => {
+    expect(distinctRecipeIds(board())).toEqual(["r1"]);
+  });
+});
+
+describe("buildReviewModel", () => {
+  it("makes one verbatim row per ingredient, grouped by meal, and routes quick meals to the no-ingredient section", () => {
+    const model = buildReviewModel(board(), {
+      r1: { status: "loaded", detail: recipeR1 },
+    });
+    expect(model.recipeGroups).toHaveLength(2); // Wed + Thu, both from r1
+    expect(model.recipeGroups[0].label).toBe(
+      "Wednesday · Dinner — Sheet Pan Chicken",
+    );
+    expect(model.recipeGroups[0].rows.map((r) => r.text)).toEqual([
+      "2 chicken breasts",
+      "1 tbsp olive oil",
+    ]);
+    expect(model.recipeGroups[0].rows.every((r) => r.selected)).toBe(true);
+    expect(model.noIngredientGroups.map((g) => g.label)).toEqual([
+      "Friday · Dinner — Taco night",
+    ]);
+    expect(model.errorGroups).toHaveLength(0);
+  });
+
+  it("routes an empty-ingredient recipe and a 404 (deleted) recipe to the no-ingredient section", () => {
+    const b = board();
+    b.days[4].slots[2].primary = {
+      id: "e2",
+      role: "primary",
+      sourceType: "recipe",
+      recipeId: "r2",
+      title: "Grandma's stew",
+      imageUrl: null,
+      note: null,
+    };
+    const model = buildReviewModel(b, {
+      r1: { status: "loaded", detail: { ...recipeR1, ingredients: [] } }, // no ingredients
+      r2: { status: "missing" }, // 404 → deleted/unavailable
+    });
+    const labels = model.noIngredientGroups.map((g) => g.label);
+    expect(labels).toContain("Wednesday · Dinner — Sheet Pan Chicken");
+    expect(labels).toContain("Thursday · Dinner — Grandma's stew");
+    expect(model.recipeGroups).toHaveLength(0);
+    expect(model.errorGroups).toHaveLength(0);
+  });
+
+  it("routes a non-404 fetch error to a retryable error group, not the no-ingredient section", () => {
+    const model = buildReviewModel(board(), { r1: { status: "error" } });
+    expect(model.errorGroups.map((g) => g.label)).toEqual([
+      "Wednesday · Dinner — Sheet Pan Chicken",
+      "Thursday · Dinner — Sheet Pan Chicken",
+    ]);
+    expect(model.errorGroups.every((g) => g.recipeId === "r1")).toBe(true);
+    expect(model.recipeGroups).toHaveLength(0);
+    expect(model.noIngredientGroups.map((g) => g.label)).toEqual([
+      "Friday · Dinner — Taco night",
+    ]);
+  });
+
+  it("emits a distinct recipe group for a recipe-backed extra alongside its primary in the same slot", () => {
+    const b = board();
+    // Wed(3) dinner keeps primary r1 and gains a recipe-backed extra r3.
+    b.days[3].slots[2].extras = [
+      {
+        id: "e4",
+        role: "extra",
+        sourceType: "recipe",
+        recipeId: "r3",
+        title: "Garlic Bread",
+        imageUrl: null,
+        note: null,
+      },
+    ];
+    const recipeR3: RecipeDetail = {
+      id: "r3",
+      title: "Garlic Bread",
+      imageUrl: null,
+      favorite: false,
+      tags: [],
+      updatedAt: "",
+      ingredients: ["1 baguette", "2 tbsp butter"],
+      instructions: [],
+      note: null,
+      sourceUrl: null,
+    };
+
+    // The extra's recipe id is collected for fetching alongside the primary's.
+    expect(distinctRecipeIds(b)).toEqual(["r1", "r3"]);
+
+    const model = buildReviewModel(b, {
+      r1: { status: "loaded", detail: recipeR1 },
+      r3: { status: "loaded", detail: recipeR3 },
+    });
+
+    // Wed primary + Wed extra + Thu primary → three recipe groups.
+    const wednesday = model.recipeGroups.filter((g) =>
+      g.label.startsWith("Wednesday · Dinner"),
+    );
+    expect(wednesday.map((g) => g.label)).toEqual([
+      "Wednesday · Dinner — Sheet Pan Chicken",
+      "Wednesday · Dinner — Garlic Bread",
+    ]);
+    // Same day/meal prefix, but the primary and extra are distinct groups (distinct keys).
+    expect(wednesday[0].key).not.toBe(wednesday[1].key);
+    expect(wednesday[0].rows.map((r) => r.text)).toEqual([
+      "2 chicken breasts",
+      "1 tbsp olive oil",
+    ]);
+    expect(wednesday[1].rows.map((r) => r.text)).toEqual([
+      "1 baguette",
+      "2 tbsp butter",
+    ]);
+  });
+});
+
+describe("toBulkItemsRequest", () => {
+  it("sends only selected rows, verbatim, uncategorized, in order", () => {
+    const model = buildReviewModel(board(), {
+      r1: { status: "loaded", detail: recipeR1 },
+    });
+    model.recipeGroups[0].rows[1].selected = false; // deselect "1 tbsp olive oil" on Wed
+    const request = toBulkItemsRequest(model);
+    expect(request).toEqual({
+      items: [
+        { text: "2 chicken breasts" },
+        { text: "2 chicken breasts" },
+        { text: "1 tbsp olive oil" },
+      ],
+    });
+  });
+});

--- a/src/components/meals/meal-ingredient-extraction.ts
+++ b/src/components/meals/meal-ingredient-extraction.ts
@@ -1,0 +1,178 @@
+import type {
+  BulkCreateListItemsRequest,
+  MealBoard,
+  MealSlotEntry,
+  RecipeDetail,
+} from "@/lib/types";
+
+const WEEKDAY_LABELS = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+const MEAL_LABELS: Record<string, string> = {
+  breakfast: "Breakfast",
+  lunch: "Lunch",
+  dinner: "Dinner",
+};
+
+export interface PlannedEntryRef {
+  dayIndex: number;
+  mealType: string;
+  entry: MealSlotEntry;
+}
+
+export interface ReviewRow {
+  id: string; // stable per (entry, ingredient index) or manual row id
+  text: string;
+  selected: boolean;
+}
+
+export interface RecipeGroup {
+  key: string;
+  label: string;
+  rows: ReviewRow[];
+}
+
+export interface NoIngredientGroup {
+  key: string;
+  label: string;
+  manualRows: ReviewRow[]; // starts empty; the UI appends manual rows
+}
+
+// A recipe-backed meal whose detail fetch failed for a non-404 reason. Rendered as a
+// retryable per-meal error row; it contributes no ingredient rows and no manual rows.
+export interface ErrorGroup {
+  key: string;
+  label: string;
+  recipeId: string;
+}
+
+// Per-recipe fetch outcome the UI passes in (built by useRecipeDetails in Task 5):
+//   loaded  → detail available
+//   missing → 404 (deleted recipe) → honest "no recipe ingredients"
+//   error   → non-404 failure → retryable per-meal error row
+export type RecipeResolution =
+  | { status: "loaded"; detail: RecipeDetail }
+  | { status: "missing" }
+  | { status: "error" };
+
+export interface ReviewModel {
+  recipeGroups: RecipeGroup[];
+  noIngredientGroups: NoIngredientGroup[];
+  errorGroups: ErrorGroup[];
+}
+
+function isRecipeBacked(entry: MealSlotEntry): boolean {
+  return entry.sourceType === "recipe" && entry.recipeId !== null;
+}
+
+export function collectPlannedEntries(board: MealBoard): PlannedEntryRef[] {
+  const refs: PlannedEntryRef[] = [];
+  for (const day of board.days) {
+    for (const slot of day.slots) {
+      const entries = [slot.primary, ...slot.extras].filter(
+        (e): e is MealSlotEntry => e !== null,
+      );
+      for (const entry of entries) {
+        refs.push({ dayIndex: day.dayIndex, mealType: slot.mealType, entry });
+      }
+    }
+  }
+  return refs;
+}
+
+export function hasRecipeBackedEntry(board: MealBoard): boolean {
+  return collectPlannedEntries(board).some((ref) => isRecipeBacked(ref.entry));
+}
+
+export function distinctRecipeIds(board: MealBoard): string[] {
+  const ids = new Set<string>();
+  for (const ref of collectPlannedEntries(board)) {
+    if (isRecipeBacked(ref.entry) && ref.entry.recipeId)
+      ids.add(ref.entry.recipeId);
+  }
+  return [...ids];
+}
+
+function label(ref: PlannedEntryRef): string {
+  return `${WEEKDAY_LABELS[ref.dayIndex]} · ${MEAL_LABELS[ref.mealType]} — ${ref.entry.title}`;
+}
+
+function groupKey(ref: PlannedEntryRef): string {
+  return `${ref.dayIndex}:${ref.mealType}:${ref.entry.id}`;
+}
+
+export function buildReviewModel(
+  board: MealBoard,
+  resolutionsById: Record<string, RecipeResolution | undefined>,
+): ReviewModel {
+  const recipeGroups: RecipeGroup[] = [];
+  const noIngredientGroups: NoIngredientGroup[] = [];
+  const errorGroups: ErrorGroup[] = [];
+
+  for (const ref of collectPlannedEntries(board)) {
+    const key = groupKey(ref);
+
+    // Quick meals (and any entry without a recipe id) never have recipe ingredients.
+    if (!isRecipeBacked(ref.entry) || !ref.entry.recipeId) {
+      noIngredientGroups.push({ key, label: label(ref), manualRows: [] });
+      continue;
+    }
+
+    const resolution = resolutionsById[ref.entry.recipeId];
+
+    // Non-404 failure (or an unresolved id) → retryable error row; never silently dropped
+    // and never treated as "no recipe ingredients".
+    if (resolution === undefined || resolution.status === "error") {
+      errorGroups.push({
+        key,
+        label: label(ref),
+        recipeId: ref.entry.recipeId,
+      });
+      continue;
+    }
+
+    // 404 (deleted recipe) → honest "no recipe ingredients".
+    if (resolution.status === "missing") {
+      noIngredientGroups.push({ key, label: label(ref), manualRows: [] });
+      continue;
+    }
+
+    // Loaded: one verbatim row per ingredient, or the no-ingredient section when empty.
+    const ingredients = resolution.detail.ingredients;
+    if (ingredients.length > 0) {
+      recipeGroups.push({
+        key,
+        label: label(ref),
+        rows: ingredients.map((text, index) => ({
+          id: `${key}#${index}`,
+          text,
+          selected: true,
+        })),
+      });
+    } else {
+      noIngredientGroups.push({ key, label: label(ref), manualRows: [] });
+    }
+  }
+
+  return { recipeGroups, noIngredientGroups, errorGroups };
+}
+
+export function toBulkItemsRequest(
+  model: ReviewModel,
+): BulkCreateListItemsRequest {
+  const rows: ReviewRow[] = [
+    ...model.recipeGroups.flatMap((g) => g.rows),
+    ...model.noIngredientGroups.flatMap((g) => g.manualRows),
+  ];
+  return {
+    items: rows
+      .filter((row) => row.selected && row.text.trim().length > 0)
+      .map((row) => ({ text: row.text.trim() })), // uncategorized in v1
+  };
+}

--- a/src/components/meals/use-recipe-details.test.ts
+++ b/src/components/meals/use-recipe-details.test.ts
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { createElement, type ReactNode } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { testRecipeDetail } from "@/test/fixtures/recipes";
+import {
+  API_BASE,
+  resetMockRecipes,
+  seedMockRecipes,
+} from "@/test/mocks/handlers";
+import { server } from "@/test/mocks/server";
+import { useRecipeDetails } from "./use-recipe-details";
+
+let queryClient: QueryClient;
+
+function createWrapper() {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: Infinity },
+    },
+  });
+  resetMockRecipes();
+});
+
+afterEach(() => {
+  queryClient.clear();
+  server.resetHandlers();
+});
+
+describe("useRecipeDetails", () => {
+  it("maps loaded, missing (404), and error (500) recipes by id", async () => {
+    // r1 → loaded, r2 → 404 missing, r3 → 500 error
+    const loaded = { ...testRecipeDetail, id: "r1" };
+    seedMockRecipes([loaded]);
+    server.use(
+      http.get(`${API_BASE}/recipes/r3`, () =>
+        HttpResponse.json({ message: "boom" }, { status: 500 }),
+      ),
+    );
+
+    const { result } = renderHook(() => useRecipeDetails(["r1", "r2", "r3"]), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.resolutionsById.r1).toEqual({
+      status: "loaded",
+      detail: loaded,
+    });
+    expect(result.current.resolutionsById.r2).toEqual({ status: "missing" });
+    expect(result.current.resolutionsById.r3).toEqual({ status: "error" });
+  });
+
+  it("reports loading while any recipe query is pending", async () => {
+    seedMockRecipes([{ ...testRecipeDetail, id: "r1" }]);
+
+    const { result } = renderHook(() => useRecipeDetails(["r1"]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.resolutionsById.r1?.status).toBe("loaded");
+  });
+
+  it("returns an empty map with no ids", () => {
+    const { result } = renderHook(() => useRecipeDetails([]), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.resolutionsById).toEqual({});
+  });
+});

--- a/src/components/meals/use-recipe-details.ts
+++ b/src/components/meals/use-recipe-details.ts
@@ -1,0 +1,47 @@
+import { useQueries } from "@tanstack/react-query";
+import { ApiException } from "@/api/client";
+import { recipesKeys } from "@/api/hooks/use-recipes";
+import { recipesService } from "@/api/services";
+import type { RecipeResolution } from "./meal-ingredient-extraction";
+
+/**
+ * Resolve `RecipeDetail` for a variable number of recipe ids with a single
+ * hook call. Using `useQueries` (rather than mapping `useRecipe` over the ids)
+ * keeps the Rules of Hooks intact when the id set changes between renders.
+ *
+ * Each id maps to a {@link RecipeResolution} the review model understands:
+ *   - loaded  → detail available
+ *   - missing → 404 (deleted recipe) → honest "no recipe ingredients"
+ *   - error   → any other failure → retryable per-meal error row
+ */
+export function useRecipeDetails(recipeIds: string[]): {
+  resolutionsById: Record<string, RecipeResolution>;
+  isLoading: boolean;
+} {
+  const results = useQueries({
+    queries: recipeIds.map((id) => ({
+      queryKey: recipesKeys.detail(id),
+      queryFn: () => recipesService.getRecipe(id),
+    })),
+  });
+
+  const resolutionsById: Record<string, RecipeResolution> = {};
+  let isLoading = false;
+  results.forEach((result, index) => {
+    const id = recipeIds[index];
+    if (result.isPending) {
+      isLoading = true;
+    } else if (result.isSuccess) {
+      resolutionsById[id] = { status: "loaded", detail: result.data.data };
+    } else if (
+      result.error instanceof ApiException &&
+      result.error.status === 404
+    ) {
+      resolutionsById[id] = { status: "missing" };
+    } else {
+      resolutionsById[id] = { status: "error" };
+    }
+  });
+
+  return { resolutionsById, isLoading };
+}

--- a/src/lib/types/lists.ts
+++ b/src/lib/types/lists.ts
@@ -89,6 +89,10 @@ export interface CreateListItemRequest {
   categoryId?: string | null;
 }
 
+export interface BulkCreateListItemsRequest {
+  items: CreateListItemRequest[];
+}
+
 export interface UpdateListItemRequest {
   text: string;
   completed: boolean;
@@ -106,6 +110,7 @@ export interface ClearCompletedResponse {
 export type ListSummariesApiResponse = ApiResponse<ListSummary[]>;
 export type ListDetailApiResponse = ApiResponse<ListDetail>;
 export type ListItemApiResponse = ApiResponse<ListItem>;
+export type ListItemsApiResponse = ApiResponse<ListItem[]>;
 export type ListPreferencesApiResponse = ApiResponse<ListPreferences>;
 export type ClearCompletedApiResponse = ApiResponse<ClearCompletedResponse>;
 export type ListCategoryCatalogApiResponse = ApiResponse<ListCategoryCatalog>;

--- a/src/lib/validations/index.ts
+++ b/src/lib/validations/index.ts
@@ -5,6 +5,8 @@ export {
   choreFormSchema,
 } from "./chores";
 export {
+  type BulkCreateListItemsFormData,
+  bulkCreateListItemsSchema,
   type ListCreateFormData,
   type ListItemFormData,
   listCreateSchema,

--- a/src/lib/validations/lists.test.ts
+++ b/src/lib/validations/lists.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { categoryNameSchema, listCreateSchema, listItemSchema } from "./lists";
+import {
+  bulkCreateListItemsSchema,
+  categoryNameSchema,
+  listCreateSchema,
+  listItemSchema,
+} from "./lists";
 
 describe("listCreateSchema", () => {
   it("trims name and requires a kind", () => {
@@ -47,6 +52,35 @@ describe("listItemSchema", () => {
     expect(() => listItemSchema.parse({ text: "   " })).toThrow(
       "Item text is required",
     );
+  });
+});
+
+describe("bulkCreateListItemsSchema", () => {
+  it("accepts a valid single row", () => {
+    expect(
+      bulkCreateListItemsSchema.parse({ items: [{ text: "2 eggs" }] }),
+    ).toEqual({
+      items: [{ text: "2 eggs" }],
+    });
+  });
+
+  it("rejects an empty items array", () => {
+    expect(() => bulkCreateListItemsSchema.parse({ items: [] })).toThrow();
+  });
+
+  it("rejects more than 100 items", () => {
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      text: `Item ${i}`,
+    }));
+    expect(() => bulkCreateListItemsSchema.parse({ items })).toThrow();
+  });
+
+  it("rejects a blank text in any row", () => {
+    expect(() =>
+      bulkCreateListItemsSchema.parse({
+        items: [{ text: "2 eggs" }, { text: "   " }],
+      }),
+    ).toThrow();
   });
 });
 

--- a/src/lib/validations/lists.ts
+++ b/src/lib/validations/lists.ts
@@ -36,6 +36,21 @@ export const categoryNameSchema = z
       .max(100, "Category name must be 100 characters or less"),
   );
 
+export const bulkCreateListItemsSchema = z.object({
+  items: z
+    .array(
+      z.object({
+        text: z.string().trim().min(1).max(100),
+        categoryId: z.string().uuid().nullable().optional(),
+      }),
+    )
+    .min(1)
+    .max(100),
+});
+
 export type ListCreateFormData = z.infer<typeof listCreateSchema>;
 export type ListItemFormData = z.infer<typeof listItemSchema>;
 export type CategoryNameFormData = z.infer<typeof categoryNameSchema>;
+export type BulkCreateListItemsFormData = z.infer<
+  typeof bulkCreateListItemsSchema
+>;

--- a/src/test/mocks/handlers.ts
+++ b/src/test/mocks/handlers.ts
@@ -1571,6 +1571,49 @@ export const handlers = [
     );
   }),
 
+  // POST /lists/:id/items/bulk - Append multiple items in one request
+  http.post(`${API_BASE}/lists/:id/items/bulk`, async ({ params, request }) => {
+    const index = mockLists.findIndex(
+      (candidate) => candidate.id === params.id,
+    );
+    if (index === -1) {
+      return HttpResponse.json(
+        { message: `List with id "${params.id}" not found` },
+        { status: 404 },
+      );
+    }
+
+    const body = (await request.json()) as {
+      items: Array<{ text: string; categoryId?: string | null }>;
+    };
+    const list = mockLists[index];
+    const createdItems: ListItem[] = body.items.map((row) => ({
+      id: createMockId(),
+      text: row.text.trim(),
+      completed: false,
+      completedAt: null,
+      categoryId: row.categoryId ?? null,
+      createdAt: MOCK_TIMESTAMP,
+      updatedAt: MOCK_TIMESTAMP,
+    }));
+    const updated: ListDetail = {
+      ...list,
+      items: [...list.items, ...createdItems],
+      updatedAt: MOCK_TIMESTAMP,
+    };
+
+    mockLists = [
+      ...mockLists.slice(0, index),
+      updated,
+      ...mockLists.slice(index + 1),
+    ];
+
+    return HttpResponse.json(
+      createApiResponse(createdItems, "List items added successfully"),
+      { status: 201 },
+    );
+  }),
+
   // PATCH /lists/:listId/items/:itemId - Update text/category/completed state
   http.patch(
     `${API_BASE}/lists/:listId/items/:itemId`,


### PR DESCRIPTION
## Summary

Adds **Add ingredients to grocery list** to the Meals week. From the visible, editable week it gathers verbatim ingredients from recipe-backed planned meals, lets the parent review/edit/select rows, and appends the selected rows to a chosen grocery list in one confirmed, transactional action.

Closes #277.

## Released backend contract

Consumes the generic bulk append endpoint `POST /api/lists/{listId}/items/bulk`, shipped in **`family-hub-api` v1.9.0** (BE joe-bor/family-hub-api#68 / PR #69). FE CI resolves the latest published BE release; the E2E was run green against `1.9.0`.

## What's in it (6 commits)

- `feat(lists): add bulk item append contract and hook` — `BulkCreateListItemsRequest`/`ListItemsApiResponse` types, Zod schema, service, and `useBulkCreateListItems` (offline guard + `updateDetailItems` cache convergence, hub invalidation).
- `feat(meals): add recipe-ingredient extraction helpers` — pure `buildReviewModel`/`toBulkItemsRequest`/`distinctRecipeIds`/`hasRecipeBackedEntry` with the `RecipeResolution` (loaded/missing/error) model.
- `feat(meals): add ingredients review sheet` — presentational `AddIngredientsSheet` + `useRecipeDetails` (via `useQueries`): verbatim rows grouped by meal, "No recipe ingredients" section, retryable error rows, offline-disabled confirm. Retry preserves in-progress edits (`mergeReviewModel`).
- `feat(meals): add ingredients-to-grocery-list action and append flow` — gated Meals action + `AddIngredientsContainer` (grocery-list picker/create, one-shot append, success + View list, failure + create-then-fail retry).
- `test(meals): e2e for ingredients-to-grocery-list append` — released-contract Playwright E2E.
- `feat(meals): guard bulk append with the shared item schema (100-item cap)` — client-side cap guard.

## Non-negotiables → code / tests

- [x] Action only on editable current/future weeks with ≥1 recipe-backed entry; never past weeks — `meals-view.tsx`; `meals-view.test.tsx`
- [x] Verbatim ingredients grouped by meal; no parsing / no de-dup — `meal-ingredient-extraction.ts`; `.test.ts`
- [x] Quick / empty-ingredient / 404 → "No recipe ingredients"; non-404 fetch error → retryable row, excluded from append — extraction + `use-recipe-details.ts`; sheet tests
- [x] Edit / remove / select before append; **Retry preserves in-progress edits** — `add-ingredients-sheet.tsx` (`mergeReviewModel`); retry-survival test
- [x] Grocery-only picker: default the single list / choose among several / create when none — `add-ingredients-container.tsx`; multi-list + create tests
- [x] One transactional append (exactly one POST) → **View list**; uncategorized items — container; "exactly one POST" test
- [x] Offline disables writes with honest copy; reads still work — sheet + `assertOnlineForWrite`
- [x] Failure never shown as success; create-then-fail retries into the created list without re-creating — container; failure + create-then-fail tests
- [x] 100-item cap guarded client-side with honest copy — shared Zod schema guard + >100 test

## Test plan

- Unit / component: `npm test -- --run` → **1430 passed** (140 files); `npx tsc --noEmit` clean; Biome clean.
- Released-contract E2E: `e2e/meals-ingredients.spec.ts` against `ghcr.io/joe-bor/family-hub-api:1.9.0` → **Mobile Chrome passed** (`--repeat-each=2` stable). CI resolves the published BE release automatically.

## Docs (root workspace `joe-bor/family-hub`)

- Story: `docs/product/backlog/module-foundations/meals-recipe-ingredients-to-grocery-list.md`
- Spec / Plan: `docs/superpowers/specs/2026-07-04-meals-recipe-ingredients-to-grocery-list.md` · `docs/superpowers/plans/2026-07-04-meals-recipe-ingredients-to-grocery-list.md`

Each task was implemented test-first and passed an independent spec-compliance review and a technical review; a final whole-branch review confirmed merge-readiness.
