### PR TITLE
feat: large-screen shell foundations (slim header, single calendar toolbar)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test-results/
 # Personal learning notes
 docs/VERSIONING-WALKTHROUGH.md
 .worktrees/
+.claude/launch.json

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -567,6 +567,13 @@ describe("CalendarModule", () => {
   });
 
   describe("Date Navigation", () => {
+    const expectedDailyLabel = (date: Date) =>
+      date.toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+      });
+
     it("navigates to previous day when Previous button clicked", async () => {
       seedMockEvents([]);
       seedCalendarStore({ calendarView: "daily" });
@@ -584,11 +591,7 @@ describe("CalendarModule", () => {
       await user.click(screen.getByRole("button", { name: /previous/i }));
 
       // Date label should update to yesterday
-      const expectedLabel = yesterday.toLocaleDateString("en-US", {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      });
+      const expectedLabel = expectedDailyLabel(yesterday);
 
       await waitFor(() => {
         expect(screen.getByText(expectedLabel)).toBeInTheDocument();
@@ -610,11 +613,7 @@ describe("CalendarModule", () => {
 
       await user.click(screen.getByRole("button", { name: /next/i }));
 
-      const expectedLabel = tomorrow.toLocaleDateString("en-US", {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      });
+      const expectedLabel = expectedDailyLabel(tomorrow);
 
       await waitFor(() => {
         expect(screen.getByText(expectedLabel)).toBeInTheDocument();
@@ -639,11 +638,7 @@ describe("CalendarModule", () => {
       await user.click(screen.getByRole("button", { name: /today/i }));
 
       const today = new Date();
-      const expectedLabel = today.toLocaleDateString("en-US", {
-        weekday: "short",
-        month: "short",
-        day: "numeric",
-      });
+      const expectedLabel = expectedDailyLabel(today);
 
       await waitFor(() => {
         expect(screen.getByText(expectedLabel)).toBeInTheDocument();

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -585,10 +585,9 @@ describe("CalendarModule", () => {
 
       // Date label should update to yesterday
       const expectedLabel = yesterday.toLocaleDateString("en-US", {
-        weekday: "long",
-        month: "long",
+        weekday: "short",
+        month: "short",
         day: "numeric",
-        year: "numeric",
       });
 
       await waitFor(() => {
@@ -612,10 +611,9 @@ describe("CalendarModule", () => {
       await user.click(screen.getByRole("button", { name: /next/i }));
 
       const expectedLabel = tomorrow.toLocaleDateString("en-US", {
-        weekday: "long",
-        month: "long",
+        weekday: "short",
+        month: "short",
         day: "numeric",
-        year: "numeric",
       });
 
       await waitFor(() => {
@@ -642,15 +640,31 @@ describe("CalendarModule", () => {
 
       const today = new Date();
       const expectedLabel = today.toLocaleDateString("en-US", {
-        weekday: "long",
-        month: "long",
+        weekday: "short",
+        month: "short",
         day: "numeric",
-        year: "numeric",
       });
 
       await waitFor(() => {
         expect(screen.getByText(expectedLabel)).toBeInTheDocument();
       });
+    });
+
+    it("renders date navigation in the toolbar for the schedule view", async () => {
+      seedMockEvents([]);
+      seedCalendarStore({ calendarView: "schedule" });
+
+      renderWithUser(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /previous/i }),
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+      expect(screen.getByText("Upcoming")).toBeInTheDocument();
     });
   });
 

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -20,6 +20,7 @@ import {
 import type { ApiException } from "@/api/client";
 import {
   AddEventButton,
+  CalendarNavigation,
   CalendarViewSwitcher,
   DailyCalendar,
   type EditScope,
@@ -27,6 +28,7 @@ import {
   EventDetailModal,
   EventFormModal,
   FamilyFilterPills,
+  getContextLabel,
   MobileDailyView,
   MobileMonthlyView,
   MobileToolbar,
@@ -391,13 +393,6 @@ export function CalendarModule() {
     filter,
   };
 
-  const navigationProps = {
-    onPrevious: goToPrevious,
-    onNext: goToNext,
-    onToday: goToToday,
-    isViewingToday,
-  };
-
   const renderCalendarView = () => {
     // Show loading state
     if (isLoading) {
@@ -465,21 +460,20 @@ export function CalendarModule() {
 
     switch (calendarView) {
       case "daily":
-        return <DailyCalendar {...commonProps} {...navigationProps} />;
+        return <DailyCalendar {...commonProps} />;
       case "weekly":
-        return <WeeklyCalendar {...commonProps} {...navigationProps} />;
+        return <WeeklyCalendar {...commonProps} />;
       case "monthly":
         return (
           <MonthlyCalendar
             {...commonProps}
-            {...navigationProps}
             onDateSelect={selectDateAndSwitchToDaily}
           />
         );
       case "schedule":
         return <ScheduleCalendar {...commonProps} />;
       default:
-        return <WeeklyCalendar {...commonProps} {...navigationProps} />;
+        return <WeeklyCalendar {...commonProps} />;
     }
   };
 
@@ -489,8 +483,15 @@ export function CalendarModule() {
       {isMobile ? (
         <MobileToolbar members={members} />
       ) : (
-        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 px-4 py-3 bg-card border-b border-border">
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-2 bg-card border-b border-border">
           <CalendarViewSwitcher />
+          <CalendarNavigation
+            label={getContextLabel(calendarView, currentDate)}
+            onPrevious={goToPrevious}
+            onNext={goToNext}
+            onToday={goToToday}
+            isViewingToday={isViewingToday}
+          />
           <FamilyFilterPills />
         </div>
       )}

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -483,7 +483,7 @@ export function CalendarModule() {
       {isMobile ? (
         <MobileToolbar members={members} />
       ) : (
-        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-4 py-2 bg-card border-b border-border">
+        <div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-2 px-3 py-2 bg-card border-b border-border">
           <CalendarViewSwitcher />
           <CalendarNavigation
             label={getContextLabel(calendarView, currentDate)}

--- a/src/components/calendar/components/calendar-navigation.tsx
+++ b/src/components/calendar/components/calendar-navigation.tsx
@@ -21,9 +21,9 @@ export function CalendarNavigation({
     <div className="flex items-center justify-center gap-2">
       <Button
         variant="ghost"
-        size="icon"
+        size="icon-lg"
         onClick={onPrevious}
-        className="h-11 w-11 text-muted-foreground hover:text-foreground"
+        className="text-muted-foreground hover:text-foreground"
         aria-label="Previous"
       >
         <ChevronLeft className="h-5 w-5" />
@@ -49,9 +49,9 @@ export function CalendarNavigation({
 
       <Button
         variant="ghost"
-        size="icon"
+        size="icon-lg"
         onClick={onNext}
-        className="h-11 w-11 text-muted-foreground hover:text-foreground"
+        className="text-muted-foreground hover:text-foreground"
         aria-label="Next"
       >
         <ChevronRight className="h-5 w-5" />

--- a/src/components/calendar/components/calendar-navigation.tsx
+++ b/src/components/calendar/components/calendar-navigation.tsx
@@ -43,7 +43,7 @@ export function CalendarNavigation({
         <span>Today</span>
       </button>
 
-      <h2 className="min-w-0 truncate text-center text-base font-semibold text-foreground sm:min-w-[200px] sm:text-lg">
+      <h2 className="min-w-0 truncate text-center text-base font-semibold text-foreground sm:min-w-[8rem] sm:text-lg">
         {label}
       </h2>
 

--- a/src/components/calendar/components/calendar-navigation.tsx
+++ b/src/components/calendar/components/calendar-navigation.tsx
@@ -18,12 +18,12 @@ export function CalendarNavigation({
   isViewingToday,
 }: CalendarNavigationProps) {
   return (
-    <div className="flex items-center justify-center gap-2 py-3">
+    <div className="flex items-center justify-center gap-2">
       <Button
         variant="ghost"
         size="icon"
         onClick={onPrevious}
-        className="h-10 w-10 text-muted-foreground hover:text-foreground"
+        className="h-11 w-11 text-muted-foreground hover:text-foreground"
         aria-label="Previous"
       >
         <ChevronLeft className="h-5 w-5" />
@@ -33,7 +33,7 @@ export function CalendarNavigation({
         onClick={onToday}
         disabled={isViewingToday}
         className={cn(
-          "flex min-h-10 items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-semibold transition-all",
+          "flex min-h-11 items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-semibold transition-all",
           isViewingToday
             ? "bg-primary/10 text-primary cursor-default"
             : "bg-primary text-primary-foreground hover:bg-primary/90 shadow-sm",
@@ -51,7 +51,7 @@ export function CalendarNavigation({
         variant="ghost"
         size="icon"
         onClick={onNext}
-        className="h-10 w-10 text-muted-foreground hover:text-foreground"
+        className="h-11 w-11 text-muted-foreground hover:text-foreground"
         aria-label="Next"
       >
         <ChevronRight className="h-5 w-5" />

--- a/src/components/calendar/components/calendar-view-switcher.tsx
+++ b/src/components/calendar/components/calendar-view-switcher.tsx
@@ -39,7 +39,7 @@ export function CalendarViewSwitcher() {
           )}
         >
           {v.icon}
-          {/* Icon-only in the 1024-1279 band so the merged toolbar keeps one row */}
+          {/* Icon-only below xl (768-1279) so the merged toolbar keeps one row */}
           <span className="hidden xl:inline">{v.label}</span>
         </button>
       ))}

--- a/src/components/calendar/components/calendar-view-switcher.tsx
+++ b/src/components/calendar/components/calendar-view-switcher.tsx
@@ -30,7 +30,7 @@ export function CalendarViewSwitcher() {
           key={v.id}
           onClick={() => setCalendarView(v.id)}
           className={cn(
-            "flex min-h-10 min-w-10 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold transition-all sm:px-3",
+            "flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold transition-all sm:px-3",
             calendarView === v.id
               ? "bg-background text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground hover:bg-background/50",

--- a/src/components/calendar/components/calendar-view-switcher.tsx
+++ b/src/components/calendar/components/calendar-view-switcher.tsx
@@ -29,6 +29,8 @@ export function CalendarViewSwitcher() {
         <button
           key={v.id}
           onClick={() => setCalendarView(v.id)}
+          aria-label={v.label}
+          title={v.label}
           className={cn(
             "flex min-h-11 min-w-11 items-center justify-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold transition-all sm:px-3",
             calendarView === v.id
@@ -37,7 +39,8 @@ export function CalendarViewSwitcher() {
           )}
         >
           {v.icon}
-          <span className="hidden sm:inline">{v.label}</span>
+          {/* Icon-only in the 1024-1279 band so the merged toolbar keeps one row */}
+          <span className="hidden xl:inline">{v.label}</span>
         </button>
       ))}
     </div>

--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -49,7 +49,7 @@ export function FamilyFilterPills() {
       <button
         onClick={handleToggleAll}
         className={cn(
-          "px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
+          "min-h-11 px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
           allSelected
             ? "bg-foreground text-background border-foreground"
             : noneSelected
@@ -63,7 +63,7 @@ export function FamilyFilterPills() {
       <button
         onClick={toggleAllDayEvents}
         className={cn(
-          "flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
+          "flex min-h-11 items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
           filter.showAllDayEvents
             ? "bg-primary/10 text-primary border-primary/30"
             : "bg-muted/50 text-muted-foreground border-border hover:bg-muted",
@@ -85,7 +85,7 @@ export function FamilyFilterPills() {
             key={member.id}
             onClick={() => toggleMember(member.id)}
             className={cn(
-              "flex items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium transition-all",
+              "flex min-h-11 items-center gap-1.5 px-2 py-1 rounded-full text-xs font-medium transition-all",
               isSelected
                 ? `${colors?.bg} text-white shadow-sm`
                 : "bg-muted text-muted-foreground hover:bg-muted/80 opacity-50",

--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -43,13 +43,13 @@ export function FamilyFilterPills() {
 
   return (
     <div
-      className="flex items-center gap-1.5"
+      className="flex flex-wrap items-center gap-1.5"
       data-testid="family-filter-pills"
     >
       <button
         onClick={handleToggleAll}
         className={cn(
-          "min-h-11 px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
+          "flex min-h-11 items-center px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
           allSelected
             ? "bg-foreground text-background border-foreground"
             : noneSelected

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -12,7 +12,6 @@ import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { CalendarEventCard } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
-import { CalendarNavigation } from "../components/calendar-navigation";
 import {
   CurrentTimeIndicator,
   useAutoScrollToNow,
@@ -23,10 +22,6 @@ interface DailyCalendarProps {
   currentDate: Date;
   onEventClick?: (event: CalendarEvent) => void;
   filter: FilterState;
-  onPrevious: () => void;
-  onNext: () => void;
-  onToday: () => void;
-  isViewingToday: boolean;
 }
 
 const START_HOUR = CALENDAR_START_HOUR;
@@ -119,10 +114,6 @@ export function DailyCalendar({
   currentDate,
   onEventClick,
   filter,
-  onPrevious,
-  onNext,
-  onToday,
-  isViewingToday,
 }: DailyCalendarProps) {
   const familyMembers = useFamilyMembers();
   const today = new Date();
@@ -133,15 +124,6 @@ export function DailyCalendar({
 
   const isToday = (date: Date) => {
     return date.toDateString() === today.toDateString();
-  };
-
-  const formatDateLabel = (date: Date) => {
-    return date.toLocaleDateString("en-US", {
-      weekday: "long",
-      month: "long",
-      day: "numeric",
-      year: "numeric",
-    });
   };
 
   // Memoize filtered and sorted events for the day
@@ -195,17 +177,6 @@ export function DailyCalendar({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-background">
-      {/* Navigation header */}
-      <div className="border-b border-border bg-card shrink-0">
-        <CalendarNavigation
-          label={formatDateLabel(currentDate)}
-          onPrevious={onPrevious}
-          onNext={onNext}
-          onToday={onToday}
-          isViewingToday={isViewingToday}
-        />
-      </div>
-
       {/* Day info header */}
       <div className="flex border-b border-border bg-card shrink-0">
         <div className="w-12 sm:w-16 shrink-0" />

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -15,7 +15,6 @@ import {
 import { cn } from "@/lib/utils";
 import { GoogleBadge, isGoogleEvent } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
-import { CalendarNavigation } from "../components/calendar-navigation";
 
 interface MonthlyCalendarProps {
   events: CalendarEvent[];
@@ -23,10 +22,6 @@ interface MonthlyCalendarProps {
   onEventClick?: (event: CalendarEvent) => void;
   filter: FilterState;
   onDateSelect?: (date: Date) => void;
-  onPrevious: () => void;
-  onNext: () => void;
-  onToday: () => void;
-  isViewingToday: boolean;
 }
 
 interface DayData {
@@ -40,10 +35,6 @@ export function MonthlyCalendar({
   onEventClick,
   filter,
   onDateSelect,
-  onPrevious,
-  onNext,
-  onToday,
-  isViewingToday,
 }: MonthlyCalendarProps) {
   const familyMembers = useFamilyMembers();
   const isMobile = useIsMobile();
@@ -137,23 +128,8 @@ export function MonthlyCalendar({
     return date.getMonth() === currentDate.getMonth();
   };
 
-  const formatMonthLabel = () => {
-    return currentDate.toLocaleDateString("en-US", {
-      month: "long",
-      year: "numeric",
-    });
-  };
-
   return (
     <div className="flex-1 flex flex-col min-h-0 bg-background p-4 overflow-auto">
-      <CalendarNavigation
-        label={formatMonthLabel()}
-        onPrevious={onPrevious}
-        onNext={onNext}
-        onToday={onToday}
-        isViewingToday={isViewingToday}
-      />
-
       {/* Weekday headers */}
       <div className="grid grid-cols-7 gap-0.5 sm:gap-1 mb-2 shrink-0">
         {weekDays.map((day) => (

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -11,7 +11,6 @@ import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { CalendarEventCard } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
-import { CalendarNavigation } from "../components/calendar-navigation";
 import {
   CurrentTimeIndicator,
   useAutoScrollToNow,
@@ -22,10 +21,6 @@ interface WeeklyCalendarProps {
   currentDate: Date;
   onEventClick?: (event: CalendarEvent) => void;
   filter: FilterState;
-  onPrevious: () => void;
-  onNext: () => void;
-  onToday: () => void;
-  isViewingToday: boolean;
 }
 
 const ROW_HEIGHT = 80; // px per hour
@@ -49,10 +44,6 @@ export function WeeklyCalendar({
   currentDate,
   onEventClick,
   filter,
-  onPrevious,
-  onNext,
-  onToday,
-  isViewingToday,
 }: WeeklyCalendarProps) {
   const familyMembers = useFamilyMembers();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -123,21 +114,6 @@ export function WeeklyCalendar({
     };
   }, [events, weekDays, filter.selectedMembers, filter.showAllDayEvents]);
 
-  const formatWeekLabel = () => {
-    const startOfWeek = weekDays[0];
-    const endOfWeek = weekDays[6];
-    const startMonth = startOfWeek.toLocaleDateString("en-US", {
-      month: "short",
-    });
-    const endMonth = endOfWeek.toLocaleDateString("en-US", { month: "short" });
-    const year = endOfWeek.getFullYear();
-
-    if (startMonth === endMonth) {
-      return `${startMonth} ${startOfWeek.getDate()} - ${endOfWeek.getDate()}, ${year}`;
-    }
-    return `${startMonth} ${startOfWeek.getDate()} - ${endMonth} ${endOfWeek.getDate()}, ${year}`;
-  };
-
   const formatDayName = (date: Date) => {
     return date.toLocaleDateString("en-US", { weekday: "short" });
   };
@@ -184,17 +160,6 @@ export function WeeklyCalendar({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-background">
-      {/* Navigation header */}
-      <div className="border-b border-border bg-card shrink-0">
-        <CalendarNavigation
-          label={formatWeekLabel()}
-          onPrevious={onPrevious}
-          onNext={onNext}
-          onToday={onToday}
-          isViewingToday={isViewingToday}
-        />
-      </div>
-
       {/* Days header */}
       <div
         className="grid border-b border-border bg-card shrink-0"

--- a/src/components/shared/app-header.test.tsx
+++ b/src/components/shared/app-header.test.tsx
@@ -125,4 +125,13 @@ describe("AppHeader (desktop)", () => {
     render(<AppHeader />);
     expect(screen.queryByText(/72°/)).not.toBeInTheDocument();
   });
+
+  it("opens the sidebar when the Menu button is clicked", async () => {
+    const { user } = renderWithUser(<AppHeader />);
+    expect(useAppStore.getState().isSidebarOpen).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: /menu/i }));
+
+    expect(useAppStore.getState().isSidebarOpen).toBe(true);
+  });
 });

--- a/src/components/shared/app-header.test.tsx
+++ b/src/components/shared/app-header.test.tsx
@@ -10,13 +10,15 @@ import {
 } from "@/test/test-utils";
 import { AppHeader } from "./app-header";
 
+const isMobileMock = vi.fn(() => true);
 vi.mock("@/hooks", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/hooks")>();
-  return { ...actual, useIsMobile: () => true };
+  return { ...actual, useIsMobile: () => isMobileMock() };
 });
 
 describe("AppHeader (mobile)", () => {
   beforeEach(() => {
+    isMobileMock.mockReturnValue(true);
     seedFamilyStore({
       name: "Test Family",
       members: [{ id: "m1", name: "Alice", color: "coral" }],
@@ -101,5 +103,26 @@ describe("AppHeader (mobile)", () => {
     expect(current.getFullYear()).toBe(now.getFullYear());
     expect(current.getMonth()).toBe(now.getMonth());
     expect(current.getDate()).toBe(now.getDate());
+  });
+});
+
+describe("AppHeader (desktop)", () => {
+  beforeEach(() => {
+    isMobileMock.mockReturnValue(false);
+    seedFamilyStore({
+      name: "Test Family",
+      members: [{ id: "m1", name: "Alice", color: "coral" }],
+    });
+  });
+
+  it("renders the family name and member dots", () => {
+    render(<AppHeader />);
+    expect(screen.getByText("Test Family")).toBeInTheDocument();
+    expect(screen.getByTitle("Alice")).toBeInTheDocument();
+  });
+
+  it("does not render the fake weather chip", () => {
+    render(<AppHeader />);
+    expect(screen.queryByText(/72°/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -1,4 +1,4 @@
-import { Cloud, Menu, Sun } from "lucide-react";
+import { Menu } from "lucide-react";
 import { useFamilyMembers, useFamilyName } from "@/api";
 import { getContextLabel } from "@/components/calendar/utils/context-label";
 import { Button } from "@/components/ui/button";
@@ -98,60 +98,48 @@ export function AppHeader() {
     );
   }
 
-  // Desktop: unchanged — Menu left + family name + date/time, weather, dots.
+  // Desktop: one compact row — Menu, family name, date/time inline, member
+  // dots right. No weather chip until a real weather feature exists.
   return (
     <header
       className={cn(
         "shrink-0 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85",
-        "flex items-center justify-between",
-        "px-6 py-4",
+        "flex min-h-14 items-center justify-between gap-4",
+        "px-6 py-2",
       )}
     >
-      <div className="flex items-center gap-4">
+      <div className="flex min-w-0 items-center gap-3">
         <Button
           variant="ghost"
           size="icon"
           aria-label="Menu"
-          className="text-muted-foreground hover:text-foreground"
+          className="h-11 w-11 text-muted-foreground hover:text-foreground"
           onClick={openSidebar}
         >
           <Menu className="h-5 w-5" />
         </Button>
-        <div>
-          <h1 className="text-[22px] leading-7 font-semibold text-foreground">
-            {familyName || "Family Hub"}
-          </h1>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <span>{formatDate(currentDate)}</span>
-            <span>•</span>
-            <span>{formatTime(new Date())}</span>
-          </div>
+        <h1 className="truncate text-lg leading-7 font-semibold text-foreground">
+          {familyName || "Family Hub"}
+        </h1>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>{formatDate(currentDate)}</span>
+          <span>•</span>
+          <span>{formatTime(new Date())}</span>
         </div>
       </div>
 
-      <div className="flex items-center gap-6">
-        {/* Weather - future: real widget */}
-        <div className="flex items-center gap-2 text-muted-foreground">
-          <div className="relative">
-            <Sun className="h-5 w-5 text-yellow-500" />
-            <Cloud className="h-4 w-4 text-gray-400 absolute -bottom-1 -right-1" />
-          </div>
-          <span className="text-sm font-medium">72°</span>
+      {/* Family member indicators - used for calendar filtering */}
+      {familyMembers.length > 0 && (
+        <div className="flex shrink-0 items-center gap-1.5">
+          {familyMembers.slice(0, 6).map((member) => (
+            <div
+              key={member.id}
+              className={`w-3 h-3 rounded-full ${colorMap[member.color].bg}`}
+              title={member.name}
+            />
+          ))}
         </div>
-
-        {/* Family member indicators - used for calendar filtering */}
-        {familyMembers.length > 0 && (
-          <div className="flex items-center gap-1.5">
-            {familyMembers.slice(0, 6).map((member) => (
-              <div
-                key={member.id}
-                className={`w-3 h-3 rounded-full ${colorMap[member.color].bg}`}
-                title={member.name}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+      )}
     </header>
   );
 }

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -104,16 +104,16 @@ export function AppHeader() {
     <header
       className={cn(
         "shrink-0 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85",
-        "flex min-h-14 items-center justify-between gap-4",
+        "flex items-center justify-between gap-4",
         "px-6 py-2",
       )}
     >
       <div className="flex min-w-0 items-center gap-3">
         <Button
           variant="ghost"
-          size="icon"
+          size="icon-lg"
           aria-label="Menu"
-          className="h-11 w-11 text-muted-foreground hover:text-foreground"
+          className="text-muted-foreground hover:text-foreground"
           onClick={openSidebar}
         >
           <Menu className="h-5 w-5" />
@@ -121,7 +121,7 @@ export function AppHeader() {
         <h1 className="truncate text-lg leading-7 font-semibold text-foreground">
           {familyName || "Family Hub"}
         </h1>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <div className="flex shrink-0 items-center gap-2 whitespace-nowrap text-sm text-muted-foreground">
           <span>{formatDate(currentDate)}</span>
           <span>•</span>
           <span>{formatTime(new Date())}</span>
@@ -134,7 +134,7 @@ export function AppHeader() {
           {familyMembers.slice(0, 6).map((member) => (
             <div
               key={member.id}
-              className={`w-3 h-3 rounded-full ${colorMap[member.color].bg}`}
+              className={cn("h-3 w-3 rounded-full", colorMap[member.color].bg)}
               title={member.name}
             />
           ))}


### PR DESCRIPTION
Story: https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-foundations.md
Spec: https://github.com/joe-bor/family-hub/blob/docs/large-screen-first-pass/docs/superpowers/specs/2026-07-06-large-screen-foundations-design.md
Plan: https://github.com/joe-bor/family-hub/blob/docs/large-screen-first-pass/docs/superpowers/plans/2026-07-06-large-screen-foundations.md

First story of the large-screen UX epic: reclaim vertical chrome on desktop/tablet so module content gets the screen.

- Desktop app header: one compact row (61px, was ~97px), fake weather chip removed
- Calendar desktop chrome: view switcher + date navigation + member filter pills in one toolbar row; per-view navigation headers removed; Schedule view gains navigation
- Header + calendar toolbar now 130px at 1440x900 (AC budget: ≤160px; previously ~230px before the time grid even starts)
- Toolbar touch targets grown to 44px (nav buttons, view switcher, filter pills); pills wrap instead of clipping for large families
- One-row toolbar holds at the 1024px lg boundary: icon-only view switcher below xl (aria-labels added; text labels return at 1280px), nav label reservation trimmed to 8rem
- Copy change: desktop calendar range labels now use the shared short context label (e.g. "Sun, Jul 5" instead of "Sunday, July 5, 2026"), matching mobile
- Mobile shell and mobile calendar toolbar unchanged (visually verified at 375x812)

Deferred spec ACs (owned by later stories in this epic):
- Module content-width discipline — Lists/Meals/Recipes stay centered columns until their module stories land
- Meals second "Fill empty slots" row — merged into the week header row by the Meals story
- Accepted deviation: 769-1023px uses flex-wrap instead of an overflow control for toolbar surplus (spec allowed overflow; wrap chosen as the cheaper graceful degradation)

Visual QA (recorded in work log): verified at 1440x900, 1280x800, 1024x768, 375x812 against a real backend (BE 1.9.0) — header 61px, header+toolbar 130px @1440, single toolbar row at 1024+, no weather chip, mobile baseline unchanged. Full suite 1436/1436, build + lint clean.