### PR TITLE
feat(calendar): large-screen week and day layouts

### DIFF
--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -10,6 +10,7 @@ import {
   it,
   vi,
 } from "vitest";
+import { railThresholdPx } from "@/components/calendar/utils/day-rail";
 import type { CalendarEventResponse, UpdateEventRequest } from "@/lib/types";
 import { useAppStore, useCalendarStore } from "@/stores";
 import {
@@ -811,6 +812,131 @@ describe("CalendarModule", () => {
       });
 
       expect(screen.getByText("TODAY")).toBeInTheDocument();
+    });
+  });
+
+  describe("Day view large-screen lanes", () => {
+    function setMatchMediaWidth(width: number) {
+      vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+        matches: matchesMinWidth(query, width),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+    }
+
+    function matchesMinWidth(query: string, width: number): boolean {
+      const minWidth = query.match(/\(min-width:\s*(\d+)px\)/);
+      if (!minWidth) return false;
+      return width >= Number(minWidth[1]);
+    }
+
+    beforeEach(() => {
+      setMatchMediaWidth(1024);
+    });
+
+    afterEach(() => {
+      setMatchMediaWidth(0);
+    });
+
+    it("keeps the tablet DailyCalendar at 1023px", async () => {
+      setMatchMediaWidth(1023);
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(2026, 6, 6),
+        calendarView: "daily",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("group", {
+          name: new RegExp(`${testMembers[0].name}'s schedule`, "i"),
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders member lanes on the daily view at 1024px", async () => {
+      setMatchMediaWidth(1024);
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(2026, 6, 6),
+        calendarView: "daily",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("group", {
+          name: new RegExp(`${testMembers[0].name}'s schedule`, "i"),
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the rail toggle below the rail fit threshold", async () => {
+      setMatchMediaWidth(railThresholdPx(testMembers.length) - 1);
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(2026, 6, 6),
+        calendarView: "daily",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole("button", { name: /month navigator/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows the rail toggle at the rail fit threshold", async () => {
+      setMatchMediaWidth(railThresholdPx(testMembers.length));
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(2026, 6, 6),
+        calendarView: "daily",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole("button", { name: /month navigator/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -750,6 +750,70 @@ describe("CalendarModule", () => {
     });
   });
 
+  describe("Week view desktop chrome", () => {
+    function setMatchMedia(matches: (query: string) => boolean) {
+      vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+        matches: matches(query),
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }));
+    }
+
+    afterEach(() => {
+      setMatchMedia(() => false);
+    });
+
+    it("renders one-line day headers without the TODAY pill tower", async () => {
+      setMatchMedia((query) => query.includes("min-width"));
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(2026, 6, 8), // Wed Jul 8 2026
+        calendarView: "weekly",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      // Collapsed header: no stacked "TODAY" pill anymore.
+      expect(screen.queryByText("TODAY")).not.toBeInTheDocument();
+      // Day numerals still render (7 days rendered as day-of-month numbers).
+      expect(screen.getAllByText(/^\d{1,2}$/).length).toBeGreaterThanOrEqual(7);
+    });
+
+    it("keeps stacked TODAY pill below lg", async () => {
+      setMatchMedia(() => false);
+      seedMockEvents([]);
+      seedCalendarStore({
+        currentDate: new Date(),
+        calendarView: "weekly",
+        filter: {
+          selectedMembers: testMembers.map((m) => m.id),
+          showAllDayEvents: true,
+        },
+      });
+
+      render(<CalendarModule />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading events...")).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByText("TODAY")).toBeInTheDocument();
+    });
+  });
+
   describe("Store Persistence", () => {
     it("respects initial calendar view from store", async () => {
       seedMockEvents([]);

--- a/src/components/calendar/calendar-module.tsx
+++ b/src/components/calendar/calendar-module.tsx
@@ -23,6 +23,8 @@ import {
   CalendarNavigation,
   CalendarViewSwitcher,
   DailyCalendar,
+  DayLanesCalendar,
+  DayRailToggle,
   type EditScope,
   EditScopeDialog,
   EventDetailModal,
@@ -37,8 +39,9 @@ import {
   ScheduleCalendar,
   WeeklyCalendar,
 } from "@/components/calendar";
+import { railThresholdPx } from "@/components/calendar/utils/day-rail";
 import { toast } from "@/components/ui/toaster";
-import { useIsMobile } from "@/hooks";
+import { useIsLargeScreen, useIsMobile, useMediaQuery } from "@/hooks";
 import { isOfflineWriteError } from "@/lib/offline/read-only-guard";
 import { buildRRule } from "@/lib/recurrence-utils";
 import {
@@ -54,6 +57,7 @@ import {
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
+  useDayRailState,
   useEditModalState,
   useEventDetailState,
   useHasUserSetView,
@@ -154,6 +158,16 @@ export function CalendarModule() {
   // Family data for mobile views
   const members = useFamilyMembers();
   const memberMap = useFamilyMemberMap();
+  const isLargeScreen = useIsLargeScreen();
+  const { dayRailHidden } = useDayRailState();
+  const memberCount = members.length;
+  const canFitRail = useMediaQuery(
+    `(min-width: ${railThresholdPx(memberCount)}px)`,
+  );
+  const isDayLanes = !isMobile && isLargeScreen && calendarView === "daily";
+  const showDayRail =
+    isDayLanes && canFitRail && !dayRailHidden && memberCount > 0;
+  const showRailToggle = isDayLanes && canFitRail && memberCount > 0;
 
   // Compute date range based on current view for API query
   const dateRange = useMemo(() => {
@@ -515,7 +529,16 @@ export function CalendarModule() {
 
     switch (calendarView) {
       case "daily":
-        return <DailyCalendar {...commonProps} />;
+        return isLargeScreen ? (
+          <DayLanesCalendar
+            {...commonProps}
+            members={members}
+            showRail={showDayRail}
+            onSelectDate={setDate}
+          />
+        ) : (
+          <DailyCalendar {...commonProps} />
+        );
       case "weekly":
         return <WeeklyCalendar {...commonProps} />;
       case "monthly":
@@ -547,7 +570,10 @@ export function CalendarModule() {
             onToday={goToToday}
             isViewingToday={isViewingToday}
           />
-          <FamilyFilterPills />
+          <div className="flex items-center gap-2">
+            <FamilyFilterPills />
+            {showRailToggle && <DayRailToggle />}
+          </div>
         </div>
       )}
 

--- a/src/components/calendar/components/current-time-indicator.test.tsx
+++ b/src/components/calendar/components/current-time-indicator.test.tsx
@@ -4,6 +4,19 @@ import { describe, expect, it, vi } from "vitest";
 import { useAutoScrollToMinutes } from "./current-time-indicator";
 
 describe("useAutoScrollToMinutes", () => {
+  function mockReducedMotion(matches: boolean) {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  }
+
   it("scrolls to the target row minus a lead offset", () => {
     const el = document.createElement("div");
     const scrollTo = vi.spyOn(el, "scrollTo");
@@ -40,5 +53,18 @@ describe("useAutoScrollToMinutes", () => {
     });
 
     expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("uses instant scroll when reduced motion is requested", () => {
+    mockReducedMotion(true);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToMinutes(ref, 600, 52);
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 320, behavior: "auto" });
   });
 });

--- a/src/components/calendar/components/current-time-indicator.test.tsx
+++ b/src/components/calendar/components/current-time-indicator.test.tsx
@@ -1,0 +1,44 @@
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { useAutoScrollToMinutes } from "./current-time-indicator";
+
+describe("useAutoScrollToMinutes", () => {
+  it("scrolls to the target row minus a lead offset", () => {
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToMinutes(ref, 180, 52); // 3h after start, 52px rows
+    });
+
+    // (180/60)*52 - 200 = 156 - 200 = -44 -> clamped to 0
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("scrolls to a positive offset for a later target", () => {
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToMinutes(ref, 600, 52); // 10h after start
+    });
+
+    // (600/60)*52 - 200 = 520 - 200 = 320
+    expect(scrollTo).toHaveBeenCalledWith({ top: 320, behavior: "smooth" });
+  });
+
+  it("does nothing when the target is null", () => {
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToMinutes(ref, null, 52);
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/calendar/components/current-time-indicator.tsx
+++ b/src/components/calendar/components/current-time-indicator.tsx
@@ -73,3 +73,25 @@ export function useAutoScrollToNow(
     });
   }, [containerRef, startHour, rowHeight]);
 }
+
+/**
+ * Scroll the grid so a target time is comfortably in view. `targetMinutes` is
+ * minutes from the grid's start hour; pass null to skip (e.g. no events and not
+ * today). Mirrors useAutoScrollToNow's 200px lead but takes an explicit target
+ * so callers can choose "now" or "first event" (spec Section 3, Week auto-scroll).
+ */
+export function useAutoScrollToMinutes(
+  containerRef: React.RefObject<HTMLElement | null>,
+  targetMinutes: number | null,
+  rowHeight = 80,
+) {
+  useEffect(() => {
+    if (!containerRef.current || targetMinutes == null) return;
+
+    const scrollPosition = (targetMinutes / 60) * rowHeight - 200;
+    containerRef.current.scrollTo({
+      top: Math.max(0, scrollPosition),
+      behavior: "smooth",
+    });
+  }, [containerRef, targetMinutes, rowHeight]);
+}

--- a/src/components/calendar/components/current-time-indicator.tsx
+++ b/src/components/calendar/components/current-time-indicator.tsx
@@ -88,10 +88,13 @@ export function useAutoScrollToMinutes(
   useEffect(() => {
     if (!containerRef.current || targetMinutes == null) return;
 
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
     const scrollPosition = (targetMinutes / 60) * rowHeight - 200;
     containerRef.current.scrollTo({
       top: Math.max(0, scrollPosition),
-      behavior: "smooth",
+      behavior: prefersReducedMotion ? "auto" : "smooth",
     });
   }, [containerRef, targetMinutes, rowHeight]);
 }

--- a/src/components/calendar/components/day-mini-month-rail.test.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.test.tsx
@@ -81,6 +81,27 @@ describe("DayMiniMonthRail", () => {
     expect(selected.getDate()).toBe(16);
   });
 
+  it("routes arrow keys from the focused date when focus is not on the selected date", async () => {
+    const onSelectDate = vi.fn();
+    const { user } = renderWithUser(
+      <DayMiniMonthRail
+        currentDate={new Date(2026, 6, 15)}
+        monthEvents={[]}
+        members={members}
+        onSelectDate={onSelectDate}
+      />,
+    );
+
+    screen.getByRole("button", { name: /july 20, 2026/i }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    const selected = onSelectDate.mock.calls[0][0] as Date;
+    expect(selected.getFullYear()).toBe(2026);
+    expect(selected.getMonth()).toBe(6);
+    expect(selected.getDate()).toBe(21);
+  });
+
   it("advances repeatedly from the selected date when arrowing after navigation", async () => {
     const onSelectDate = vi.fn();
 

--- a/src/components/calendar/components/day-mini-month-rail.test.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CalendarEvent, FamilyMember } from "@/lib/types";
+import { render, renderWithUser, screen } from "@/test/test-utils";
+import { DayMiniMonthRail } from "./day-mini-month-rail";
+
+const members: FamilyMember[] = [
+  { id: "m1", name: "Alice", color: "coral" },
+  { id: "m2", name: "Ben", color: "teal" },
+];
+
+const ev = (date: Date, memberId: string, title = "E"): CalendarEvent => ({
+  id: `${memberId}-${date.getDate()}`,
+  title,
+  date,
+  startTime: "9:00 AM",
+  endTime: "10:00 AM",
+  memberId,
+  isAllDay: false,
+  source: "NATIVE",
+});
+
+describe("DayMiniMonthRail", () => {
+  it("renders a labelled month navigator with the selected date pressed", () => {
+    render(
+      <DayMiniMonthRail
+        currentDate={new Date(2026, 6, 15)}
+        monthEvents={[ev(new Date(2026, 6, 6), "m1", "Secret Piano Lesson")]}
+        members={members}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("complementary", { name: /month navigator/i }),
+    ).toBeInTheDocument();
+    const selectedDate = screen.getByRole("button", {
+      name: /july 15, 2026/i,
+    });
+    expect(selectedDate).toHaveAttribute("aria-pressed", "true");
+    expect(screen.queryByText("Secret Piano Lesson")).not.toBeInTheDocument();
+  });
+
+  it("routes a day tap through onSelectDate", async () => {
+    const onSelectDate = vi.fn();
+    const { user } = renderWithUser(
+      <DayMiniMonthRail
+        currentDate={new Date(2026, 6, 15)}
+        monthEvents={[]}
+        members={members}
+        onSelectDate={onSelectDate}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /july 20, 2026/i }));
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    const selected = onSelectDate.mock.calls[0][0] as Date;
+    expect(selected.getFullYear()).toBe(2026);
+    expect(selected.getMonth()).toBe(6);
+    expect(selected.getDate()).toBe(20);
+  });
+});

--- a/src/components/calendar/components/day-mini-month-rail.test.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { CalendarEvent, FamilyMember } from "@/lib/types";
 import { render, renderWithUser, screen } from "@/test/test-utils";
@@ -57,5 +58,57 @@ describe("DayMiniMonthRail", () => {
     expect(selected.getFullYear()).toBe(2026);
     expect(selected.getMonth()).toBe(6);
     expect(selected.getDate()).toBe(20);
+  });
+
+  it("routes arrow keys to adjacent dates", async () => {
+    const onSelectDate = vi.fn();
+    const { user } = renderWithUser(
+      <DayMiniMonthRail
+        currentDate={new Date(2026, 6, 15)}
+        monthEvents={[]}
+        members={members}
+        onSelectDate={onSelectDate}
+      />,
+    );
+
+    screen.getByRole("button", { name: /july 15, 2026/i }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    const selected = onSelectDate.mock.calls[0][0] as Date;
+    expect(selected.getFullYear()).toBe(2026);
+    expect(selected.getMonth()).toBe(6);
+    expect(selected.getDate()).toBe(16);
+  });
+
+  it("advances repeatedly from the selected date when arrowing after navigation", async () => {
+    const onSelectDate = vi.fn();
+
+    function StatefulRail() {
+      const [currentDate, setCurrentDate] = useState(new Date(2026, 6, 15));
+      return (
+        <DayMiniMonthRail
+          currentDate={currentDate}
+          monthEvents={[]}
+          members={members}
+          onSelectDate={(date) => {
+            onSelectDate(date);
+            setCurrentDate(date);
+          }}
+        />
+      );
+    }
+
+    const { user } = renderWithUser(<StatefulRail />);
+
+    screen.getByRole("button", { name: /july 15, 2026/i }).focus();
+    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowRight}");
+
+    expect(onSelectDate).toHaveBeenCalledTimes(2);
+    const secondSelection = onSelectDate.mock.calls[1][0] as Date;
+    expect(secondSelection.getFullYear()).toBe(2026);
+    expect(secondSelection.getMonth()).toBe(6);
+    expect(secondSelection.getDate()).toBe(17);
   });
 });

--- a/src/components/calendar/components/day-mini-month-rail.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import type React from "react";
 import { DAY_INITIALS } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, type FamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -29,6 +30,25 @@ export function DayMiniMonthRail({
   const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
   const isCurrentMonth = (date: Date) =>
     date.getMonth() === currentDate.getMonth();
+  const handleDayKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    const dayOffsetByKey: Record<string, number> = {
+      ArrowLeft: -1,
+      ArrowRight: 1,
+      ArrowUp: -7,
+      ArrowDown: 7,
+    };
+    const offset = dayOffsetByKey[event.key];
+    if (offset === undefined) return;
+
+    event.preventDefault();
+    onSelectDate(
+      new Date(
+        currentDate.getFullYear(),
+        currentDate.getMonth(),
+        currentDate.getDate() + offset,
+      ),
+    );
+  };
 
   return (
     <aside
@@ -61,6 +81,7 @@ export function DayMiniMonthRail({
               aria-pressed={selected}
               aria-label={format(date, "MMMM d, yyyy")}
               onClick={() => onSelectDate(date)}
+              onKeyDown={handleDayKeyDown}
               className={cn(
                 "relative mx-auto flex h-11 w-11 flex-col items-center justify-center rounded-full text-sm transition-colors",
                 !isCurrentMonth(date) && "text-muted-foreground/40",

--- a/src/components/calendar/components/day-mini-month-rail.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.tsx
@@ -1,5 +1,6 @@
 import { format } from "date-fns";
 import type React from "react";
+import { useEffect, useRef } from "react";
 import { DAY_INITIALS } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, type FamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -30,7 +31,20 @@ export function DayMiniMonthRail({
   const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
   const isCurrentMonth = (date: Date) =>
     date.getMonth() === currentDate.getMonth();
-  const handleDayKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+  const focusSelectedAfterKeyboardNav = useRef(false);
+  const selectedDayButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (!focusSelectedAfterKeyboardNav.current) return;
+
+    focusSelectedAfterKeyboardNav.current = false;
+    selectedDayButtonRef.current?.focus();
+  });
+
+  const handleDayKeyDown = (
+    event: React.KeyboardEvent<HTMLButtonElement>,
+    date: Date,
+  ) => {
     const dayOffsetByKey: Record<string, number> = {
       ArrowLeft: -1,
       ArrowRight: 1,
@@ -41,12 +55,9 @@ export function DayMiniMonthRail({
     if (offset === undefined) return;
 
     event.preventDefault();
+    focusSelectedAfterKeyboardNav.current = true;
     onSelectDate(
-      new Date(
-        currentDate.getFullYear(),
-        currentDate.getMonth(),
-        currentDate.getDate() + offset,
-      ),
+      new Date(date.getFullYear(), date.getMonth(), date.getDate() + offset),
     );
   };
 
@@ -77,11 +88,12 @@ export function DayMiniMonthRail({
             <button
               type="button"
               key={date.toDateString()}
+              ref={selected ? selectedDayButtonRef : undefined}
               aria-current={selected ? "date" : undefined}
               aria-pressed={selected}
               aria-label={format(date, "MMMM d, yyyy")}
               onClick={() => onSelectDate(date)}
-              onKeyDown={handleDayKeyDown}
+              onKeyDown={(event) => handleDayKeyDown(event, date)}
               className={cn(
                 "relative mx-auto flex h-11 w-11 flex-col items-center justify-center rounded-full text-sm transition-colors",
                 !isCurrentMonth(date) && "text-muted-foreground/40",

--- a/src/components/calendar/components/day-mini-month-rail.tsx
+++ b/src/components/calendar/components/day-mini-month-rail.tsx
@@ -1,0 +1,93 @@
+import { format } from "date-fns";
+import { DAY_INITIALS } from "@/lib/time-utils";
+import { type CalendarEvent, colorMap, type FamilyMember } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import {
+  buildMonthMatrix,
+  RAIL_WIDTH,
+  selectMonthDayDots,
+} from "../utils/day-rail";
+
+interface DayMiniMonthRailProps {
+  currentDate: Date;
+  monthEvents: CalendarEvent[];
+  members: FamilyMember[];
+  onSelectDate: (date: Date) => void;
+}
+
+export function DayMiniMonthRail({
+  currentDate,
+  monthEvents,
+  members,
+  onSelectDate,
+}: DayMiniMonthRailProps) {
+  const today = new Date();
+  const matrix = buildMonthMatrix(currentDate);
+  const dots = selectMonthDayDots(monthEvents, members);
+  const monthLabel = format(currentDate, "MMMM yyyy");
+
+  const isSameDay = (a: Date, b: Date) => a.toDateString() === b.toDateString();
+  const isCurrentMonth = (date: Date) =>
+    date.getMonth() === currentDate.getMonth();
+
+  return (
+    <aside
+      aria-label="Month navigator"
+      className="shrink-0 border-l border-border bg-card px-3 py-4"
+      style={{ width: RAIL_WIDTH }}
+    >
+      <p className="mb-3 px-1 text-sm font-semibold text-foreground">
+        {monthLabel}
+      </p>
+      <div className="grid grid-cols-7 gap-y-1">
+        {DAY_INITIALS.map((initial, i) => (
+          <div
+            key={`h-${i}`}
+            className="pb-1 text-center text-[10px] font-medium text-muted-foreground"
+          >
+            {initial}
+          </div>
+        ))}
+        {matrix.map((date) => {
+          const dayDots = dots.get(date.toDateString()) ?? [];
+          const selected = isSameDay(date, currentDate);
+          const dayIsToday = isSameDay(date, today);
+
+          return (
+            <button
+              type="button"
+              key={date.toDateString()}
+              aria-current={selected ? "date" : undefined}
+              aria-pressed={selected}
+              aria-label={format(date, "MMMM d, yyyy")}
+              onClick={() => onSelectDate(date)}
+              className={cn(
+                "relative mx-auto flex h-11 w-11 flex-col items-center justify-center rounded-full text-sm transition-colors",
+                !isCurrentMonth(date) && "text-muted-foreground/40",
+                dayIsToday && !selected && "ring-2 ring-primary ring-inset",
+                selected
+                  ? "bg-primary font-bold text-primary-foreground"
+                  : "hover:bg-muted",
+              )}
+            >
+              <span className="tabular-nums">{date.getDate()}</span>
+              <span className="absolute bottom-1 flex gap-0.5">
+                {dayDots.slice(0, 4).map((color, i) => (
+                  <span
+                    key={`${color}-${i}`}
+                    className={cn(
+                      "h-1 w-1 rounded-full",
+                      selected
+                        ? "bg-primary-foreground/80"
+                        : colorMap[color]?.bg,
+                    )}
+                  />
+                ))}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/src/components/calendar/components/day-rail-toggle.test.tsx
+++ b/src/components/calendar/components/day-rail-toggle.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { useCalendarStore } from "@/stores";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { DayRailToggle } from "./day-rail-toggle";
+
+describe("DayRailToggle", () => {
+  it("reflects and flips the persisted rail preference", async () => {
+    useCalendarStore.setState({ dayRailHidden: false });
+    const { user } = renderWithUser(<DayRailToggle />);
+
+    const button = screen.getByRole("button", {
+      name: /hide month navigator/i,
+    });
+    expect(button).toHaveAttribute("aria-pressed", "true");
+
+    await user.click(button);
+
+    expect(useCalendarStore.getState().dayRailHidden).toBe(true);
+    expect(
+      screen.getByRole("button", { name: /show month navigator/i }),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+});

--- a/src/components/calendar/components/day-rail-toggle.tsx
+++ b/src/components/calendar/components/day-rail-toggle.tsx
@@ -1,0 +1,27 @@
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useDayRailState } from "@/stores";
+
+export function DayRailToggle() {
+  const { dayRailHidden, toggleDayRail } = useDayRailState();
+  const Icon = dayRailHidden ? PanelRightOpen : PanelRightClose;
+
+  return (
+    <button
+      type="button"
+      onClick={toggleDayRail}
+      aria-pressed={!dayRailHidden}
+      aria-label={
+        dayRailHidden ? "Show month navigator" : "Hide month navigator"
+      }
+      className={cn(
+        "flex min-h-11 min-w-11 items-center justify-center rounded-full border transition-colors",
+        dayRailHidden
+          ? "border-border bg-muted/50 text-muted-foreground hover:bg-muted"
+          : "border-primary/30 bg-primary/10 text-primary",
+      )}
+    >
+      <Icon className="h-5 w-5" />
+    </button>
+  );
+}

--- a/src/components/calendar/components/index.ts
+++ b/src/components/calendar/components/index.ts
@@ -6,6 +6,8 @@ export { CalendarFilter } from "./calendar-filter";
 export { CalendarNavigation } from "./calendar-navigation";
 export { CalendarViewSwitcher } from "./calendar-view-switcher";
 export { CurrentTimeIndicator } from "./current-time-indicator";
+export { DayMiniMonthRail } from "./day-mini-month-rail";
+export { DayRailToggle } from "./day-rail-toggle";
 export type { EditScope } from "./edit-scope-dialog";
 export { EditScopeDialog } from "./edit-scope-dialog";
 export { EventDetailModal } from "./event-detail-modal";

--- a/src/components/calendar/utils/day-rail.test.ts
+++ b/src/components/calendar/utils/day-rail.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent, FamilyMember } from "@/lib/types";
+import {
+  buildMonthMatrix,
+  MIN_LANE_WIDTH,
+  RAIL_WIDTH,
+  railThresholdPx,
+  selectMonthDayDots,
+} from "./day-rail";
+
+const member = (id: string, color: FamilyMember["color"]): FamilyMember => ({
+  id,
+  name: id.toUpperCase(),
+  color,
+});
+
+const ev = (date: Date, memberId: string): CalendarEvent => ({
+  id: `${memberId}-${date.getDate()}`,
+  title: "E",
+  date,
+  startTime: "9:00 AM",
+  endTime: "10:00 AM",
+  memberId,
+  isAllDay: false,
+  source: "NATIVE",
+});
+
+describe("day-rail math", () => {
+  it("threshold grows with member count and accounts for the desktop nav", () => {
+    expect(railThresholdPx(3)).toBeLessThan(railThresholdPx(6));
+    // 3 comfortable lanes + axis + rail + the 80px desktop nav fit a ~13" laptop
+    // (~1280) but need more than a bare 1024...
+    expect(railThresholdPx(3)).toBeGreaterThan(1024);
+    expect(railThresholdPx(3)).toBeLessThanOrEqual(1120);
+    // ...and 6 lanes must not fit until well past 1440 (rail yields width to lanes).
+    expect(railThresholdPx(6)).toBeGreaterThan(1440);
+  });
+
+  it("uses the documented lane/rail widths", () => {
+    expect(RAIL_WIDTH).toBe(300);
+    expect(MIN_LANE_WIDTH).toBeGreaterThanOrEqual(160);
+  });
+
+  it("builds a 6x7 (or 5x7) month matrix covering the current month", () => {
+    const matrix = buildMonthMatrix(new Date(2026, 6, 15)); // July 2026
+    expect(matrix.length % 7).toBe(0);
+    expect(matrix.some((d) => d.getMonth() === 6 && d.getDate() === 1)).toBe(
+      true,
+    );
+    expect(matrix.some((d) => d.getMonth() === 6 && d.getDate() === 31)).toBe(
+      true,
+    );
+  });
+
+  it("maps each day to its unique member colors (deduped, filtered)", () => {
+    const members = [member("m1", "coral"), member("m2", "teal")];
+    const july6 = new Date(2026, 6, 6);
+    const dots = selectMonthDayDots(
+      [ev(july6, "m1"), ev(july6, "m1"), ev(july6, "m2")],
+      members,
+    );
+    expect(dots.get(july6.toDateString())).toEqual(["coral", "teal"]);
+  });
+});

--- a/src/components/calendar/utils/day-rail.ts
+++ b/src/components/calendar/utils/day-rail.ts
@@ -1,0 +1,87 @@
+import { isEventOnDate } from "@/lib/time-utils";
+import type { CalendarEvent, FamilyColor, FamilyMember } from "@/lib/types";
+
+/** Fixed rail width when shown (spec Section 4.2, ~300px). Tunable in the screenshot gate. */
+export const RAIL_WIDTH = 300;
+/** Minimum comfortable member-lane width before the rail yields its space back. */
+export const MIN_LANE_WIDTH = 190;
+/** Time-axis gutter width (matches the `w-16` axis = 64px). */
+export const TIME_AXIS_WIDTH = 64;
+/**
+ * Persistent desktop module-nav rail (`NavigationTabs`, `w-20` = 80px, rendered
+ * `{!isMobile && <NavigationTabs/>}` in `App.tsx`) sits left of the calendar, so
+ * the calendar's content box is `viewport - 80`. The threshold must include it.
+ */
+export const DESKTOP_NAV_WIDTH = 80;
+/** Slack for lane borders/padding so the threshold is not razor-thin. */
+export const RAIL_LAYOUT_SLACK = 48;
+
+/**
+ * Minimum viewport width at which the mini-month rail can appear for a family
+ * of `memberCount`: desktop nav + time axis + lanes + rail + slack.
+ */
+export function railThresholdPx(memberCount: number): number {
+  return (
+    DESKTOP_NAV_WIDTH +
+    TIME_AXIS_WIDTH +
+    MIN_LANE_WIDTH * Math.max(memberCount, 1) +
+    RAIL_WIDTH +
+    RAIL_LAYOUT_SLACK
+  );
+}
+
+export function buildMonthMatrix(currentDate: Date): Date[] {
+  const year = currentDate.getFullYear();
+  const month = currentDate.getMonth();
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+
+  const result: Date[] = [];
+  const leading = firstDay.getDay();
+  const prevMonthLastDate = new Date(year, month, 0).getDate();
+  for (let i = leading - 1; i >= 0; i--) {
+    result.push(new Date(year, month - 1, prevMonthLastDate - i));
+  }
+  for (let d = 1; d <= lastDay.getDate(); d++) {
+    result.push(new Date(year, month, d));
+  }
+  let nextDay = 1;
+  while (result.length % 7 !== 0) {
+    result.push(new Date(year, month + 1, nextDay++));
+  }
+  return result;
+}
+
+export function selectMonthDayDots(
+  events: CalendarEvent[],
+  members: FamilyMember[],
+): Map<string, FamilyColor[]> {
+  const dayMemberIds = new Map<string, Set<string>>();
+  for (const event of events) {
+    for (const day of uniqueEventDays(event)) {
+      const key = day.toDateString();
+      if (!dayMemberIds.has(key)) dayMemberIds.set(key, new Set());
+      dayMemberIds.get(key)?.add(event.memberId);
+    }
+  }
+
+  const result = new Map<string, FamilyColor[]>();
+  for (const [key, ids] of dayMemberIds) {
+    const colors = members.filter((m) => ids.has(m.id)).map((m) => m.color);
+    if (colors.length > 0) result.set(key, colors);
+  }
+  return result;
+}
+
+function uniqueEventDays(event: CalendarEvent): Date[] {
+  const days: Date[] = [event.date];
+  if (event.endDate) {
+    const cursor = new Date(event.date);
+    cursor.setDate(cursor.getDate() + 1);
+    while (cursor <= event.endDate) {
+      days.push(new Date(cursor));
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+  return days.filter((day) => isEventOnDate(event, day));
+}

--- a/src/components/calendar/utils/hour-grid.test.ts
+++ b/src/components/calendar/utils/hour-grid.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { CALENDAR_START_HOUR } from "@/lib/time-utils";
+import {
+  DEFAULT_HOUR_ROW_HEIGHT,
+  DENSE_HOUR_ROW_HEIGHT,
+  earliestEventStartMinutes,
+  getEventOffsets,
+  hourRowHeightFor,
+  minutesFromStartHour,
+  pxFromOffsets,
+  TIME_SLOTS,
+} from "./hour-grid";
+
+describe("hour-grid geometry", () => {
+  it("exposes the 6 AM-11 PM slot labels", () => {
+    expect(TIME_SLOTS).toHaveLength(18);
+    expect(TIME_SLOTS[0]).toBe("6 AM");
+    expect(TIME_SLOTS.at(-1)).toBe("11 PM");
+  });
+
+  it("picks the dense row height only on large screens", () => {
+    expect(hourRowHeightFor(false)).toBe(DEFAULT_HOUR_ROW_HEIGHT);
+    expect(hourRowHeightFor(true)).toBe(DENSE_HOUR_ROW_HEIGHT);
+    expect(DENSE_HOUR_ROW_HEIGHT).toBeLessThan(DEFAULT_HOUR_ROW_HEIGHT);
+  });
+
+  it("computes event offsets in hours from the start hour", () => {
+    // 9:00 AM-10:30 AM with a 6 AM start hour -> starts 3h in, spans 1.5h
+    expect(getEventOffsets("9:00 AM", "10:30 AM")).toEqual({
+      startOffsetHours: 3,
+      spanHours: 1.5,
+    });
+  });
+
+  it("converts offsets to pixels with a per-row height and a minimum", () => {
+    expect(pxFromOffsets({ startOffsetHours: 3, spanHours: 1 }, 52)).toEqual({
+      top: 156,
+      height: 52,
+    });
+    // A 10-minute event never collapses below the 30px minimum.
+    expect(
+      pxFromOffsets({ startOffsetHours: 0, spanHours: 10 / 60 }, 52).height,
+    ).toBe(30);
+  });
+
+  it("converts a time string to minutes from the start hour", () => {
+    expect(minutesFromStartHour("6:00 AM", CALENDAR_START_HOUR)).toBe(0);
+    expect(minutesFromStartHour("9:30 AM", CALENDAR_START_HOUR)).toBe(210);
+  });
+
+  it("finds the earliest timed-event start, ignoring all-day, or null", () => {
+    const base = {
+      date: new Date(2026, 6, 6),
+      memberId: "m1",
+      isAllDay: false,
+    };
+    expect(
+      earliestEventStartMinutes(
+        [
+          { ...base, startTime: "2:00 PM", endTime: "3:00 PM" },
+          { ...base, startTime: "8:15 AM", endTime: "9:00 AM" },
+          {
+            ...base,
+            isAllDay: true,
+            startTime: "12:00 AM",
+            endTime: "12:00 AM",
+          },
+        ],
+        CALENDAR_START_HOUR,
+      ),
+    ).toBe(135); // 8:15 AM = 2h15m after 6 AM
+    expect(earliestEventStartMinutes([], CALENDAR_START_HOUR)).toBeNull();
+  });
+});

--- a/src/components/calendar/utils/hour-grid.ts
+++ b/src/components/calendar/utils/hour-grid.ts
@@ -1,0 +1,93 @@
+import { CALENDAR_START_HOUR, parseTime } from "@/lib/time-utils";
+import type { CalendarEvent } from "@/lib/types";
+
+/** Desktop hour-row height at tablet widths (768-1023px), matching today's grid. */
+export const DEFAULT_HOUR_ROW_HEIGHT = 80;
+/**
+ * Denser hour-row height applied on lg+ (1024px+). Spec Section 3 calls for 48-56px so
+ * 12-14 hours are visible at 1440x900; tuned during the screenshot gate (Task 8).
+ */
+export const DENSE_HOUR_ROW_HEIGHT = 52;
+
+/** Minimum rendered event height so a short event stays tappable. */
+export const MIN_EVENT_PX = 30;
+
+/** 6 AM-11 PM row labels shared by the Week and Day grids (18 rows). */
+export const TIME_SLOTS = [
+  "6 AM",
+  "7 AM",
+  "8 AM",
+  "9 AM",
+  "10 AM",
+  "11 AM",
+  "12 PM",
+  "1 PM",
+  "2 PM",
+  "3 PM",
+  "4 PM",
+  "5 PM",
+  "6 PM",
+  "7 PM",
+  "8 PM",
+  "9 PM",
+  "10 PM",
+  "11 PM",
+] as const;
+
+/** Row height for the current breakpoint. */
+export function hourRowHeightFor(isLargeScreen: boolean): number {
+  return isLargeScreen ? DENSE_HOUR_ROW_HEIGHT : DEFAULT_HOUR_ROW_HEIGHT;
+}
+
+export interface EventOffsets {
+  startOffsetHours: number;
+  spanHours: number;
+}
+
+/** Offsets (in hours from CALENDAR_START_HOUR) for an event's start and span. */
+export function getEventOffsets(
+  startTime: string,
+  endTime: string,
+): EventOffsets {
+  const start = parseTime(startTime);
+  const end = parseTime(endTime);
+  const startOffsetHours =
+    start.hours - CALENDAR_START_HOUR + start.minutes / 60;
+  const endOffsetHours = end.hours - CALENDAR_START_HOUR + end.minutes / 60;
+  return { startOffsetHours, spanHours: endOffsetHours - startOffsetHours };
+}
+
+/** Absolute top/height in px for the given offsets at a row height. */
+export function pxFromOffsets(
+  { startOffsetHours, spanHours }: EventOffsets,
+  rowHeight: number,
+): { top: number; height: number } {
+  return {
+    top: startOffsetHours * rowHeight,
+    height: Math.max(spanHours * rowHeight, MIN_EVENT_PX),
+  };
+}
+
+/** Minutes from the start hour for a "9:30 AM"-style time string. */
+export function minutesFromStartHour(
+  timeStr: string,
+  startHour: number,
+): number {
+  const { hours, minutes } = parseTime(timeStr);
+  return (hours - startHour) * 60 + minutes;
+}
+
+/**
+ * Earliest timed-event start (minutes from the start hour) across the given
+ * events, ignoring all-day events. Returns null when there are no timed events.
+ */
+export function earliestEventStartMinutes(
+  events: Pick<CalendarEvent, "startTime" | "isAllDay">[],
+  startHour: number,
+): number | null {
+  const timed = events.filter((event) => !event.isAllDay);
+  if (timed.length === 0) return null;
+  return Math.min(
+    ...timed.map((event) => minutesFromStartHour(event.startTime, startHour)),
+  );
+}

--- a/src/components/calendar/views/daily-calendar.tsx
+++ b/src/components/calendar/views/daily-calendar.tsx
@@ -1,12 +1,9 @@
 import { useMemo, useRef } from "react";
 import { useFamilyMembers } from "@/api";
 import {
-  CALENDAR_START_HOUR,
   compareEventsByTime,
   getEventKey,
-  getTimeInMinutes,
   isEventOnDate,
-  parseTime,
 } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -16,6 +13,8 @@ import {
   CurrentTimeIndicator,
   useAutoScrollToNow,
 } from "../components/current-time-indicator";
+import { getEventOffsets, pxFromOffsets, TIME_SLOTS } from "../utils/hour-grid";
+import { calculateEventColumns } from "./day-lane-layout";
 
 interface DailyCalendarProps {
   events: CalendarEvent[];
@@ -24,90 +23,7 @@ interface DailyCalendarProps {
   filter: FilterState;
 }
 
-const START_HOUR = CALENDAR_START_HOUR;
 const ROW_HEIGHT = 80; // px per hour
-
-function getEventGridPosition(startTime: string, endTime: string) {
-  const start = parseTime(startTime);
-  const end = parseTime(endTime);
-
-  // Calculate row index from start hour (6 AM = row 0)
-  const startRow = start.hours - START_HOUR;
-  const startMinuteOffset = start.minutes / 60;
-
-  const endRow = end.hours - START_HOUR;
-  const endMinuteOffset = end.minutes / 60;
-
-  // Calculate top position: row * height + minute offset
-  const top = (startRow + startMinuteOffset) * ROW_HEIGHT;
-  const bottom = (endRow + endMinuteOffset) * ROW_HEIGHT;
-  const height = Math.max(bottom - top, 30); // Minimum 30px height
-
-  return { top, height };
-}
-
-function eventsOverlap(a: CalendarEvent, b: CalendarEvent): boolean {
-  const aStart = getTimeInMinutes(a.startTime);
-  const aEnd = getTimeInMinutes(a.endTime);
-  const bStart = getTimeInMinutes(b.startTime);
-  const bEnd = getTimeInMinutes(b.endTime);
-  return aStart < bEnd && bStart < aEnd;
-}
-
-interface EventWithLayout extends CalendarEvent {
-  column: number;
-  totalColumns: number;
-}
-
-function calculateEventColumns(events: CalendarEvent[]): EventWithLayout[] {
-  if (events.length === 0) return [];
-
-  // Sort by start time, then by duration (longer events first)
-  const sorted = [...events].sort((a, b) => {
-    const aStart = getTimeInMinutes(a.startTime);
-    const bStart = getTimeInMinutes(b.startTime);
-    if (aStart !== bStart) return aStart - bStart;
-
-    const aDuration = getTimeInMinutes(a.endTime) - aStart;
-    const bDuration = getTimeInMinutes(b.endTime) - bStart;
-    return bDuration - aDuration; // Longer events first
-  });
-
-  const result: EventWithLayout[] = [];
-  const columns: CalendarEvent[][] = []; // Each column tracks events in that column
-
-  for (const event of sorted) {
-    // Find the first column where this event doesn't overlap with existing events
-    let assignedColumn = -1;
-    for (let col = 0; col < columns.length; col++) {
-      const hasOverlap = columns[col].some((e) => eventsOverlap(e, event));
-      if (!hasOverlap) {
-        assignedColumn = col;
-        break;
-      }
-    }
-
-    // If no suitable column found, create a new one
-    if (assignedColumn === -1) {
-      assignedColumn = columns.length;
-      columns.push([]);
-    }
-
-    columns[assignedColumn].push(event);
-    result.push({ ...event, column: assignedColumn, totalColumns: 0 }); // totalColumns set later
-  }
-
-  // Now calculate totalColumns for each event based on overlapping events
-  for (const eventWithLayout of result) {
-    // Find all events that overlap with this one
-    const overlapping = result.filter((e) => eventsOverlap(e, eventWithLayout));
-    // Find the max column among overlapping events + 1
-    const maxColumn = Math.max(...overlapping.map((e) => e.column));
-    eventWithLayout.totalColumns = maxColumn + 1;
-  }
-
-  return result;
-}
 
 export function DailyCalendar({
   events,
@@ -153,27 +69,6 @@ export function DailyCalendar({
     () => calculateEventColumns(timedEvents),
     [timedEvents],
   );
-
-  const timeSlots = [
-    "6 AM",
-    "7 AM",
-    "8 AM",
-    "9 AM",
-    "10 AM",
-    "11 AM",
-    "12 PM",
-    "1 PM",
-    "2 PM",
-    "3 PM",
-    "4 PM",
-    "5 PM",
-    "6 PM",
-    "7 PM",
-    "8 PM",
-    "9 PM",
-    "10 PM",
-    "11 PM",
-  ];
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-background">
@@ -243,7 +138,7 @@ export function DailyCalendar({
       <div className="flex-1 flex overflow-y-auto" ref={scrollContainerRef}>
         {/* Time column */}
         <div className="w-12 sm:w-16 shrink-0 bg-card border-r border-border">
-          {timeSlots.map((time, index) => (
+          {TIME_SLOTS.map((time, index) => (
             <div
               key={index}
               className="h-20 flex items-start justify-end pr-2 pt-1 border-b border-border/50"
@@ -263,7 +158,7 @@ export function DailyCalendar({
           )}
         >
           {/* Grid rows */}
-          {timeSlots.map((_, index) => (
+          {TIME_SLOTS.map((_, index) => (
             <div
               key={index}
               className={cn(
@@ -280,9 +175,9 @@ export function DailyCalendar({
           )}
 
           {eventsWithLayout.map((event) => {
-            const { top, height } = getEventGridPosition(
-              event.startTime,
-              event.endTime,
+            const { top, height } = pxFromOffsets(
+              getEventOffsets(event.startTime, event.endTime),
+              ROW_HEIGHT,
             );
             const { column, totalColumns } = event;
 

--- a/src/components/calendar/views/day-lane-layout.test.ts
+++ b/src/components/calendar/views/day-lane-layout.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { CalendarEvent } from "@/lib/types";
+import { calculateEventColumns, eventsOverlap } from "./day-lane-layout";
+
+const ev = (overrides: Partial<CalendarEvent>): CalendarEvent => ({
+  id: overrides.id ?? "e",
+  title: "Event",
+  date: new Date(2026, 6, 6),
+  startTime: "9:00 AM",
+  endTime: "10:00 AM",
+  memberId: "m1",
+  isAllDay: false,
+  source: "NATIVE",
+  ...overrides,
+});
+
+describe("day-lane-layout", () => {
+  it("detects overlapping and non-overlapping events", () => {
+    const a = ev({ startTime: "9:00 AM", endTime: "10:00 AM" });
+    const b = ev({ startTime: "9:30 AM", endTime: "10:30 AM" });
+    const c = ev({ startTime: "10:00 AM", endTime: "11:00 AM" });
+    expect(eventsOverlap(a, b)).toBe(true);
+    expect(eventsOverlap(a, c)).toBe(false); // touching edges do not overlap
+  });
+
+  it("packs non-overlapping events into a single column", () => {
+    const result = calculateEventColumns([
+      ev({ id: "a", startTime: "9:00 AM", endTime: "10:00 AM" }),
+      ev({ id: "b", startTime: "10:00 AM", endTime: "11:00 AM" }),
+    ]);
+    expect(result.map((e) => e.column)).toEqual([0, 0]);
+    expect(result.every((e) => e.totalColumns === 1)).toBe(true);
+  });
+
+  it("assigns overlapping events to separate columns", () => {
+    const result = calculateEventColumns([
+      ev({ id: "a", startTime: "9:00 AM", endTime: "10:30 AM" }),
+      ev({ id: "b", startTime: "9:30 AM", endTime: "10:00 AM" }),
+    ]);
+    expect(result.find((e) => e.id === "a")?.column).toBe(0);
+    expect(result.find((e) => e.id === "b")?.column).toBe(1);
+    expect(result.every((e) => e.totalColumns === 2)).toBe(true);
+  });
+
+  it("returns an empty array for no events", () => {
+    expect(calculateEventColumns([])).toEqual([]);
+  });
+});

--- a/src/components/calendar/views/day-lane-layout.ts
+++ b/src/components/calendar/views/day-lane-layout.ts
@@ -1,0 +1,63 @@
+import { getTimeInMinutes } from "@/lib/time-utils";
+import type { CalendarEvent } from "@/lib/types";
+
+export interface EventWithLayout extends CalendarEvent {
+  column: number;
+  totalColumns: number;
+}
+
+export function eventsOverlap(a: CalendarEvent, b: CalendarEvent): boolean {
+  const aStart = getTimeInMinutes(a.startTime);
+  const aEnd = getTimeInMinutes(a.endTime);
+  const bStart = getTimeInMinutes(b.startTime);
+  const bEnd = getTimeInMinutes(b.endTime);
+  return aStart < bEnd && bStart < aEnd;
+}
+
+/**
+ * Greedy column packing for overlapping timed events. Each event gets the first
+ * column where it does not overlap an existing event; totalColumns is the width
+ * of its overlap cluster. Used by the tablet Day canvas and each member lane.
+ */
+export function calculateEventColumns(
+  events: CalendarEvent[],
+): EventWithLayout[] {
+  if (events.length === 0) return [];
+
+  const sorted = [...events].sort((a, b) => {
+    const aStart = getTimeInMinutes(a.startTime);
+    const bStart = getTimeInMinutes(b.startTime);
+    if (aStart !== bStart) return aStart - bStart;
+    const aDuration = getTimeInMinutes(a.endTime) - aStart;
+    const bDuration = getTimeInMinutes(b.endTime) - bStart;
+    return bDuration - aDuration;
+  });
+
+  const result: EventWithLayout[] = [];
+  const columns: CalendarEvent[][] = [];
+
+  for (const event of sorted) {
+    let assignedColumn = -1;
+    for (let col = 0; col < columns.length; col++) {
+      const hasOverlap = columns[col].some((e) => eventsOverlap(e, event));
+      if (!hasOverlap) {
+        assignedColumn = col;
+        break;
+      }
+    }
+    if (assignedColumn === -1) {
+      assignedColumn = columns.length;
+      columns.push([]);
+    }
+    columns[assignedColumn].push(event);
+    result.push({ ...event, column: assignedColumn, totalColumns: 0 });
+  }
+
+  for (const eventWithLayout of result) {
+    const overlapping = result.filter((e) => eventsOverlap(e, eventWithLayout));
+    const maxColumn = Math.max(...overlapping.map((e) => e.column));
+    eventWithLayout.totalColumns = maxColumn + 1;
+  }
+
+  return result;
+}

--- a/src/components/calendar/views/day-lanes-calendar.test.tsx
+++ b/src/components/calendar/views/day-lanes-calendar.test.tsx
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CalendarEvent, FamilyMember } from "@/lib/types";
+import {
+  render,
+  renderWithUser,
+  screen,
+  seedFamilyStore,
+  within,
+} from "@/test/test-utils";
+import { DayLanesCalendar } from "./day-lanes-calendar";
+
+const members: FamilyMember[] = [
+  { id: "m1", name: "Alice", color: "coral" },
+  { id: "m2", name: "Ben", color: "teal" },
+];
+
+const sixMembers: FamilyMember[] = [
+  { id: "m1", name: "Alice", color: "coral" },
+  { id: "m2", name: "Ben", color: "teal" },
+  { id: "m3", name: "Cara", color: "green" },
+  { id: "m4", name: "Dev", color: "purple" },
+  { id: "m5", name: "Eli", color: "yellow" },
+  { id: "m6", name: "Fran", color: "pink" },
+];
+
+const base = {
+  date: new Date(2026, 6, 6),
+  source: "NATIVE" as const,
+  isAllDay: false,
+};
+
+const events: CalendarEvent[] = [
+  {
+    ...base,
+    id: "a",
+    title: "Swim",
+    startTime: "9:00 AM",
+    endTime: "10:00 AM",
+    memberId: "m1",
+  },
+  {
+    ...base,
+    id: "b",
+    title: "Soccer",
+    startTime: "11:00 AM",
+    endTime: "12:00 PM",
+    memberId: "m2",
+  },
+  {
+    ...base,
+    id: "c",
+    title: "Camp week",
+    startTime: "12:00 AM",
+    endTime: "12:00 AM",
+    memberId: "m1",
+    isAllDay: true,
+  },
+];
+
+const noopFilter = {
+  selectedMembers: ["m1", "m2"],
+  showAllDayEvents: true,
+};
+
+describe("DayLanesCalendar", () => {
+  beforeEach(() => {
+    seedFamilyStore({ name: "Test Family", members });
+  });
+
+  it("renders one labelled lane per member in family order", () => {
+    render(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    const alice = screen.getByRole("group", { name: /alice's schedule/i });
+    const ben = screen.getByRole("group", { name: /ben's schedule/i });
+    expect(alice).toBeInTheDocument();
+    expect(ben).toBeInTheDocument();
+    expect(within(alice).getByText("Swim")).toBeInTheDocument();
+    expect(within(ben).getByText("Soccer")).toBeInTheDocument();
+  });
+
+  it("uses shrinkable lane tracks so six members fit without horizontal scroll", () => {
+    render(
+      <DayLanesCalendar
+        events={[]}
+        currentDate={new Date(2026, 6, 6)}
+        members={sixMembers}
+        filter={{
+          selectedMembers: sixMembers.map((member) => member.id),
+          showAllDayEvents: true,
+        }}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("day-lanes-grid")).toHaveStyle({
+      gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+    });
+  });
+
+  it("positions three overlapping events in distinct visible columns", () => {
+    const overlappingEvents: CalendarEvent[] = [
+      {
+        ...base,
+        id: "overlap-a",
+        title: "Overlap A",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: "m1",
+      },
+      {
+        ...base,
+        id: "overlap-b",
+        title: "Overlap B",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: "m1",
+      },
+      {
+        ...base,
+        id: "overlap-c",
+        title: "Overlap C",
+        startTime: "9:00 AM",
+        endTime: "10:00 AM",
+        memberId: "m1",
+      },
+    ];
+
+    render(
+      <DayLanesCalendar
+        events={overlappingEvents}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    const leftPositions = screen
+      .getAllByTestId("day-lane-event")
+      .map((event) => event.style.left);
+    expect(leftPositions).toContain("calc(0% + 6px)");
+    expect(leftPositions.some((left) => left.startsWith("calc(33.333"))).toBe(
+      true,
+    );
+    expect(leftPositions.some((left) => left.startsWith("calc(66.666"))).toBe(
+      true,
+    );
+  });
+
+  it("renders all-day chips in the band aligned under the owning member", () => {
+    render(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    const band = screen.getByRole("group", { name: /all-day events/i });
+    expect(
+      within(band).getByRole("button", { name: /camp week/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("routes lane event taps through onEventClick", async () => {
+    const onEventClick = vi.fn();
+    const { user } = renderWithUser(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={onEventClick}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText("Swim"));
+    expect(onEventClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "a" }),
+    );
+  });
+
+  it("routes all-day chip taps through onEventClick", async () => {
+    const onEventClick = vi.fn();
+    const { user } = renderWithUser(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={onEventClick}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /camp week/i }));
+    expect(onEventClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "c" }),
+    );
+  });
+
+  it("does not render the rail when showRail is false", () => {
+    render(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("complementary", { name: /month navigator/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/calendar/views/day-lanes-calendar.test.tsx
+++ b/src/components/calendar/views/day-lanes-calendar.test.tsx
@@ -67,6 +67,19 @@ describe("DayLanesCalendar", () => {
     seedFamilyStore({ name: "Test Family", members });
   });
 
+  function mockReducedMotion(matches: boolean) {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  }
+
   it("renders one labelled lane per member in family order", () => {
     render(
       <DayLanesCalendar
@@ -235,5 +248,28 @@ describe("DayLanesCalendar", () => {
     expect(
       screen.queryByRole("complementary", { name: /month navigator/i }),
     ).not.toBeInTheDocument();
+  });
+
+  it("uses instant auto-scroll when reduced motion is requested", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 6, 6, 10, 0, 0));
+    mockReducedMotion(true);
+
+    render(
+      <DayLanesCalendar
+        events={events}
+        currentDate={new Date(2026, 6, 6)}
+        members={members}
+        filter={noopFilter}
+        showRail={false}
+        onEventClick={vi.fn()}
+        onSelectDate={vi.fn()}
+      />,
+    );
+
+    expect(Element.prototype.scrollTo).toHaveBeenCalledWith({
+      top: 8,
+      behavior: "auto",
+    });
   });
 });

--- a/src/components/calendar/views/day-lanes-calendar.tsx
+++ b/src/components/calendar/views/day-lanes-calendar.tsx
@@ -1,9 +1,10 @@
-import { endOfMonth, format, startOfMonth } from "date-fns";
+import { endOfMonth, startOfMonth } from "date-fns";
 import { useMemo, useRef } from "react";
 import { useCalendarEvents } from "@/api";
 import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
+  formatLocalDate,
   getEventKey,
   isEventOnDate,
 } from "@/lib/time-utils";
@@ -13,7 +14,7 @@ import { cn } from "@/lib/utils";
 import { CalendarEventCard } from "../components/calendar-event";
 import {
   CurrentTimeIndicator,
-  useAutoScrollToNow,
+  useAutoScrollToMinutes,
 } from "../components/current-time-indicator";
 import { DayMiniMonthRail } from "../components/day-mini-month-rail";
 import { MemberAvatar } from "../components/member-avatar";
@@ -75,8 +76,8 @@ function DayRailPanel({
 }) {
   const monthRange = useMemo(
     () => ({
-      startDate: format(startOfMonth(currentDate), "yyyy-MM-dd"),
-      endDate: format(endOfMonth(currentDate), "yyyy-MM-dd"),
+      startDate: formatLocalDate(startOfMonth(currentDate)),
+      endDate: formatLocalDate(endOfMonth(currentDate)),
     }),
     [currentDate],
   );
@@ -111,12 +112,16 @@ export function DayLanesCalendar({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const today = isCurrentDay(currentDate);
   const laneTemplate = `repeat(${Math.max(members.length, 1)}, minmax(0, 1fr))`;
+  const autoScrollMinutes = useMemo(() => {
+    if (!today) return null;
+    const now = new Date();
+    return Math.max(
+      0,
+      (now.getHours() - CALENDAR_START_HOUR) * 60 + now.getMinutes(),
+    );
+  }, [today]);
 
-  useAutoScrollToNow(
-    today ? scrollContainerRef : { current: null },
-    CALENDAR_START_HOUR,
-    ROW_HEIGHT,
-  );
+  useAutoScrollToMinutes(scrollContainerRef, autoScrollMinutes, ROW_HEIGHT);
 
   const { timedEventsByMember, allDayEventsByMember } = useMemo(() => {
     const dayEvents = events

--- a/src/components/calendar/views/day-lanes-calendar.tsx
+++ b/src/components/calendar/views/day-lanes-calendar.tsx
@@ -1,0 +1,330 @@
+import { endOfMonth, format, startOfMonth } from "date-fns";
+import { useMemo, useRef } from "react";
+import { useCalendarEvents } from "@/api";
+import {
+  CALENDAR_START_HOUR,
+  compareEventsByTime,
+  getEventKey,
+  isEventOnDate,
+} from "@/lib/time-utils";
+import type { CalendarEvent, FamilyMember, FilterState } from "@/lib/types";
+import { colorMap } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { CalendarEventCard } from "../components/calendar-event";
+import {
+  CurrentTimeIndicator,
+  useAutoScrollToNow,
+} from "../components/current-time-indicator";
+import { DayMiniMonthRail } from "../components/day-mini-month-rail";
+import { MemberAvatar } from "../components/member-avatar";
+import {
+  DENSE_HOUR_ROW_HEIGHT,
+  getEventOffsets,
+  pxFromOffsets,
+  TIME_SLOTS,
+} from "../utils/hour-grid";
+import { calculateEventColumns } from "./day-lane-layout";
+
+interface DayLanesCalendarProps {
+  events: CalendarEvent[];
+  currentDate: Date;
+  members: FamilyMember[];
+  filter: FilterState;
+  showRail: boolean;
+  onEventClick: (event: CalendarEvent) => void;
+  onSelectDate: (date: Date) => void;
+}
+
+const ROW_HEIGHT = DENSE_HOUR_ROW_HEIGHT;
+
+function isCurrentDay(date: Date): boolean {
+  return date.toDateString() === new Date().toDateString();
+}
+
+function groupByMember(events: CalendarEvent[]): Map<string, CalendarEvent[]> {
+  const groups = new Map<string, CalendarEvent[]>();
+  for (const event of events) {
+    const memberEvents = groups.get(event.memberId) ?? [];
+    memberEvents.push(event);
+    groups.set(event.memberId, memberEvents);
+  }
+  return groups;
+}
+
+function eventMatchesFilter(
+  event: CalendarEvent,
+  filter: FilterState,
+  includeAllDay: boolean,
+): boolean {
+  return (
+    filter.selectedMembers.includes(event.memberId) &&
+    (includeAllDay || !event.isAllDay)
+  );
+}
+
+function DayRailPanel({
+  currentDate,
+  members,
+  filter,
+  onSelectDate,
+}: {
+  currentDate: Date;
+  members: FamilyMember[];
+  filter: FilterState;
+  onSelectDate: (date: Date) => void;
+}) {
+  const monthRange = useMemo(
+    () => ({
+      startDate: format(startOfMonth(currentDate), "yyyy-MM-dd"),
+      endDate: format(endOfMonth(currentDate), "yyyy-MM-dd"),
+    }),
+    [currentDate],
+  );
+  const { data } = useCalendarEvents(monthRange);
+  const monthEvents = useMemo(
+    () =>
+      (data?.data ?? []).filter((event) =>
+        eventMatchesFilter(event, filter, filter.showAllDayEvents),
+      ),
+    [data?.data, filter],
+  );
+
+  return (
+    <DayMiniMonthRail
+      currentDate={currentDate}
+      monthEvents={monthEvents}
+      members={members}
+      onSelectDate={onSelectDate}
+    />
+  );
+}
+
+export function DayLanesCalendar({
+  events,
+  currentDate,
+  members,
+  filter,
+  showRail,
+  onEventClick,
+  onSelectDate,
+}: DayLanesCalendarProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const today = isCurrentDay(currentDate);
+  const laneTemplate = `repeat(${Math.max(members.length, 1)}, minmax(0, 1fr))`;
+
+  useAutoScrollToNow(
+    today ? scrollContainerRef : { current: null },
+    CALENDAR_START_HOUR,
+    ROW_HEIGHT,
+  );
+
+  const { timedEventsByMember, allDayEventsByMember } = useMemo(() => {
+    const dayEvents = events
+      .filter(
+        (event) =>
+          isEventOnDate(event, currentDate) &&
+          eventMatchesFilter(event, filter, filter.showAllDayEvents),
+      )
+      .sort(compareEventsByTime);
+
+    return {
+      timedEventsByMember: groupByMember(
+        dayEvents.filter((event) => !event.isAllDay),
+      ),
+      allDayEventsByMember: groupByMember(
+        filter.showAllDayEvents
+          ? dayEvents.filter((event) => event.isAllDay)
+          : [],
+      ),
+    };
+  }, [events, currentDate, filter]);
+
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex shrink-0 border-b border-border bg-card">
+          <div className="w-14 shrink-0 border-r border-border" />
+          <div
+            className="grid min-w-0 flex-1"
+            style={{ gridTemplateColumns: laneTemplate }}
+          >
+            {members.map((member) => {
+              const colors = colorMap[member.color];
+              return (
+                <div
+                  key={member.id}
+                  className="min-w-0 border-r border-border px-3 py-3 last:border-r-0"
+                >
+                  <div className="flex min-w-0 items-center gap-2">
+                    <MemberAvatar
+                      name={member.name}
+                      color={member.color}
+                      size="md"
+                    />
+                    <span className="truncate text-sm font-semibold text-foreground">
+                      {member.name}
+                    </span>
+                  </div>
+                  <div
+                    className={cn("mt-2 h-1 rounded-full", colors.bg)}
+                    aria-hidden="true"
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {filter.showAllDayEvents && (
+          <fieldset
+            aria-label="All-day events"
+            className="m-0 flex shrink-0 border-0 border-b border-border bg-card p-0"
+          >
+            <div className="flex w-14 shrink-0 items-center justify-end border-r border-border pr-2">
+              <span className="text-[11px] font-medium text-muted-foreground">
+                All Day
+              </span>
+            </div>
+            <div
+              className="grid min-w-0 flex-1"
+              style={{ gridTemplateColumns: laneTemplate }}
+            >
+              {members.map((member) => (
+                <div
+                  key={member.id}
+                  className="min-h-12 min-w-0 border-r border-border p-2 last:border-r-0"
+                >
+                  <div className="flex flex-wrap gap-1.5">
+                    {(allDayEventsByMember.get(member.id) ?? []).map(
+                      (event) => {
+                        const colors = colorMap[member.color];
+                        return (
+                          <button
+                            type="button"
+                            key={getEventKey(event)}
+                            onClick={() => onEventClick(event)}
+                            title={event.title}
+                            aria-label={`${event.title} - All day event`}
+                            className={cn(
+                              "max-w-full truncate rounded-full px-2.5 py-1 text-xs font-medium text-white transition-all hover:scale-105 hover:shadow-sm",
+                              colors.bg,
+                            )}
+                          >
+                            {event.title}
+                          </button>
+                        );
+                      },
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </fieldset>
+        )}
+
+        <div
+          className="flex min-h-0 flex-1 overflow-y-auto"
+          ref={scrollContainerRef}
+        >
+          <div className="w-14 shrink-0 border-r border-border bg-card">
+            {TIME_SLOTS.map((time) => (
+              <div
+                key={time}
+                className="flex items-start justify-end border-b border-border/50 pr-2 pt-1"
+                style={{ height: ROW_HEIGHT }}
+              >
+                <span className="text-xs font-semibold text-foreground/70">
+                  {time}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div
+            data-testid="day-lanes-grid"
+            className={cn(
+              "relative grid min-w-0 flex-1",
+              today && "bg-primary/5",
+            )}
+            style={{ gridTemplateColumns: laneTemplate }}
+          >
+            {members.map((member) => {
+              const memberEvents = timedEventsByMember.get(member.id) ?? [];
+              const eventsWithLayout = calculateEventColumns(memberEvents);
+
+              return (
+                <fieldset
+                  key={member.id}
+                  aria-label={`${member.name}'s schedule`}
+                  className="relative m-0 min-w-0 border-0 border-r border-border p-0 last:border-r-0"
+                >
+                  {TIME_SLOTS.map((time, index) => (
+                    <div
+                      key={time}
+                      className={cn(
+                        "border-b border-border/50",
+                        index % 2 === 0 && "bg-muted/30",
+                      )}
+                      style={{ height: ROW_HEIGHT }}
+                    />
+                  ))}
+
+                  {eventsWithLayout.map((event) => {
+                    const { top, height } = pxFromOffsets(
+                      getEventOffsets(event.startTime, event.endTime),
+                      ROW_HEIGHT,
+                    );
+                    const effectiveColumns = Math.min(event.totalColumns, 3);
+                    const columnWidth = 100 / effectiveColumns;
+                    const visibleColumn = Math.min(event.column, 2);
+                    const left = visibleColumn * columnWidth;
+                    const variant =
+                      event.totalColumns >= 3 ? "compact" : "default";
+
+                    return (
+                      <div
+                        key={getEventKey(event)}
+                        data-testid="day-lane-event"
+                        className="absolute overflow-hidden rounded-xl"
+                        style={{
+                          top,
+                          height,
+                          left: `calc(${left}% + 6px)`,
+                          width: `calc(${columnWidth}% - 10px)`,
+                        }}
+                      >
+                        <CalendarEventCard
+                          event={event}
+                          onClick={() => onEventClick(event)}
+                          variant={variant}
+                        />
+                      </div>
+                    );
+                  })}
+                </fieldset>
+              );
+            })}
+
+            {today && (
+              <div className="pointer-events-none absolute inset-0">
+                <CurrentTimeIndicator
+                  startHour={CALENDAR_START_HOUR}
+                  rowHeight={ROW_HEIGHT}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {showRail && (
+        <DayRailPanel
+          currentDate={currentDate}
+          members={members}
+          filter={filter}
+          onSelectDate={onSelectDate}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/calendar/views/index.ts
+++ b/src/components/calendar/views/index.ts
@@ -1,4 +1,5 @@
 export { DailyCalendar } from "./daily-calendar";
+export { DayLanesCalendar } from "./day-lanes-calendar";
 export * from "./mobile";
 export { MonthlyCalendar } from "./monthly-calendar";
 export { ScheduleCalendar } from "./schedule-calendar";

--- a/src/components/calendar/views/weekly-calendar.tsx
+++ b/src/components/calendar/views/weekly-calendar.tsx
@@ -1,11 +1,11 @@
 import { useMemo, useRef } from "react";
 import { useFamilyMembers } from "@/api";
+import { useIsLargeScreen } from "@/hooks";
 import {
   CALENDAR_START_HOUR,
   compareEventsByTime,
   getEventKey,
   isEventOnDate,
-  parseTime,
 } from "@/lib/time-utils";
 import { type CalendarEvent, colorMap, getFamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -13,8 +13,15 @@ import { CalendarEventCard } from "../components/calendar-event";
 import type { FilterState } from "../components/calendar-filter";
 import {
   CurrentTimeIndicator,
-  useAutoScrollToNow,
+  useAutoScrollToMinutes,
 } from "../components/current-time-indicator";
+import {
+  earliestEventStartMinutes,
+  getEventOffsets,
+  hourRowHeightFor,
+  pxFromOffsets,
+  TIME_SLOTS,
+} from "../utils/hour-grid";
 
 interface WeeklyCalendarProps {
   events: CalendarEvent[];
@@ -23,21 +30,7 @@ interface WeeklyCalendarProps {
   filter: FilterState;
 }
 
-const ROW_HEIGHT = 80; // px per hour
 const START_HOUR = CALENDAR_START_HOUR;
-
-function getEventPosition(startTime: string, endTime: string) {
-  const start = parseTime(startTime);
-  const end = parseTime(endTime);
-
-  const startOffset = start.hours - START_HOUR + start.minutes / 60;
-  const endOffset = end.hours - START_HOUR + end.minutes / 60;
-
-  const top = startOffset * ROW_HEIGHT;
-  const height = Math.max((endOffset - startOffset) * ROW_HEIGHT, 30); // Minimum 30px
-
-  return { top, height };
-}
 
 export function WeeklyCalendar({
   events,
@@ -48,8 +41,8 @@ export function WeeklyCalendar({
   const familyMembers = useFamilyMembers();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const today = new Date();
-
-  useAutoScrollToNow(scrollContainerRef);
+  const isLargeScreen = useIsLargeScreen();
+  const rowHeight = hourRowHeightFor(isLargeScreen);
 
   // Memoize week days calculation
   const weekDays = useMemo(() => {
@@ -114,14 +107,6 @@ export function WeeklyCalendar({
     };
   }, [events, weekDays, filter.selectedMembers, filter.showAllDayEvents]);
 
-  const formatDayName = (date: Date) => {
-    return date.toLocaleDateString("en-US", { weekday: "short" });
-  };
-
-  const formatDayNumber = (date: Date) => {
-    return date.getDate();
-  };
-
   const isToday = (date: Date) => {
     return date.toDateString() === today.toDateString();
   };
@@ -135,26 +120,22 @@ export function WeeklyCalendar({
     return allDayByDay.get(date.toDateString()) ?? [];
   };
 
-  const timeSlots = [
-    "6 AM",
-    "7 AM",
-    "8 AM",
-    "9 AM",
-    "10 AM",
-    "11 AM",
-    "12 PM",
-    "1 PM",
-    "2 PM",
-    "3 PM",
-    "4 PM",
-    "5 PM",
-    "6 PM",
-    "7 PM",
-    "8 PM",
-    "9 PM",
-    "10 PM",
-    "11 PM",
-  ];
+  const isTodayInWeek = weekDays.some((date) => isToday(date));
+
+  // Auto-scroll target (minutes from START_HOUR): now when today is in the
+  // visible week, otherwise the earliest timed event across the week (spec Section 3).
+  const autoScrollMinutes = useMemo(() => {
+    if (!isLargeScreen || isTodayInWeek) {
+      const now = new Date();
+      return (now.getHours() - START_HOUR) * 60 + now.getMinutes();
+    }
+    const weekTimedEvents = weekDays.flatMap(
+      (date) => timedByDay.get(date.toDateString()) ?? [],
+    );
+    return earliestEventStartMinutes(weekTimedEvents, START_HOUR);
+  }, [isLargeScreen, isTodayInWeek, weekDays, timedByDay]);
+
+  useAutoScrollToMinutes(scrollContainerRef, autoScrollMinutes, rowHeight);
 
   const gridTemplateColumns = "4rem repeat(7, minmax(0, 1fr))";
 
@@ -167,57 +148,111 @@ export function WeeklyCalendar({
       >
         {/* Time column spacer */}
         <div className="border-r border-border" />
-        {weekDays.map((date, index) => (
-          <div
-            key={index}
-            className={cn(
-              "text-center py-3 border-l border-border relative",
-              isToday(date) && "bg-primary/10",
-            )}
-          >
+        {weekDays.map((date, index) => {
+          const dayIsToday = isToday(date);
+          const busyMembers = familyMembers.filter(
+            (member) =>
+              getEventsForDay(date).some((e) => e.memberId === member.id) ||
+              getAllDayEventsForDay(date).some((e) => e.memberId === member.id),
+          );
+
+          if (!isLargeScreen) {
+            return (
+              <div
+                key={index}
+                className={cn(
+                  "text-center py-3 border-l border-border relative",
+                  dayIsToday && "bg-primary/10",
+                )}
+              >
+                <div
+                  className={cn(
+                    "text-sm font-medium",
+                    dayIsToday ? "text-primary" : "text-muted-foreground",
+                  )}
+                >
+                  {date.toLocaleDateString("en-US", { weekday: "short" })}
+                </div>
+                <div
+                  className={cn(
+                    "text-2xl font-bold mt-1",
+                    dayIsToday
+                      ? "text-primary-foreground bg-primary w-10 h-10 rounded-full flex items-center justify-center mx-auto"
+                      : "text-foreground",
+                  )}
+                >
+                  {date.getDate()}
+                </div>
+                {dayIsToday && (
+                  <span className="inline-block mt-2 px-2 py-0.5 bg-primary/20 text-primary text-[10px] font-bold rounded-full">
+                    TODAY
+                  </span>
+                )}
+                <div className="flex justify-center gap-1 mt-1.5">
+                  {familyMembers.slice(0, 4).map((member) => {
+                    const hasEvent =
+                      getEventsForDay(date).some(
+                        (e) => e.memberId === member.id,
+                      ) ||
+                      getAllDayEventsForDay(date).some(
+                        (e) => e.memberId === member.id,
+                      );
+                    return hasEvent ? (
+                      <div
+                        key={member.id}
+                        className={cn(
+                          "w-2 h-2 rounded-full",
+                          colorMap[member.color]?.bg,
+                        )}
+                      />
+                    ) : null;
+                  })}
+                </div>
+              </div>
+            );
+          }
+
+          return (
             <div
+              key={index}
               className={cn(
-                "text-sm font-medium",
-                isToday(date) ? "text-primary" : "text-muted-foreground",
+                "flex items-center justify-center gap-2 border-l border-border px-2 py-2",
+                dayIsToday && "bg-primary/10",
               )}
             >
-              {formatDayName(date)}
-            </div>
-            <div
-              className={cn(
-                "text-2xl font-bold mt-1",
-                isToday(date)
-                  ? "text-primary-foreground bg-primary w-10 h-10 rounded-full flex items-center justify-center mx-auto"
-                  : "text-foreground",
-              )}
-            >
-              {formatDayNumber(date)}
-            </div>
-            {isToday(date) && (
-              <span className="inline-block mt-2 px-2 py-0.5 bg-primary/20 text-primary text-[10px] font-bold rounded-full">
-                TODAY
+              <span
+                className={cn(
+                  "text-xs font-medium uppercase tracking-wide",
+                  dayIsToday ? "text-primary" : "text-muted-foreground",
+                )}
+              >
+                {date.toLocaleDateString("en-US", { weekday: "short" })}
               </span>
-            )}
-            <div className="flex justify-center gap-1 mt-1.5">
-              {familyMembers.slice(0, 4).map((member) => {
-                const hasEvent =
-                  getEventsForDay(date).some((e) => e.memberId === member.id) ||
-                  getAllDayEventsForDay(date).some(
-                    (e) => e.memberId === member.id,
-                  );
-                return hasEvent ? (
-                  <div
+              <span
+                className={cn(
+                  "flex h-7 min-w-7 items-center justify-center rounded-full px-1 text-sm font-bold tabular-nums",
+                  dayIsToday
+                    ? "bg-primary text-primary-foreground"
+                    : "text-foreground",
+                )}
+              >
+                {date.getDate()}
+              </span>
+              <span className="flex items-center gap-0.5">
+                {busyMembers.slice(0, 4).map((member) => (
+                  <span
                     key={member.id}
                     className={cn(
-                      "w-2 h-2 rounded-full",
+                      "h-1.5 w-1.5 rounded-full",
                       colorMap[member.color]?.bg,
                     )}
+                    title={member.name}
                   />
-                ) : null;
-              })}
+                ))}
+              </span>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
 
       {/* All-day events row */}
@@ -275,10 +310,11 @@ export function WeeklyCalendar({
           <div className="grid min-h-full" style={{ gridTemplateColumns }}>
             {/* Time column */}
             <div className="bg-card border-r border-border">
-              {timeSlots.map((time, index) => (
+              {TIME_SLOTS.map((time, index) => (
                 <div
                   key={index}
-                  className="h-20 flex items-start justify-end pr-2 pt-1 border-b border-border/50"
+                  className="flex items-start justify-end pr-2 pt-1 border-b border-border/50"
+                  style={{ height: rowHeight }}
                 >
                   <span className="text-xs text-foreground/70 font-semibold">
                     {time}
@@ -300,23 +336,26 @@ export function WeeklyCalendar({
                     isTodayColumn && "bg-primary/5",
                   )}
                 >
-                  {timeSlots.map((_, index) => (
+                  {TIME_SLOTS.map((_, index) => (
                     <div
                       key={index}
                       className={cn(
-                        "h-20 border-b border-border/50",
+                        "border-b border-border/50",
                         index % 2 === 0 && !isTodayColumn && "bg-muted/20",
                       )}
+                      style={{ height: rowHeight }}
                     />
                   ))}
 
-                  {isTodayColumn && <CurrentTimeIndicator />}
+                  {isTodayColumn && (
+                    <CurrentTimeIndicator rowHeight={rowHeight} />
+                  )}
 
                   <div className="absolute inset-0 px-0.5">
                     {dayEvents.map((event) => {
-                      const { top, height } = getEventPosition(
-                        event.startTime,
-                        event.endTime,
+                      const { top, height } = pxFromOffsets(
+                        getEventOffsets(event.startTime, event.endTime),
+                        rowHeight,
                       );
                       return (
                         <div

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,10 @@ export { useBackHandler } from "./use-back-handler";
 export { useDebounce } from "./use-debounce";
 export { useGoogleAuthReturn } from "./use-google-auth-return";
 export { useInstallPrompt } from "./use-install-prompt";
+export {
+  LARGE_SCREEN_BREAKPOINT,
+  useIsLargeScreen,
+} from "./use-is-large-screen";
 export { useIsMobile } from "./use-is-mobile";
 export {
   LARGE_SCREEN_HOME_IDLE_MS,

--- a/src/hooks/use-is-large-screen.test.tsx
+++ b/src/hooks/use-is-large-screen.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIsLargeScreen } from "./use-is-large-screen";
+
+function mockMatchMedia(matches: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe("useIsLargeScreen", () => {
+  beforeEach(() => {
+    // afterEach clears call data but not the impl; set it explicitly each test.
+    mockMatchMedia(false);
+  });
+
+  it("is false below the lg breakpoint", () => {
+    mockMatchMedia(false);
+    const { result } = renderHook(() => useIsLargeScreen());
+    expect(result.current).toBe(false);
+  });
+
+  it("is true at lg and above", () => {
+    mockMatchMedia(true);
+    const { result } = renderHook(() => useIsLargeScreen());
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/hooks/use-is-large-screen.ts
+++ b/src/hooks/use-is-large-screen.ts
@@ -1,0 +1,13 @@
+import { useMediaQuery } from "./use-media-query";
+
+/** Tailwind `lg` breakpoint - the large-screen calendar boundary (spec Scope). */
+export const LARGE_SCREEN_BREAKPOINT = 1024;
+
+/**
+ * True when the viewport is at least the `lg` breakpoint (1024px). Drives the
+ * denser Week rows and the Day member-lanes layout; below this the calendar
+ * keeps its current desktop/tablet rendering.
+ */
+export function useIsLargeScreen(): boolean {
+  return useMediaQuery(`(min-width: ${LARGE_SCREEN_BREAKPOINT}px)`);
+}

--- a/src/stores/calendar-store.test.ts
+++ b/src/stores/calendar-store.test.ts
@@ -41,6 +41,10 @@ describe("CalendarStore", () => {
       expect(useCalendarStore.getState().hasUserSetView).toBe(false);
     });
 
+    it("initializes day rail hidden preference as false", () => {
+      expect(useCalendarStore.getState().dayRailHidden).toBe(false);
+    });
+
     it("initializes with empty selectedMembers", () => {
       expect(useCalendarStore.getState().filter.selectedMembers).toEqual([]);
     });
@@ -636,6 +640,18 @@ describe("CalendarStore", () => {
     });
   });
 
+  describe("day rail", () => {
+    it("toggles day rail hidden from false to true to false", () => {
+      expect(useCalendarStore.getState().dayRailHidden).toBe(false);
+
+      useCalendarStore.getState().toggleDayRail();
+      expect(useCalendarStore.getState().dayRailHidden).toBe(true);
+
+      useCalendarStore.getState().toggleDayRail();
+      expect(useCalendarStore.getState().dayRailHidden).toBe(false);
+    });
+  });
+
   describe("add event modal", () => {
     it("openAddEventModal sets isAddEventModalOpen to true", () => {
       useCalendarStore.getState().openAddEventModal();
@@ -915,6 +931,14 @@ describe("CalendarStore", () => {
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
 
       expect(stored.state?.hasUserSetView).toBe(true);
+    });
+
+    it("persists day rail hidden preference to localStorage", () => {
+      useCalendarStore.getState().toggleDayRail();
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+
+      expect(stored.state?.dayRailHidden).toBe(true);
     });
 
     it("does NOT persist currentDate", () => {

--- a/src/stores/calendar-store.ts
+++ b/src/stores/calendar-store.ts
@@ -11,6 +11,9 @@ interface CalendarState {
   hasUserSetView: boolean; // Track if user explicitly changed view (for smart defaulting)
   filter: FilterState;
   isAddEventModalOpen: boolean;
+  /** User preference: hide the Day view mini-month rail even when it would fit. */
+  dayRailHidden: boolean;
+  toggleDayRail: () => void;
   addEventDefaults: Partial<EventFormData> | null;
 
   // Event detail modal state
@@ -63,6 +66,7 @@ export const useCalendarStore = create<CalendarState>()(
         showAllDayEvents: true,
       },
       isAddEventModalOpen: false,
+      dayRailHidden: false,
       addEventDefaults: null,
 
       // Event detail modal state
@@ -169,6 +173,9 @@ export const useCalendarStore = create<CalendarState>()(
       // Filter actions
       setFilter: (filter) => set({ filter }),
 
+      toggleDayRail: () =>
+        set((state) => ({ dayRailHidden: !state.dayRailHidden })),
+
       toggleMember: (memberId) => {
         const { filter } = get();
         const isSelected = filter.selectedMembers.includes(memberId);
@@ -237,6 +244,7 @@ export const useCalendarStore = create<CalendarState>()(
         filter: state.filter,
         calendarView: state.calendarView,
         hasUserSetView: state.hasUserSetView,
+        dayRailHidden: state.dayRailHidden,
       }),
     },
   ),
@@ -272,6 +280,14 @@ export const useIsViewingToday = () =>
         return true;
     }
   });
+
+export const useDayRailState = () =>
+  useCalendarStore(
+    useShallow((state) => ({
+      dayRailHidden: state.dayRailHidden,
+      toggleDayRail: state.toggleDayRail,
+    })),
+  );
 
 /**
  * Compound selector for calendar state.

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -20,6 +20,7 @@ export {
   useCalendarActions,
   useCalendarState,
   useCalendarStore,
+  useDayRailState,
   useEditModalState,
   useEventDetailState,
   useFilterPillsState,

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -88,6 +88,7 @@ function resetAllStores(): void {
     hasUserSetView: false,
     filter: { selectedMembers: [], showAllDayEvents: true },
     isAddEventModalOpen: false,
+    dayRailHidden: false,
     addEventDefaults: null,
     selectedEvent: null,
     isDetailModalOpen: false,

--- a/src/test/test-utils.tsx
+++ b/src/test/test-utils.tsx
@@ -238,6 +238,7 @@ export function seedCalendarStore(data: {
   hasUserSetView?: boolean;
   filter?: Partial<FilterState>;
   isAddEventModalOpen?: boolean;
+  dayRailHidden?: boolean;
   selectedEvent?: CalendarEvent | null;
   isDetailModalOpen?: boolean;
   editingEvent?: CalendarEvent | null;
@@ -263,6 +264,9 @@ export function seedCalendarStore(data: {
     ...(data.isAddEventModalOpen !== undefined && {
       isAddEventModalOpen: data.isAddEventModalOpen,
     }),
+    ...(data.dayRailHidden !== undefined && {
+      dayRailHidden: data.dayRailHidden,
+    }),
     ...(data.selectedEvent !== undefined && {
       selectedEvent: data.selectedEvent,
     }),
@@ -287,6 +291,7 @@ export function resetCalendarStore(): void {
     hasUserSetView: false,
     filter: { selectedMembers: [], showAllDayEvents: true },
     isAddEventModalOpen: false,
+    dayRailHidden: false,
     selectedEvent: null,
     isDetailModalOpen: false,
     editingEvent: null,


### PR DESCRIPTION
## Summary
- Densify the lg+ Week view with one-line day headers, shared hour-grid geometry, and now-or-first-event auto-scroll behavior.
- Add lg+ Day member lanes with per-member headers, aligned all-day chips, preserved within-lane overlap behavior, and no synthetic Everyone lane.
- Add the optional lg+ day mini-month rail with pure width/member threshold math, persisted toolbar toggle, and tap-to-navigate behavior.
- Preserve mobile calendar rendering, 768-1023px tablet Day/Week rendering, and Home -> Calendar event tap-through behavior.

## Links
- Story: https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-calendar.md
- Spec: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-06-large-screen-calendar-design.md
- Plan: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-07-06-large-screen-calendar.md

## Verification
- `npm run build` - exit 0
- `npm run lint` - exit 0, existing Biome schema/deprecation infos only
- `npm test -- --run` - 155 files / 1530 tests passed
- Real-backend screenshot matrix captured locally under `/Users/joe.bor/.codex/visualizations/2026/07/09/019f4835-408a-7053-9c31-ba3fbf602d91/large-screen-calendar/evidence.json`
- Mobile 375px comparison against `origin/main` was byte-identical after matching font loading: `92bce8b23a5e200f0a22ce3ddfc113820ce254b4afcc4076f8e9005aeaf5362f`

## Screenshot Matrix Captured
- Busy week: 1024, 1440, 1920
- Sparse week with no today: 1440
- 3-member day with rail: 1440, 1920
- 3-member day without rail at constrained width: 1024
- 6-member day without rail: 1024, 1440
- Persisted rail hidden state
- Long event titles
- Mobile week: 375
- Tablet day: 900

## Review Follow-up
- Fixed PR review finding in `9001a27`: mini-month arrow-key navigation now derives from the focused day and keeps focus aligned with keyboard-selected dates.

## Notes
- Screenshots are captured as local Codex artifacts; the GitHub connector used to create this PR does not expose binary upload/attachment support.
- Backend stack was torn down after screenshot capture with `docker compose -f docker-compose.e2e.yml down`.