### PR TITLE
feat(meals): deliver large-screen full-width week board

### DIFF
--- a/e2e/large-screen-meals.spec.ts
+++ b/e2e/large-screen-meals.spec.ts
@@ -1,0 +1,404 @@
+import {
+  type APIRequestContext,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import { formatLocalDate, getWeekStartSunday } from "../src/lib/time-utils";
+import {
+  createRecipe,
+  registerFamily,
+  seedBrowserAuth,
+  upsertMealSlot,
+} from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+const FIXED_NOW = new Date(2026, 6, 5, 8, 0, 0);
+const ACCEPTANCE_WIDTHS = [1024, 1280, 1440, 1920];
+const SCREENSHOT_WIDTHS = [1024, 1440, 1920];
+const MEAL_TYPES = ["breakfast", "lunch", "dinner"] as const;
+
+function currentWeekStart() {
+  return formatLocalDate(getWeekStartSunday(FIXED_NOW));
+}
+
+function titleFor(mealType: (typeof MEAL_TYPES)[number], dayIndex: number) {
+  return `${mealType} meal ${dayIndex + 1}`;
+}
+
+async function openMealsBoard(page: Page) {
+  const nav = page.getByRole("navigation", { name: "Primary" });
+  await safeClick(nav.getByRole("button", { name: "Meals", exact: true }));
+  await expect(
+    page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+  ).toBeVisible();
+  await expect(page.getByRole("table", { name: "Weekly meals" })).toBeVisible();
+}
+
+async function seedFilledWeek(
+  request: APIRequestContext,
+  token: string,
+  title = titleFor,
+) {
+  const weekStartDate = currentWeekStart();
+
+  for (let dayIndex = 0; dayIndex < 7; dayIndex += 1) {
+    for (const mealType of MEAL_TYPES) {
+      await upsertMealSlot(request, token, {
+        weekStartDate,
+        dayIndex,
+        mealType,
+        primary: {
+          sourceType: "quick",
+          recipeId: null,
+          title: title(mealType, dayIndex),
+          imageUrl: null,
+          note: null,
+        },
+        extras: [],
+        note: null,
+        collisionMode: null,
+      });
+    }
+  }
+}
+
+async function authenticateAndOpenMeals(
+  page: Page,
+  registration: Awaited<ReturnType<typeof registerFamily>>,
+) {
+  await clearStorage(page);
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        const request = indexedDB.open("family-hub-offline");
+        request.onerror = () => resolve();
+        request.onupgradeneeded = () => resolve();
+        request.onsuccess = () => {
+          try {
+            const transaction = request.result.transaction(
+              "query-cache",
+              "readwrite",
+            );
+            transaction.objectStore("query-cache").clear();
+            transaction.oncomplete = () => resolve();
+            transaction.onerror = () => resolve();
+          } catch {
+            resolve();
+          }
+        };
+      }),
+  );
+  await seedBrowserAuth(page, registration);
+  await page.reload();
+  await waitForHydration(page);
+  await openMealsBoard(page);
+}
+
+async function attachBoardScreenshot(page: Page, name: string, width: number) {
+  await page.setViewportSize({
+    width,
+    height: width === 1024 ? 768 : 900,
+  });
+  const table = page.getByRole("table", { name: "Weekly meals" });
+  await expect(table).toBeVisible();
+  const section = page.locator("section", { has: table });
+  await expect(section).toBeVisible();
+  await page.evaluate(() =>
+    Promise.all(
+      document
+        .getAnimations({ subtree: true })
+        .map((animation) => animation.finished.catch(() => undefined)),
+    ).then(() => undefined),
+  );
+  await test.info().attach(`${name}-${width}`, {
+    body: await section.screenshot(),
+    contentType: "image/png",
+  });
+}
+
+test.describe("Large-screen Meals", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(isMobile, "Large-screen only");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.clock.setFixedTime(FIXED_NOW);
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("keeps the current empty week inside the viewport at all accepted widths", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+    await page.setViewportSize({ width: ACCEPTANCE_WIDTHS[0], height: 768 });
+
+    const registration = await registerFamily(request, {
+      familyName: "Large Meals Geometry",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await authenticateAndOpenMeals(page, registration);
+    const table = page.getByRole("table", { name: "Weekly meals" });
+
+    for (const width of ACCEPTANCE_WIDTHS) {
+      await page.setViewportSize({ width, height: width === 1024 ? 768 : 900 });
+      await expect(table).toBeVisible();
+      await expect(table.getByRole("columnheader")).toHaveCount(8);
+      await expect(table.getByRole("rowheader")).toHaveCount(3);
+      await expect(
+        table.locator('th[scope="col"][aria-current="date"]'),
+      ).toHaveCount(1);
+
+      const geometry = await table.evaluate((element) => {
+        const scroller = element.parentElement;
+        const tableBox = element.getBoundingClientRect();
+        const root = document.documentElement;
+
+        return {
+          tableRight: tableBox.right,
+          viewportWidth: window.innerWidth,
+          scrollerClientWidth: scroller?.clientWidth ?? 0,
+          scrollerScrollWidth: scroller?.scrollWidth ?? 0,
+          documentClientWidth: root.clientWidth,
+          documentScrollWidth: root.scrollWidth,
+        };
+      });
+
+      expect(geometry.scrollerScrollWidth).toBeLessThanOrEqual(
+        geometry.scrollerClientWidth + 1,
+      );
+      expect(geometry.documentScrollWidth).toBeLessThanOrEqual(
+        geometry.documentClientWidth + 1,
+      );
+      expect(geometry.tableRight).toBeLessThanOrEqual(
+        geometry.viewportWidth + 1,
+      );
+    }
+
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const compactTableBox = await table.boundingBox();
+    expect(compactTableBox).not.toBeNull();
+    expect(compactTableBox!.y + compactTableBox!.height).toBeLessThanOrEqual(
+      768,
+    );
+
+    await page.setViewportSize({ width: 1920, height: 900 });
+    const wideTableBox = await table.boundingBox();
+    const sectionBox = await page
+      .locator("section", { has: table })
+      .boundingBox();
+    expect(wideTableBox).not.toBeNull();
+    expect(sectionBox).not.toBeNull();
+    expect(wideTableBox!.width).toBeLessThanOrEqual(1600);
+    expect(
+      Math.abs(
+        wideTableBox!.x -
+          sectionBox!.x -
+          (sectionBox!.width -
+            wideTableBox!.width -
+            (wideTableBox!.x - sectionBox!.x)),
+      ),
+    ).toBeLessThanOrEqual(1);
+  });
+
+  test("keeps the day-card actions below the large-screen breakpoint", async ({
+    page,
+    request,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 800 });
+    const registration = await registerFamily(request, {
+      familyName: "Meals Breakpoint Cards",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+
+    await seedBrowserAuth(page, registration);
+    await page.reload();
+    await waitForHydration(page);
+
+    const nav = page.getByRole("navigation", { name: "Primary" });
+    await safeClick(nav.getByRole("button", { name: "Meals", exact: true }));
+    await expect(
+      page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+    ).toBeVisible();
+    await expect(page.getByRole("table", { name: "Weekly meals" })).toHaveCount(
+      0,
+    );
+    await expect(
+      page.getByRole("button", { name: "Add dinner meal" }),
+    ).toHaveCount(7);
+
+    const fillEmptySlots = page.getByRole("button", {
+      name: "Fill empty slots",
+    });
+    await expect(fillEmptySlots).toBeVisible();
+    await expect(
+      page
+        .locator('[data-slot="week-header"]')
+        .getByRole("button", { name: "Fill empty slots" }),
+    ).toHaveCount(0);
+  });
+
+  test("captures the large-screen meals visual matrix", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120000);
+
+    const fullWeek = await registerFamily(request, {
+      familyName: "Meals Full Week Matrix",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await seedFilledWeek(request, fullWeek.token);
+    const recipe = await createRecipe(request, fullWeek.token, {
+      title: "Sheet Pan Chicken",
+      ingredients: ["1 lb chicken"],
+      instructions: ["Roast"],
+      tags: ["Dinner"],
+      favorite: false,
+    });
+    await upsertMealSlot(request, fullWeek.token, {
+      weekStartDate: currentWeekStart(),
+      dayIndex: 0,
+      mealType: "dinner",
+      primary: {
+        sourceType: "recipe",
+        recipeId: recipe.id,
+        title: recipe.title,
+        imageUrl: null,
+        note: null,
+      },
+      extras: [],
+      note: null,
+      collisionMode: "replace_primary",
+    });
+    await authenticateAndOpenMeals(page, fullWeek);
+
+    for (const width of SCREENSHOT_WIDTHS) {
+      await page.setViewportSize({
+        width,
+        height: width === 1024 ? 768 : 900,
+      });
+      const table = page.getByRole("table", { name: "Weekly meals" });
+      await expect(
+        table.locator('th[scope="col"][aria-current="date"]'),
+      ).toHaveCount(1);
+      await expect(
+        page
+          .locator('[data-slot="week-header"]')
+          .getByRole("button", { name: "Add ingredients" }),
+      ).toBeVisible();
+      await expect(
+        page
+          .locator('[data-slot="week-header"]')
+          .getByRole("button", { name: "Fill empty slots" }),
+      ).toBeVisible();
+      await expect(table.getByRole("button")).toHaveCount(21);
+      await attachBoardScreenshot(page, "full-week", width);
+    }
+
+    const emptyWeek = await registerFamily(request, {
+      familyName: "Meals Empty Week Matrix",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await authenticateAndOpenMeals(page, emptyWeek);
+
+    for (const width of SCREENSHOT_WIDTHS) {
+      await page.setViewportSize({
+        width,
+        height: width === 1024 ? 768 : 900,
+      });
+      const table = page.getByRole("table", { name: "Weekly meals" });
+      await expect(
+        table.locator('th[scope="col"][aria-current="date"]'),
+      ).toHaveCount(1);
+      await expect(
+        table.getByRole("button", {
+          name: /^Add (breakfast|lunch|dinner) meal, /,
+        }),
+      ).toHaveCount(21);
+      await attachBoardScreenshot(page, "empty-week", width);
+    }
+
+    const longNames = await registerFamily(request, {
+      familyName: "Meals Long Names Matrix",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await seedFilledWeek(
+      request,
+      longNames.token,
+      (mealType, dayIndex) =>
+        `A deliberately very long ${mealType} name for day ${dayIndex + 1} that must truncate inside one fixed-height card`,
+    );
+    await authenticateAndOpenMeals(page, longNames);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    const longEyebrow = page
+      .getByRole("table", { name: "Weekly meals" })
+      .locator(
+        "p.text-xs.font-semibold.uppercase.tracking-wide.text-muted-foreground",
+      )
+      .first();
+    const longEyebrowMetrics = await longEyebrow.evaluate((element) => {
+      const card = element.closest("button");
+      return {
+        eyebrowRight: element.getBoundingClientRect().right,
+        cardRight: card?.getBoundingClientRect().right ?? 0,
+        overflow: window.getComputedStyle(element).overflow,
+        whiteSpace: window.getComputedStyle(element).whiteSpace,
+      };
+    });
+    expect(longEyebrowMetrics.eyebrowRight).toBeLessThanOrEqual(
+      longEyebrowMetrics.cardRight + 1,
+    );
+    expect(longEyebrowMetrics.overflow).toBe("hidden");
+    expect(longEyebrowMetrics.whiteSpace).toBe("nowrap");
+    const longTitle = page
+      .getByRole("table", { name: "Weekly meals" })
+      .locator("p.truncate")
+      .first();
+    const longTitleMetrics = await longTitle.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return {
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        height: element.getBoundingClientRect().height,
+        lineHeight: Number.parseFloat(style.lineHeight),
+      };
+    });
+    expect(longTitleMetrics.scrollWidth).toBeGreaterThan(
+      longTitleMetrics.clientWidth,
+    );
+    expect(longTitleMetrics.height).toBeCloseTo(longTitleMetrics.lineHeight, 4);
+
+    for (const width of SCREENSHOT_WIDTHS) {
+      await attachBoardScreenshot(page, "long-names", width);
+    }
+
+    const pastWeek = await registerFamily(request, {
+      familyName: "Meals Past Week Matrix",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await authenticateAndOpenMeals(page, pastWeek);
+    await safeClick(page.getByRole("button", { name: "Previous week" }));
+    await expect(page.getByText("Review only", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add ingredients" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Fill empty slots" }),
+    ).toHaveCount(0);
+    await expect(
+      page
+        .getByRole("table", { name: "Weekly meals" })
+        .locator('th[scope="col"][aria-current="date"]'),
+    ).toHaveCount(0);
+
+    for (const width of SCREENSHOT_WIDTHS) {
+      await attachBoardScreenshot(page, "past-week", width);
+    }
+  });
+});

--- a/e2e/large-screen-meals.spec.ts
+++ b/e2e/large-screen-meals.spec.ts
@@ -172,26 +172,25 @@ test.describe("Large-screen Meals", () => {
       await expect(table.getByRole("columnheader")).toHaveCount(8);
       await expect(table.getByRole("rowheader")).toHaveCount(3);
       await expect(
-        table.locator('th[scope="col"][aria-current="date"]'),
+        table.locator('[role="columnheader"][aria-current="date"]'),
       ).toHaveCount(1);
 
       const geometry = await table.evaluate((element) => {
-        const scroller = element.parentElement;
-        const tableBox = element.getBoundingClientRect();
+        const box = element.getBoundingClientRect();
         const root = document.documentElement;
 
         return {
-          tableRight: tableBox.right,
+          tableRight: box.right,
           viewportWidth: window.innerWidth,
-          scrollerClientWidth: scroller?.clientWidth ?? 0,
-          scrollerScrollWidth: scroller?.scrollWidth ?? 0,
+          tableScrollWidth: element.scrollWidth,
+          tableClientWidth: element.clientWidth,
           documentClientWidth: root.clientWidth,
           documentScrollWidth: root.scrollWidth,
         };
       });
 
-      expect(geometry.scrollerScrollWidth).toBeLessThanOrEqual(
-        geometry.scrollerClientWidth + 1,
+      expect(geometry.tableScrollWidth).toBeLessThanOrEqual(
+        geometry.tableClientWidth + 1,
       );
       expect(geometry.documentScrollWidth).toBeLessThanOrEqual(
         geometry.documentClientWidth + 1,
@@ -225,6 +224,104 @@ test.describe("Large-screen Meals", () => {
             (wideTableBox!.x - sectionBox!.x)),
       ),
     ).toBeLessThanOrEqual(1);
+  });
+
+  test("fills the viewport height and floors row height on short screens", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60000);
+    const registration = await registerFamily(request, {
+      familyName: "Meals Vertical Fill",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await authenticateAndOpenMeals(page, registration);
+    const table = page.getByRole("table", { name: "Weekly meals" });
+
+    // Tall viewports: board bottom lands within section bottom padding.
+    for (const [width, height] of [
+      [1280, 800],
+      [1440, 900],
+      [1920, 1080],
+    ] as const) {
+      await page.setViewportSize({ width, height });
+      await expect(table).toBeVisible();
+      const box = await table.boundingBox();
+      expect(box).not.toBeNull();
+      expect(box!.y + box!.height).toBeGreaterThanOrEqual(height - 40);
+      expect(box!.y + box!.height).toBeLessThanOrEqual(height + 1);
+    }
+
+    // Rail: ~36px wide, vertical labels.
+    const rail = table.getByRole("rowheader", { name: "Breakfast" });
+    const railBox = await rail.boundingBox();
+    expect(railBox).not.toBeNull();
+    expect(railBox!.width).toBeGreaterThanOrEqual(35);
+    expect(railBox!.width).toBeLessThanOrEqual(40);
+    const railOrientation = await rail.locator("span").evaluate((label) => {
+      const style = window.getComputedStyle(label);
+      return {
+        writingMode: style.writingMode,
+        rotate: style.rotate,
+      };
+    });
+    expect(railOrientation.writingMode).toBe("vertical-rl");
+    expect(railOrientation.rotate).toBe("180deg");
+
+    // Short viewport: rows floor at 170px and module scrolls.
+    await page.setViewportSize({ width: 1280, height: 560 });
+    const bodyRows = table
+      .locator('[role="rowgroup"]')
+      .nth(1)
+      .locator('[role="row"]');
+    await expect(bodyRows).toHaveCount(3);
+    for (let index = 0; index < 3; index += 1) {
+      const rowBox = await bodyRows.nth(index).boundingBox();
+      expect(rowBox).not.toBeNull();
+      expect(rowBox!.height).toBeGreaterThanOrEqual(169);
+    }
+    const section = page.locator("section", { has: table });
+    const scrollGeometry = await section.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return {
+        overflowY: style.overflowY,
+        scrollHeight: element.scrollHeight,
+        clientHeight: element.clientHeight,
+      };
+    });
+    expect(["auto", "scroll"]).toContain(scrollGeometry.overflowY);
+    expect(scrollGeometry.scrollHeight).toBeGreaterThan(
+      scrollGeometry.clientHeight + 1,
+    );
+
+    const scrollTop = await section.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+      return element.scrollTop;
+    });
+    expect(scrollTop).toBeGreaterThan(0);
+    const lastRowReachability = await bodyRows.last().evaluate((row) => {
+      const section = row.closest("section");
+      if (!section) return null;
+
+      const rowBox = row.getBoundingClientRect();
+      const sectionBox = section.getBoundingClientRect();
+      return {
+        rowTop: rowBox.top,
+        rowBottom: rowBox.bottom,
+        sectionTop: sectionBox.top,
+        sectionBottom: sectionBox.bottom,
+      };
+    });
+    expect(lastRowReachability).not.toBeNull();
+    expect(lastRowReachability!.rowTop).toBeGreaterThanOrEqual(
+      lastRowReachability!.sectionTop - 1,
+    );
+    expect(lastRowReachability!.rowBottom).toBeLessThanOrEqual(
+      lastRowReachability!.sectionBottom + 1,
+    );
+    await section.evaluate((element) => {
+      element.scrollTop = 0;
+    });
   });
 
   test("keeps the day-card actions below the large-screen breakpoint", async ({
@@ -306,7 +403,7 @@ test.describe("Large-screen Meals", () => {
       });
       const table = page.getByRole("table", { name: "Weekly meals" });
       await expect(
-        table.locator('th[scope="col"][aria-current="date"]'),
+        table.locator('[role="columnheader"][aria-current="date"]'),
       ).toHaveCount(1);
       await expect(
         page
@@ -335,7 +432,7 @@ test.describe("Large-screen Meals", () => {
       });
       const table = page.getByRole("table", { name: "Weekly meals" });
       await expect(
-        table.locator('th[scope="col"][aria-current="date"]'),
+        table.locator('[role="columnheader"][aria-current="date"]'),
       ).toHaveCount(1);
       await expect(
         table.getByRole("button", {
@@ -355,45 +452,217 @@ test.describe("Large-screen Meals", () => {
       (mealType, dayIndex) =>
         `A deliberately very long ${mealType} name for day ${dayIndex + 1} that must truncate inside one fixed-height card`,
     );
+    const containedTitle =
+      "A deliberately very long breakfast name for day 1 that must truncate inside one fixed-height card";
+    await upsertMealSlot(request, longNames.token, {
+      weekStartDate: currentWeekStart(),
+      dayIndex: 0,
+      mealType: "breakfast",
+      primary: {
+        sourceType: "quick",
+        recipeId: null,
+        title: containedTitle,
+        imageUrl: null,
+        note: "A primary note that yields before the pinned extras tray",
+      },
+      extras: [
+        {
+          sourceType: "quick",
+          recipeId: null,
+          title: "Extra-long garlic bread accompaniment",
+          imageUrl: null,
+          note: null,
+        },
+        {
+          sourceType: "quick",
+          recipeId: null,
+          title: "Extra-long seasonal salad accompaniment",
+          imageUrl: null,
+          note: null,
+        },
+        {
+          sourceType: "quick",
+          recipeId: null,
+          title: "Juice",
+          imageUrl: null,
+          note: null,
+        },
+      ],
+      note: "A slot note that stays in the bounded notes region",
+      collisionMode: "replace_primary",
+    });
     await authenticateAndOpenMeals(page, longNames);
     await page.setViewportSize({ width: 1024, height: 768 });
-    const longEyebrow = page
-      .getByRole("table", { name: "Weekly meals" })
-      .locator(
-        "p.text-xs.font-semibold.uppercase.tracking-wide.text-muted-foreground",
-      )
-      .first();
-    const longEyebrowMetrics = await longEyebrow.evaluate((element) => {
-      const card = element.closest("button");
-      return {
-        eyebrowRight: element.getBoundingClientRect().right,
-        cardRight: card?.getBoundingClientRect().right ?? 0,
-        overflow: window.getComputedStyle(element).overflow,
-        whiteSpace: window.getComputedStyle(element).whiteSpace,
-      };
-    });
-    expect(longEyebrowMetrics.eyebrowRight).toBeLessThanOrEqual(
-      longEyebrowMetrics.cardRight + 1,
-    );
-    expect(longEyebrowMetrics.overflow).toBe("hidden");
-    expect(longEyebrowMetrics.whiteSpace).toBe("nowrap");
-    const longTitle = page
-      .getByRole("table", { name: "Weekly meals" })
-      .locator("p.truncate")
+    const boardTable = page.getByRole("table", { name: "Weekly meals" });
+    await expect(
+      boardTable.getByRole("rowheader", { name: "Breakfast" }),
+    ).toHaveCount(1);
+    await expect(
+      boardTable.getByText("Breakfast", { exact: true }),
+    ).toHaveCount(1); // rail only — cards carry no eyebrow
+
+    const longTitle = boardTable
+      .locator('[role="cell"] p.line-clamp-2')
       .first();
     const longTitleMetrics = await longTitle.evaluate((element) => {
       const style = window.getComputedStyle(element);
       return {
-        clientWidth: element.clientWidth,
-        scrollWidth: element.scrollWidth,
-        height: element.getBoundingClientRect().height,
+        clientHeight: element.clientHeight,
+        scrollHeight: element.scrollHeight,
         lineHeight: Number.parseFloat(style.lineHeight),
       };
     });
-    expect(longTitleMetrics.scrollWidth).toBeGreaterThan(
-      longTitleMetrics.clientWidth,
+    // Clamped: content overflows, and the visible box is exactly two lines.
+    expect(longTitleMetrics.scrollHeight).toBeGreaterThan(
+      longTitleMetrics.clientHeight,
     );
-    expect(longTitleMetrics.height).toBeCloseTo(longTitleMetrics.lineHeight, 4);
+    expect(longTitleMetrics.clientHeight).toBeGreaterThanOrEqual(
+      longTitleMetrics.lineHeight * 2 - 2,
+    );
+    expect(longTitleMetrics.clientHeight).toBeLessThanOrEqual(
+      longTitleMetrics.lineHeight * 2 + 2,
+    );
+
+    // At an acceptance viewport, notes yield at least one complete line and
+    // remain bounded above the pinned extras tray.
+    const longContentCard = boardTable.getByRole("button", {
+      name: `Open breakfast, Sunday: ${containedTitle}`,
+    });
+    await expect(
+      longContentCard.locator('[data-slot="meal-notes"]'),
+    ).toBeVisible();
+    const noteContainment = await longContentCard.evaluate((card) => {
+      const notes = card.querySelector('[data-slot="meal-notes"]');
+      const firstNote = notes?.querySelector("p") ?? null;
+      const overflow = Array.from(card.querySelectorAll("span")).find(
+        (element) => element.textContent?.trim() === "+1 more",
+      );
+      const tray = overflow?.parentElement ?? null;
+      const bounds = (element: Element | null) => {
+        const box = element?.getBoundingClientRect();
+        return box
+          ? {
+              top: box.top,
+              right: box.right,
+              bottom: box.bottom,
+              left: box.left,
+            }
+          : null;
+      };
+
+      return {
+        card: bounds(card),
+        notes: bounds(notes),
+        firstNote: bounds(firstNote),
+        firstNoteLineHeight: firstNote
+          ? Number.parseFloat(window.getComputedStyle(firstNote).lineHeight)
+          : null,
+        tray: bounds(tray),
+      };
+    });
+    expect(noteContainment.card).not.toBeNull();
+    expect(noteContainment.notes).not.toBeNull();
+    expect(noteContainment.firstNote).not.toBeNull();
+    expect(noteContainment.firstNoteLineHeight).not.toBeNull();
+    expect(noteContainment.tray).not.toBeNull();
+    const visibleNoteTop = Math.max(
+      noteContainment.notes!.top,
+      noteContainment.firstNote!.top,
+    );
+    const visibleNoteBottom = Math.min(
+      noteContainment.notes!.bottom,
+      noteContainment.firstNote!.bottom,
+    );
+    expect(visibleNoteBottom - visibleNoteTop).toBeGreaterThanOrEqual(
+      noteContainment.firstNoteLineHeight! - 1,
+    );
+    expect(noteContainment.notes!.top).toBeGreaterThanOrEqual(
+      noteContainment.card!.top - 1,
+    );
+    expect(noteContainment.notes!.right).toBeLessThanOrEqual(
+      noteContainment.card!.right + 1,
+    );
+    expect(noteContainment.notes!.bottom).toBeLessThanOrEqual(
+      noteContainment.card!.bottom + 1,
+    );
+    expect(noteContainment.notes!.left).toBeGreaterThanOrEqual(
+      noteContainment.card!.left - 1,
+    );
+    expect(noteContainment.notes!.bottom).toBeLessThanOrEqual(
+      noteContainment.tray!.top + 1,
+    );
+
+    // At the 170px row floor, the full title and extras tray stay in the card.
+    await page.setViewportSize({ width: 1280, height: 560 });
+    const constrainedCard = boardTable.getByRole("button", {
+      name: `Open breakfast, Sunday: ${containedTitle}`,
+    });
+    const constrainedCell = constrainedCard.locator(
+      'xpath=ancestor::*[@role="cell"]',
+    );
+    const constrainedRow = constrainedCell.locator(
+      'xpath=ancestor::*[@role="row"]',
+    );
+    const overflowChip = constrainedCard.getByText("+1 more", { exact: true });
+    await expect(overflowChip).toBeVisible();
+    const extrasTray = overflowChip.locator("..");
+    await expect(extrasTray.locator(":scope > *")).toHaveCount(3);
+    const [cellBox, rowBox] = await Promise.all([
+      constrainedCell.boundingBox(),
+      constrainedRow.boundingBox(),
+    ]);
+    expect(cellBox).not.toBeNull();
+    expect(rowBox).not.toBeNull();
+    expect(rowBox!.height).toBeLessThanOrEqual(171);
+    const containment = await constrainedCard.evaluate((card) => {
+      const title = card.querySelector("p.line-clamp-2");
+      const overflow = Array.from(card.querySelectorAll("span")).find(
+        (element) => element.textContent?.trim() === "+1 more",
+      );
+      const tray = overflow?.parentElement ?? null;
+      const bounds = (element: Element | null) => {
+        const box = element?.getBoundingClientRect();
+        return box
+          ? {
+              top: box.top,
+              right: box.right,
+              bottom: box.bottom,
+              left: box.left,
+            }
+          : null;
+      };
+
+      return {
+        card: bounds(card),
+        title: bounds(title),
+        tray: bounds(tray),
+        trayItems: tray
+          ? Array.from(tray.children).map((item) => bounds(item))
+          : [],
+      };
+    });
+    expect(containment.card).not.toBeNull();
+    expect(containment.title).not.toBeNull();
+    expect(containment.tray).not.toBeNull();
+    expect(containment.card!.top).toBeGreaterThanOrEqual(cellBox!.y - 1);
+    expect(containment.card!.right).toBeLessThanOrEqual(
+      cellBox!.x + cellBox!.width + 1,
+    );
+    expect(containment.card!.bottom).toBeLessThanOrEqual(
+      cellBox!.y + cellBox!.height + 1,
+    );
+    expect(containment.card!.left).toBeGreaterThanOrEqual(cellBox!.x - 1);
+    for (const box of [
+      containment.title,
+      containment.tray,
+      ...containment.trayItems,
+    ]) {
+      expect(box).not.toBeNull();
+      expect(box!.top).toBeGreaterThanOrEqual(containment.card!.top - 1);
+      expect(box!.right).toBeLessThanOrEqual(containment.card!.right + 1);
+      expect(box!.bottom).toBeLessThanOrEqual(containment.card!.bottom + 1);
+      expect(box!.left).toBeGreaterThanOrEqual(containment.card!.left - 1);
+    }
 
     for (const width of SCREENSHOT_WIDTHS) {
       await page.setViewportSize({
@@ -403,7 +672,7 @@ test.describe("Large-screen Meals", () => {
       await expect(
         page
           .getByRole("table", { name: "Weekly meals" })
-          .locator('th[scope="col"][aria-current="date"]'),
+          .locator('[role="columnheader"][aria-current="date"]'),
       ).toHaveCount(1);
       await attachBoardScreenshot(page, "long-names", width);
     }
@@ -424,7 +693,7 @@ test.describe("Large-screen Meals", () => {
     await expect(
       page
         .getByRole("table", { name: "Weekly meals" })
-        .locator('th[scope="col"][aria-current="date"]'),
+        .locator('[role="columnheader"][aria-current="date"]'),
     ).toHaveCount(0);
 
     for (const width of SCREENSHOT_WIDTHS) {

--- a/e2e/large-screen-meals.spec.ts
+++ b/e2e/large-screen-meals.spec.ts
@@ -375,6 +375,10 @@ test.describe("Large-screen Meals", () => {
     expect(longTitleMetrics.height).toBeCloseTo(longTitleMetrics.lineHeight, 4);
 
     for (const width of SCREENSHOT_WIDTHS) {
+      await page.setViewportSize({
+        width,
+        height: width === 1024 ? 768 : 900,
+      });
       await expect(
         page
           .getByRole("table", { name: "Weekly meals" })

--- a/e2e/large-screen-meals.spec.ts
+++ b/e2e/large-screen-meals.spec.ts
@@ -72,27 +72,48 @@ async function authenticateAndOpenMeals(
   registration: Awaited<ReturnType<typeof registerFamily>>,
 ) {
   await clearStorage(page);
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        const request = indexedDB.open("family-hub-offline");
-        request.onerror = () => resolve();
-        request.onupgradeneeded = () => resolve();
-        request.onsuccess = () => {
-          try {
-            const transaction = request.result.transaction(
-              "query-cache",
-              "readwrite",
-            );
-            transaction.objectStore("query-cache").clear();
-            transaction.oncomplete = () => resolve();
-            transaction.onerror = () => resolve();
-          } catch {
+  await page.evaluate(async () => {
+    if (!indexedDB.databases) return;
+
+    let databases: IDBDatabaseInfo[];
+    try {
+      databases = await indexedDB.databases();
+    } catch {
+      return;
+    }
+    if (!databases.some((database) => database.name === "family-hub-offline")) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const request = indexedDB.open("family-hub-offline");
+      request.onerror = () => resolve();
+      request.onblocked = () => resolve();
+      request.onsuccess = () => {
+        const database = request.result;
+        if (!database.objectStoreNames.contains("query-cache")) {
+          database.close();
+          resolve();
+          return;
+        }
+
+        try {
+          const transaction = database.transaction("query-cache", "readwrite");
+          transaction.objectStore("query-cache").clear();
+          const finish = () => {
+            database.close();
             resolve();
-          }
-        };
-      }),
-  );
+          };
+          transaction.oncomplete = finish;
+          transaction.onerror = finish;
+          transaction.onabort = finish;
+        } catch {
+          database.close();
+          resolve();
+        }
+      };
+    });
+  });
   await seedBrowserAuth(page, registration);
   await page.reload();
   await waitForHydration(page);

--- a/e2e/large-screen-meals.spec.ts
+++ b/e2e/large-screen-meals.spec.ts
@@ -257,7 +257,7 @@ test.describe("Large-screen Meals", () => {
     const recipe = await createRecipe(request, fullWeek.token, {
       title: "Sheet Pan Chicken",
       ingredients: ["1 lb chicken"],
-      instructions: ["Roast"],
+      instructions: ["Roast until cooked through."],
       tags: ["Dinner"],
       favorite: false,
     });
@@ -375,6 +375,11 @@ test.describe("Large-screen Meals", () => {
     expect(longTitleMetrics.height).toBeCloseTo(longTitleMetrics.lineHeight, 4);
 
     for (const width of SCREENSHOT_WIDTHS) {
+      await expect(
+        page
+          .getByRole("table", { name: "Weekly meals" })
+          .locator('th[scope="col"][aria-current="date"]'),
+      ).toHaveCount(1);
       await attachBoardScreenshot(page, "long-names", width);
     }
 

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -41,6 +41,7 @@ vi.mock("@/hooks", async (importOriginal) => {
   return {
     ...actual,
     useMediaQuery: () => viewport.showGrid,
+    useIsLargeScreen: () => viewport.showGrid,
   };
 });
 
@@ -1067,6 +1068,32 @@ describe("MealsView", () => {
     expect(
       screen.getByRole("columnheader", { name: "Sunday" }),
     ).toBeInTheDocument();
+  });
+
+  it("merges board actions into the large-screen week header", async () => {
+    viewport.showGrid = true;
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    renderWithUser(<MealsView />);
+
+    const fillEmptySlots = await screen.findByRole("button", {
+      name: "Fill empty slots",
+    });
+    expect(
+      screen.getAllByRole("button", { name: "Fill empty slots" }),
+    ).toHaveLength(1);
+    expect(fillEmptySlots.closest('[data-slot="week-header"]')).not.toBeNull();
+  });
+
+  it("keeps board actions outside the week header below the large-screen breakpoint", async () => {
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    renderWithUser(<MealsView />);
+
+    const fillEmptySlots = await screen.findByRole("button", {
+      name: "Fill empty slots",
+    });
+    expect(fillEmptySlots.closest('[data-slot="week-header"]')).toBeNull();
   });
 
   it("prompts when moving into an occupied slot and move clears the source", async () => {

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -1123,6 +1123,19 @@ describe("MealsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses weekday context after the empty meal action label on large screens", async () => {
+    viewport.showGrid = true;
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    renderWithUser(<MealsView />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Add breakfast meal, Sunday",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("merges board actions into the large-screen week header", async () => {
     viewport.showGrid = true;
     seedMockMealsBoard(createEmptyMealsBoard());

--- a/src/components/meals-view.test.tsx
+++ b/src/components/meals-view.test.tsx
@@ -1070,6 +1070,59 @@ describe("MealsView", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders one-line weekday headers while retaining full weekday names", async () => {
+    viewport.showGrid = true;
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    renderWithUser(<MealsView />);
+
+    const table = await screen.findByRole("table", { name: "Weekly meals" });
+    expect(within(table).getByText("Wed")).toBeVisible();
+    expect(within(table).queryByText("Wednesday")).not.toBeInTheDocument();
+    expect(
+      within(table).getByRole("columnheader", { name: "Sunday" }),
+    ).toBeInTheDocument();
+  });
+
+  it("highlights today in the weekday header", async () => {
+    viewport.showGrid = true;
+    seedMockMealsBoard(createEmptyMealsBoard());
+
+    renderWithUser(<MealsView />);
+
+    const table = await screen.findByRole("table", { name: "Weekly meals" });
+    const todayHeader = within(table).getByRole("columnheader", {
+      name: "Wednesday",
+    });
+    expect(todayHeader).toHaveAttribute("aria-label", "Wednesday");
+    expect(todayHeader).toHaveAttribute("aria-current", "date");
+    expect(
+      within(table)
+        .getAllByRole("columnheader")
+        .filter((header) => header.getAttribute("aria-current") === "date"),
+    ).toHaveLength(1);
+  });
+
+  it("uses full weekday context in large-screen meal slot names", async () => {
+    viewport.showGrid = true;
+    seedMockMealsBoard(
+      withOccupiedMealSlot(
+        createEmptyMealsBoard(),
+        3,
+        "dinner",
+        "Turbong Manok",
+      ),
+    );
+
+    renderWithUser(<MealsView />);
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Open dinner, Wednesday: Turbong Manok",
+      }),
+    ).toBeInTheDocument();
+  });
+
   it("merges board actions into the large-screen week header", async () => {
     viewport.showGrid = true;
     seedMockMealsBoard(createEmptyMealsBoard());

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -543,8 +543,8 @@ export function MealsView() {
     ) : null;
 
   return (
-    <section className="flex-1 overflow-y-auto p-4 sm:p-6">
-      <div className="mx-auto flex max-w-[1600px] flex-col gap-4">
+    <section className="flex flex-1 flex-col overflow-y-auto p-4 sm:p-6">
+      <div className="mx-auto flex w-full max-w-[1600px] flex-1 flex-col gap-4">
         <WeekHeader
           weekStartDate={visibleWeekStartDate}
           readOnly={readOnly}

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useMealsBoard, useRecipes, useSaveMealPlan } from "@/api";
 import { ApiException } from "@/api/client";
 import { AddIngredientsContainer } from "@/components/meals/add-ingredients-container";
+import { MealBoardActions } from "@/components/meals/meal-board-actions";
 import {
   MealComposerSheet,
   type MealSlotSelection,
@@ -26,7 +27,7 @@ import {
 import { formatWeekRange, WeekHeader } from "@/components/meals/week-header";
 import { OfflineUnavailable } from "@/components/shared";
 import { Button } from "@/components/ui/button";
-import { useMediaQuery } from "@/hooks";
+import { useIsLargeScreen } from "@/hooks";
 import {
   formatLocalDate,
   getWeekStartSunday,
@@ -171,7 +172,7 @@ export function MealsView() {
     (state) => state.setIdleReturnBlocked,
   );
   const readOnly = isPastWeek(visibleWeekStartDate);
-  const showGrid = useMediaQuery("(min-width: 1024px)");
+  const isLargeScreen = useIsLargeScreen();
   const persistedBoard = board.data?.data ?? null;
   // "Add ingredients" is offered only when the visible, editable week has at
   // least one recipe-backed planned meal to extract ingredients from.
@@ -532,12 +533,22 @@ export function MealsView() {
     setSelectedSlot({ ...slot, intent: "extra" });
   }
 
+  const boardActions =
+    persistedBoard && !readOnly ? (
+      <MealBoardActions
+        canAddIngredients={canAddIngredients}
+        onAddIngredients={() => setAddIngredientsOpen(true)}
+        onFillEmptySlots={() => setScopeOpen(true)}
+      />
+    ) : null;
+
   return (
     <section className="flex-1 overflow-y-auto p-4 sm:p-6">
-      <div className="mx-auto flex max-w-5xl flex-col gap-4">
+      <div className="mx-auto flex max-w-[1600px] flex-col gap-4">
         <WeekHeader
           weekStartDate={visibleWeekStartDate}
           readOnly={readOnly}
+          actions={isLargeScreen ? boardActions : undefined}
           onWeekChange={(weekStartDate) => {
             setVisibleWeekStartDate(weekStartDate);
             setSelectedSlot(null);
@@ -547,25 +558,8 @@ export function MealsView() {
           }}
         />
 
-        {persistedBoard && !readOnly ? (
-          <div className="flex flex-wrap justify-end gap-2">
-            {canAddIngredients ? (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => setAddIngredientsOpen(true)}
-              >
-                Add ingredients
-              </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => setScopeOpen(true)}
-            >
-              Fill empty slots
-            </Button>
-          </div>
+        {!isLargeScreen && boardActions ? (
+          <div className="flex flex-wrap justify-end gap-2">{boardActions}</div>
         ) : null}
 
         {placementRecipe ? (
@@ -609,7 +603,7 @@ export function MealsView() {
           <OfflineUnavailable label="meals" />
         ) : null}
 
-        {displayBoard && !showGrid ? (
+        {displayBoard && !isLargeScreen ? (
           <div className="space-y-4">
             {displayBoard.days.map((day) => (
               <MealDayCard
@@ -625,7 +619,7 @@ export function MealsView() {
           </div>
         ) : null}
 
-        {displayBoard && showGrid ? (
+        {displayBoard && isLargeScreen ? (
           <MealGrid
             board={displayBoard}
             readOnly={readOnly}

--- a/src/components/meals/meal-board-actions.test.tsx
+++ b/src/components/meals/meal-board-actions.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { MealBoardActions } from "./meal-board-actions";
+
+describe("MealBoardActions", () => {
+  it("renders both buttons when canAddIngredients is true", () => {
+    renderWithUser(
+      <MealBoardActions
+        canAddIngredients
+        onAddIngredients={vi.fn()}
+        onFillEmptySlots={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add ingredients" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fill empty slots" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides Add ingredients when canAddIngredients is false", () => {
+    renderWithUser(
+      <MealBoardActions
+        canAddIngredients={false}
+        onAddIngredients={vi.fn()}
+        onFillEmptySlots={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Add ingredients" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fill empty slots" }),
+    ).toBeInTheDocument();
+  });
+
+  it("invokes callbacks when the buttons are clicked", async () => {
+    const onAddIngredients = vi.fn();
+    const onFillEmptySlots = vi.fn();
+    const { user } = renderWithUser(
+      <MealBoardActions
+        canAddIngredients
+        onAddIngredients={onAddIngredients}
+        onFillEmptySlots={onFillEmptySlots}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Add ingredients" }));
+    await user.click(screen.getByRole("button", { name: "Fill empty slots" }));
+
+    expect(onAddIngredients).toHaveBeenCalledOnce();
+    expect(onFillEmptySlots).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/meals/meal-board-actions.tsx
+++ b/src/components/meals/meal-board-actions.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@/components/ui/button";
+
+interface MealBoardActionsProps {
+  canAddIngredients: boolean;
+  onAddIngredients: () => void;
+  onFillEmptySlots: () => void;
+}
+
+export function MealBoardActions({
+  canAddIngredients,
+  onAddIngredients,
+  onFillEmptySlots,
+}: MealBoardActionsProps) {
+  return (
+    <div className="flex flex-wrap justify-end gap-2">
+      {canAddIngredients ? (
+        <Button type="button" variant="outline" onClick={onAddIngredients}>
+          Add ingredients
+        </Button>
+      ) : null}
+      <Button type="button" variant="outline" onClick={onFillEmptySlots}>
+        Fill empty slots
+      </Button>
+    </div>
+  );
+}

--- a/src/components/meals/meal-grid-card.test.tsx
+++ b/src/components/meals/meal-grid-card.test.tsx
@@ -1,0 +1,471 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import type { MealSlot, MealSlotEntry } from "@/lib/types";
+import { MealGridCard } from "./meal-grid-card";
+
+function buildEntry(overrides: Partial<MealSlotEntry> = {}): MealSlotEntry {
+  return {
+    id: "entry-1",
+    role: "primary",
+    sourceType: "quick",
+    recipeId: null,
+    title: "Meal",
+    imageUrl: null,
+    note: null,
+    ...overrides,
+  };
+}
+
+function buildSlot(overrides: Partial<MealSlot> = {}): MealSlot {
+  return {
+    id: null,
+    weekStartDate: "2026-07-05",
+    dayIndex: 3,
+    mealType: "dinner",
+    primary: null,
+    extras: [],
+    note: null,
+    ...overrides,
+  };
+}
+
+describe("MealGridCard", () => {
+  it("renders a photo banner and title for a recipe-backed meal", () => {
+    const slot = buildSlot({
+      primary: buildEntry({
+        id: "p1",
+        sourceType: "recipe",
+        recipeId: "r1",
+        title: "Chicken Adobo",
+        imageUrl: "https://example.com/adobo.jpg",
+        note: "rice night",
+      }),
+    });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Open dinner, Wednesday: Chicken Adobo",
+    });
+    expect(card).toBeVisible();
+    const image = card.querySelector("img");
+    expect(image).toHaveAttribute("src", "https://example.com/adobo.jpg");
+    expect(image).toHaveAttribute("alt", "");
+    expect(screen.getByText("Chicken Adobo")).toBeVisible();
+    expect(screen.getByText("Chicken Adobo")).toHaveClass("line-clamp-2");
+    expect(screen.getByText("rice night")).toBeVisible();
+    // Grid cards carry no meal-type eyebrow; the rail labels the row.
+    expect(screen.queryByText("Dinner")).not.toBeInTheDocument();
+  });
+
+  it("renders a tinted placeholder band for image-less meals", () => {
+    const slot = buildSlot({
+      primary: buildEntry({
+        id: "p1",
+        title: "Leftovers",
+      }),
+    });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: "Open dinner, Wednesday: Leftovers",
+    });
+    const band = card.querySelector('[data-slot="meal-band"]');
+    expect(band).not.toBeNull();
+    expect(band).toHaveClass("bg-meal-dinner");
+    expect(band?.querySelector("svg")).toHaveAttribute("aria-hidden", "true");
+    expect(card.querySelector("img")).toBeNull();
+    // Filled card, not an add target: solid border, no dashed styling.
+    expect(card.className).not.toContain("border-dashed");
+  });
+
+  it("shows extras chips with overflow count", () => {
+    const slot = buildSlot({
+      primary: buildEntry({
+        id: "p1",
+        title: "Pasta",
+      }),
+      extras: [
+        buildEntry({ id: "e1", role: "extra", title: "Garlic bread" }),
+        buildEntry({ id: "e2", role: "extra", title: "Salad" }),
+        buildEntry({ id: "e3", role: "extra", title: "Juice" }),
+      ],
+    });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Monday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Garlic bread")).toBeVisible();
+    expect(screen.getByText("Salad")).toBeVisible();
+    expect(screen.getByText("+1 more")).toBeVisible();
+    expect(screen.queryByText("Juice")).not.toBeInTheDocument();
+  });
+
+  it("renders a draft badge and hides extras while drafting", () => {
+    const slot = buildSlot({
+      extras: [buildEntry({ id: "e1", role: "extra", title: "Rice" })],
+    });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Friday"
+        draft={{
+          target: { dayIndex: 3, mealType: "dinner" },
+          displayTitle: "Sinigang",
+          displayImageUrl: null,
+          displayNote: null,
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Sinigang",
+            imageUrl: null,
+            note: null,
+          },
+          note: null,
+        }}
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Draft dinner, Friday: Sinigang" }),
+    ).toBeVisible();
+    expect(screen.getByText("Draft")).toBeVisible();
+    expect(screen.getByText("Draft")).toHaveClass("shrink-0");
+    expect(screen.queryByText("Rice")).not.toBeInTheDocument();
+  });
+
+  it("renders a full-cell add target for empty editable slots", async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={onSelectSlot}
+      />,
+    );
+
+    const target = screen.getByRole("button", {
+      name: "Add dinner meal, Wednesday",
+    });
+    expect(target).toBeVisible();
+    expect(target.className).toContain("border-dashed");
+    expect(screen.getByText("Add dinner")).toBeVisible();
+
+    await user.click(target);
+    expect(onSelectSlot).toHaveBeenCalledWith(slot);
+  });
+
+  it("labels recipe placement on empty slots", () => {
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        pendingRecipeId="r9"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add recipe to dinner, Wednesday" }),
+    ).toBeVisible();
+  });
+
+  it("treats an empty pending recipe ID as no pending recipe", () => {
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        pendingRecipeId=""
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add dinner meal, Wednesday" }),
+    ).toBeVisible();
+  });
+
+  it("renders a quiet non-interactive cell for empty read-only slots", () => {
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText("Dinner")).toBeVisible();
+  });
+
+  it("marks the active planning target", () => {
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        isPlanningTarget
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add dinner meal, Wednesday" }),
+    ).toHaveAttribute("aria-current", "true");
+  });
+
+  it("recovers from an image error when the meal image URL changes", () => {
+    const imageA = "https://example.com/a.jpg";
+    const imageB = "https://example.com/b.jpg";
+    const { rerender } = render(
+      <MealGridCard
+        slot={buildSlot({
+          primary: buildEntry({ title: "Adobo", imageUrl: imageA }),
+        })}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const firstImage = screen
+      .getByRole("button", { name: "Open dinner, Wednesday: Adobo" })
+      .querySelector("img");
+    expect(firstImage).toHaveAttribute("src", imageA);
+    expect(firstImage).toHaveAttribute("alt", "");
+    fireEvent.error(firstImage as HTMLImageElement);
+
+    const fallback = screen
+      .getByRole("button", { name: "Open dinner, Wednesday: Adobo" })
+      .querySelector('[data-slot="meal-band"]');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.querySelector("svg")).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    );
+
+    rerender(
+      <MealGridCard
+        slot={buildSlot({
+          primary: buildEntry({ title: "Adobo", imageUrl: imageB }),
+        })}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const recoveredImage = screen
+      .getByRole("button", { name: "Open dinner, Wednesday: Adobo" })
+      .querySelector("img");
+    expect(recoveredImage).toHaveAttribute("src", imageB);
+    expect(recoveredImage).toHaveAttribute("alt", "");
+  });
+
+  it("protects long content within a 154px card in the 170px row floor", () => {
+    const primaryTitle =
+      "A very long family dinner title that needs exactly two visible lines";
+    const primaryNote =
+      "A long primary note that may yield space before fixed content clips";
+    const slotNote =
+      "A long slot note that stays in the bounded notes region at minimum height";
+    const slot = buildSlot({
+      primary: buildEntry({ title: primaryTitle, note: primaryNote }),
+      note: slotNote,
+      extras: [
+        buildEntry({
+          id: "e1",
+          role: "extra",
+          title: "Extra-long garlic bread accompaniment",
+        }),
+        buildEntry({
+          id: "e2",
+          role: "extra",
+          title: "Extra-long seasonal salad accompaniment",
+        }),
+        buildEntry({ id: "e3", role: "extra", title: "Juice" }),
+      ],
+    });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Wednesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const card = screen.getByRole("button", {
+      name: `Open dinner, Wednesday: ${primaryTitle}`,
+    });
+    const body = card.querySelector('[data-slot="meal-body"]');
+    // 154px card - 2px border = 152px content; 42% banner leaves 88.16px.
+    // Body p-2 leaves 72.16px.
+    // Two title lines (35px) + tray with pt-1 (24px) + two gaps (4px) = 63px,
+    // leaving 9.16px for the notes region to yield into.
+    expect.soft(body).toHaveClass("gap-0.5", "p-2");
+
+    const title = screen.getByText(primaryTitle);
+    expect(title).toBeVisible();
+    expect.soft(title).toHaveClass("line-clamp-2", "shrink-0", "leading-tight");
+
+    const notes = card.querySelector('[data-slot="meal-notes"]');
+    expect.soft(notes).toHaveClass("min-h-0", "overflow-hidden");
+    expect(screen.getByText(primaryNote)).toBeVisible();
+    expect(screen.getByText(slotNote)).toBeVisible();
+
+    const extras = card.querySelector('[data-slot="meal-extras"]');
+    expect
+      .soft(extras)
+      .toHaveClass("shrink-0", "flex-nowrap", "overflow-hidden");
+    expect
+      .soft(screen.getByText("Extra-long garlic bread accompaniment"))
+      .toHaveClass("truncate", "py-0.5");
+    expect
+      .soft(screen.getByText("Extra-long seasonal salad accompaniment"))
+      .toHaveClass("truncate", "py-0.5");
+    expect(screen.getByText("+1 more")).toBeVisible();
+    expect.soft(screen.getByText("+1 more")).toHaveClass("py-0.5");
+  });
+
+  it("renders extras-only meals with the exact shared label", () => {
+    render(
+      <MealGridCard
+        slot={buildSlot({
+          extras: [
+            buildEntry({ id: "e1", role: "extra", title: "Mango salad" }),
+          ],
+        })}
+        readOnly={false}
+        dayLabel="Sunday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open dinner, Sunday: extras - Mango salad",
+      }),
+    ).toBeVisible();
+    expect(screen.getByText("Extras")).toBeVisible();
+    expect(screen.getByText("Mango salad")).toBeVisible();
+  });
+
+  it("renders the slot note", () => {
+    render(
+      <MealGridCard
+        slot={buildSlot({
+          primary: buildEntry({ title: "Tacos" }),
+          note: "Use the blue serving bowls",
+        })}
+        readOnly={false}
+        dayLabel="Tuesday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Use the blue serving bowls")).toBeVisible();
+  });
+
+  it("selects a filled slot", async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    const slot = buildSlot({ primary: buildEntry({ title: "Tacos" }) });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Tuesday"
+        onSelectSlot={onSelectSlot}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Open dinner, Tuesday: Tacos" }),
+    );
+    expect(onSelectSlot).toHaveBeenCalledWith(slot);
+  });
+
+  it("selects a draft slot", async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    const slot = buildSlot();
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly={false}
+        dayLabel="Friday"
+        draft={{
+          target: { dayIndex: 3, mealType: "dinner" },
+          displayTitle: "Sinigang",
+          displayImageUrl: null,
+          displayNote: null,
+          primary: {
+            sourceType: "quick",
+            recipeId: null,
+            title: "Sinigang",
+            imageUrl: null,
+            note: null,
+          },
+          note: null,
+        }}
+        onSelectSlot={onSelectSlot}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Draft dinner, Friday: Sinigang" }),
+    );
+    expect(onSelectSlot).toHaveBeenCalledWith(slot);
+  });
+
+  it("keeps filled read-only slots selectable", async () => {
+    const user = userEvent.setup();
+    const onSelectSlot = vi.fn();
+    const slot = buildSlot({ primary: buildEntry({ title: "Tacos" }) });
+    render(
+      <MealGridCard
+        slot={slot}
+        readOnly
+        dayLabel="Tuesday"
+        onSelectSlot={onSelectSlot}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Open dinner, Tuesday: Tacos" }),
+    );
+    expect(onSelectSlot).toHaveBeenCalledWith(slot);
+  });
+});

--- a/src/components/meals/meal-grid-card.tsx
+++ b/src/components/meals/meal-grid-card.tsx
@@ -1,0 +1,177 @@
+import { Plus } from "lucide-react";
+import { useState } from "react";
+import type { MealSlot } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import type { MealPlanningDraft } from "./meal-planning-session";
+import { emptySlotLabel, filledSlotLabel } from "./meal-slot-labels";
+import {
+  formatMealType,
+  mealTypeBandClasses,
+  mealTypeIcon,
+} from "./meal-type-utils";
+
+interface MealGridCardProps {
+  slot: MealSlot;
+  readOnly: boolean;
+  pendingRecipeId?: string | null;
+  draft?: MealPlanningDraft | null;
+  isPlanningTarget?: boolean;
+  dayLabel: string;
+  onSelectSlot: (slot: MealSlot) => void;
+}
+
+// Grid-only banner card. The mobile day-card layout keeps using MealSlotCard;
+// the two share label logic via meal-slot-labels.
+export function MealGridCard({
+  slot,
+  readOnly,
+  pendingRecipeId = null,
+  draft = null,
+  isPlanningTarget = false,
+  dayLabel,
+  onSelectSlot,
+}: MealGridCardProps) {
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
+  const primary = draft
+    ? {
+        title: draft.displayTitle,
+        imageUrl: draft.displayImageUrl,
+        note: draft.displayNote,
+      }
+    : slot.primary;
+  const hasExtras = !draft && slot.extras.length > 0;
+  const imageUrl = primary?.imageUrl ?? null;
+  const BandIcon = mealTypeIcon(slot.mealType);
+
+  if (primary || hasExtras) {
+    return (
+      <button
+        type="button"
+        className={cn(
+          "flex h-full w-full flex-col overflow-hidden rounded-lg border border-border bg-card text-left shadow-sm transition-colors",
+          readOnly ? "cursor-default" : "hover:bg-muted/50",
+          isPlanningTarget
+            ? "border-primary/70 bg-primary/5 ring-2 ring-primary/20"
+            : null,
+        )}
+        aria-current={isPlanningTarget ? "true" : undefined}
+        aria-label={filledSlotLabel({
+          mealType: slot.mealType,
+          dayLabel,
+          draftTitle: draft ? draft.displayTitle : null,
+          primaryTitle: !draft && slot.primary ? slot.primary.title : null,
+          firstExtraTitle: slot.extras[0]?.title ?? null,
+        })}
+        onClick={() => onSelectSlot(slot)}
+      >
+        <div className="relative min-h-14 w-full shrink-0 basis-[42%]">
+          {imageUrl && imageUrl !== failedImageUrl ? (
+            <img
+              src={imageUrl}
+              alt=""
+              className="absolute inset-0 h-full w-full object-cover"
+              onError={() => setFailedImageUrl(imageUrl)}
+            />
+          ) : (
+            <div
+              data-slot="meal-band"
+              className={cn(
+                "flex h-full w-full items-center justify-center",
+                mealTypeBandClasses(slot.mealType),
+              )}
+            >
+              <BandIcon aria-hidden className="h-6 w-6 opacity-80" />
+            </div>
+          )}
+        </div>
+        <div
+          data-slot="meal-body"
+          className="flex min-h-0 flex-1 flex-col gap-0.5 p-2"
+        >
+          {draft ? (
+            <span className="inline-flex shrink-0 self-start rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+              Draft
+            </span>
+          ) : null}
+          <p className="line-clamp-2 shrink-0 text-sm font-semibold leading-tight text-foreground">
+            {primary?.title ?? "Extras"}
+          </p>
+          {primary?.note || slot.note ? (
+            <div data-slot="meal-notes" className="min-h-0 overflow-hidden">
+              {primary?.note ? (
+                <p className="line-clamp-2 text-xs text-muted-foreground">
+                  {primary.note}
+                </p>
+              ) : null}
+              {slot.note ? (
+                <p className="line-clamp-2 text-xs italic text-muted-foreground">
+                  {slot.note}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+          {hasExtras ? (
+            <div
+              data-slot="meal-extras"
+              className="mt-auto flex shrink-0 flex-nowrap items-center gap-1 overflow-hidden pt-1"
+            >
+              {slot.extras.slice(0, 2).map((extra) => (
+                <span
+                  key={extra.id}
+                  className="min-w-0 flex-1 truncate rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+                >
+                  {extra.title}
+                </span>
+              ))}
+              {slot.extras.length > 2 ? (
+                <span className="shrink-0 rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+                  +{slot.extras.length - 2} more
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </button>
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <div
+        className={cn(
+          "flex h-full w-full items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 p-3 text-sm text-muted-foreground",
+          isPlanningTarget ? "border-primary/70 ring-2 ring-primary/20" : null,
+        )}
+        aria-current={isPlanningTarget ? "true" : undefined}
+      >
+        <span className="font-medium">{formatMealType(slot.mealType)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex h-full min-h-20 w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-background p-3 transition-colors hover:border-primary/50 hover:bg-primary/5",
+        isPlanningTarget
+          ? "border-primary/70 bg-primary/5 ring-2 ring-primary/20"
+          : null,
+      )}
+      aria-current={isPlanningTarget ? "true" : undefined}
+      aria-label={emptySlotLabel({
+        mealType: slot.mealType,
+        dayLabel,
+        hasPendingRecipe: Boolean(pendingRecipeId),
+      })}
+      onClick={() => onSelectSlot(slot)}
+    >
+      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-primary/10">
+        <Plus aria-hidden className="h-4 w-4 text-primary" />
+      </span>
+      <span className="text-sm font-medium text-muted-foreground">
+        Add {slot.mealType}
+      </span>
+    </button>
+  );
+}

--- a/src/components/meals/meal-grid-card.tsx
+++ b/src/components/meals/meal-grid-card.tsx
@@ -118,7 +118,7 @@ export function MealGridCard({
               {slot.extras.slice(0, 2).map((extra) => (
                 <span
                   key={extra.id}
-                  className="min-w-0 flex-1 truncate rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
+                  className="min-w-0 flex-initial truncate rounded-full bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground"
                 >
                   {extra.title}
                 </span>

--- a/src/components/meals/meal-grid.tsx
+++ b/src/components/meals/meal-grid.tsx
@@ -129,6 +129,12 @@ export function MealGrid({
               if (!slot) return null;
 
               return (
+                // [contain:size]: the cell must take its height from the grid
+                // row (flex-distributed, floored at 170px) rather than its
+                // content. Without it the implicit auto row grows to the
+                // tallest card, breaking the equal-height fill and the row
+                // floor; align-content: stretch (the default) then re-expands
+                // the size-contained track to the row height. Don't remove it.
                 <div
                   key={`${day.date}-${mealType}`}
                   role="cell"

--- a/src/components/meals/meal-grid.tsx
+++ b/src/components/meals/meal-grid.tsx
@@ -1,12 +1,14 @@
+// biome-ignore-all lint/a11y/useSemanticElements: CSS grid needs explicit ARIA table roles so rows can flex vertically.
+// biome-ignore-all lint/a11y/useFocusableInteractive: ARIA table structure is descriptive, not interactive.
 import { formatLocalDate, parseLocalDate } from "@/lib/time-utils";
 import type { MealBoard, MealSlot } from "@/lib/types";
 import { cn } from "@/lib/utils";
+import { MealGridCard } from "./meal-grid-card";
 import type {
   MealPlanningDraft,
   MealPlanningTarget,
 } from "./meal-planning-session";
-import { MealSlotCard } from "./meal-slot-card";
-import { formatMealType } from "./meal-type-utils";
+import { formatMealType, mealTypeRailClasses } from "./meal-type-utils";
 
 function shortWeekday(date: string) {
   return parseLocalDate(date).toLocaleDateString("en-US", {
@@ -22,6 +24,9 @@ function fullWeekday(date: string) {
 
 const MEAL_ROWS: Array<MealSlot["mealType"]> = ["breakfast", "lunch", "dinner"];
 
+// One shared column template so header and body rows always align.
+const GRID_COLS = "grid grid-cols-[2.25rem_repeat(7,minmax(0,1fr))]";
+
 interface MealGridProps {
   board: MealBoard;
   readOnly: boolean;
@@ -31,6 +36,8 @@ interface MealGridProps {
   onSelectSlot: (slot: MealSlot) => void;
 }
 
+// ARIA table semantics are attached explicitly: real <table> rows cannot
+// stretch to share viewport height, a flex column of CSS grids can.
 export function MealGrid({
   board,
   readOnly,
@@ -42,104 +49,118 @@ export function MealGrid({
   const todayIso = formatLocalDate(new Date());
 
   return (
-    <div className="overflow-x-auto">
-      <table
-        aria-label="Weekly meals"
-        className="w-full table-fixed overflow-hidden rounded-lg border border-border"
-      >
-        <thead>
-          <tr>
-            <th
-              scope="col"
-              className="w-[120px] border-b border-r border-border bg-muted/40 p-3"
-            />
-            {board.days.map((day) => {
-              const isToday = day.date === todayIso;
+    <div
+      role="table"
+      aria-label="Weekly meals"
+      className="flex flex-1 flex-col overflow-hidden rounded-lg border border-border"
+    >
+      <div role="rowgroup">
+        <div role="row" className={GRID_COLS}>
+          <div
+            role="columnheader"
+            className="border-b border-r border-border bg-muted/40"
+          />
+          {board.days.map((day) => {
+            const isToday = day.date === todayIso;
 
-              return (
-                <th
-                  key={day.date}
-                  scope="col"
-                  aria-label={fullWeekday(day.date)}
-                  aria-current={isToday ? "date" : undefined}
-                  className={cn(
-                    "border-b border-r border-border p-2 text-center text-sm font-semibold text-foreground last:border-r-0",
-                    isToday ? "bg-primary/10" : "bg-muted/40",
-                  )}
-                >
-                  <span className="flex items-center justify-center gap-1.5">
-                    <span
-                      className={cn(
-                        "text-xs font-semibold uppercase",
-                        isToday ? "text-primary" : "text-muted-foreground",
-                      )}
-                    >
-                      {shortWeekday(day.date)}
-                    </span>
-                    <span
-                      className={cn(
-                        "flex h-6 min-w-6 items-center justify-center rounded-full px-1 text-sm",
-                        isToday
-                          ? "bg-primary text-primary-foreground"
-                          : "text-foreground",
-                      )}
-                    >
-                      {parseLocalDate(day.date).getDate()}
-                    </span>
-                  </span>
-                </th>
-              );
-            })}
-          </tr>
-        </thead>
-        <tbody>
-          {MEAL_ROWS.map((mealType) => (
-            <tr key={mealType}>
-              <th
-                scope="row"
-                className="border-b border-r border-border bg-muted/30 p-3 text-left text-sm font-semibold text-foreground last:border-b-0"
+            return (
+              <div
+                key={day.date}
+                role="columnheader"
+                aria-label={fullWeekday(day.date)}
+                aria-current={isToday ? "date" : undefined}
+                className={cn(
+                  "border-b border-r border-border p-2 text-center text-sm font-semibold text-foreground last:border-r-0",
+                  isToday ? "bg-primary/10" : "bg-muted/40",
+                )}
               >
-                {formatMealType(mealType)}
-              </th>
-              {board.days.map((day) => {
-                const slot = day.slots.find(
-                  (candidate) => candidate.mealType === mealType,
-                );
-                if (!slot) return null;
-
-                return (
-                  <td
-                    key={`${day.date}-${mealType}`}
+                <span className="flex items-center justify-center gap-1.5">
+                  <span
                     className={cn(
-                      "border-b border-r border-border p-2 align-top last:border-r-0",
-                      day.date === todayIso ? "bg-primary/5" : null,
+                      "text-xs font-semibold uppercase",
+                      isToday ? "text-primary" : "text-muted-foreground",
                     )}
                   >
-                    <MealSlotCard
-                      slot={slot}
-                      readOnly={readOnly}
-                      pendingRecipeId={pendingRecipeId}
-                      draft={
-                        planningDrafts.find(
-                          (draft) =>
-                            draft.target.dayIndex === slot.dayIndex &&
-                            draft.target.mealType === slot.mealType,
-                        ) ?? null
-                      }
-                      isPlanningTarget={
-                        planningTarget?.dayIndex === slot.dayIndex &&
-                        planningTarget.mealType === slot.mealType
-                      }
-                      dayLabel={fullWeekday(day.date)}
-                      onSelectSlot={onSelectSlot}
-                    />
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+                    {shortWeekday(day.date)}
+                  </span>
+                  <span
+                    className={cn(
+                      "flex h-6 min-w-6 items-center justify-center rounded-full px-1 text-sm",
+                      isToday
+                        ? "bg-primary text-primary-foreground"
+                        : "text-foreground",
+                    )}
+                  >
+                    {parseLocalDate(day.date).getDate()}
+                  </span>
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div role="rowgroup" className="flex flex-1 flex-col">
+        {MEAL_ROWS.map((mealType) => (
+          <div
+            key={mealType}
+            role="row"
+            className={cn(
+              GRID_COLS,
+              "min-h-[170px] flex-1 [&:last-child>*]:border-b-0",
+            )}
+          >
+            <div
+              role="rowheader"
+              className="flex items-center justify-center border-b border-r border-border bg-muted/30"
+            >
+              <span
+                className={cn(
+                  "rotate-180 text-xs font-semibold uppercase tracking-widest [writing-mode:vertical-rl]",
+                  mealTypeRailClasses(mealType),
+                )}
+              >
+                {formatMealType(mealType)}
+              </span>
+            </div>
+            {board.days.map((day) => {
+              const slot = day.slots.find(
+                (candidate) => candidate.mealType === mealType,
+              );
+              if (!slot) return null;
+
+              return (
+                <div
+                  key={`${day.date}-${mealType}`}
+                  role="cell"
+                  className={cn(
+                    "[contain:size] border-b border-r border-border p-2 last:border-r-0",
+                    day.date === todayIso ? "bg-primary/5" : null,
+                  )}
+                >
+                  <MealGridCard
+                    slot={slot}
+                    readOnly={readOnly}
+                    pendingRecipeId={pendingRecipeId}
+                    draft={
+                      planningDrafts.find(
+                        (draft) =>
+                          draft.target.dayIndex === slot.dayIndex &&
+                          draft.target.mealType === slot.mealType,
+                      ) ?? null
+                    }
+                    isPlanningTarget={
+                      planningTarget?.dayIndex === slot.dayIndex &&
+                      planningTarget.mealType === slot.mealType
+                    }
+                    dayLabel={fullWeekday(day.date)}
+                    onSelectSlot={onSelectSlot}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/meals/meal-grid.tsx
+++ b/src/components/meals/meal-grid.tsx
@@ -1,5 +1,6 @@
-import { parseLocalDate } from "@/lib/time-utils";
+import { formatLocalDate, parseLocalDate } from "@/lib/time-utils";
 import type { MealBoard, MealSlot } from "@/lib/types";
+import { cn } from "@/lib/utils";
 import type {
   MealPlanningDraft,
   MealPlanningTarget,
@@ -7,7 +8,13 @@ import type {
 import { MealSlotCard } from "./meal-slot-card";
 import { formatMealType } from "./meal-type-utils";
 
-function dayName(date: string) {
+function shortWeekday(date: string) {
+  return parseLocalDate(date).toLocaleDateString("en-US", {
+    weekday: "short",
+  });
+}
+
+function fullWeekday(date: string) {
   return parseLocalDate(date).toLocaleDateString("en-US", {
     weekday: "long",
   });
@@ -32,11 +39,13 @@ export function MealGrid({
   planningTarget = null,
   onSelectSlot,
 }: MealGridProps) {
+  const todayIso = formatLocalDate(new Date());
+
   return (
     <div className="overflow-x-auto">
       <table
         aria-label="Weekly meals"
-        className="min-w-[960px] table-fixed overflow-hidden rounded-lg border border-border"
+        className="w-full table-fixed overflow-hidden rounded-lg border border-border"
       >
         <thead>
           <tr>
@@ -44,15 +53,43 @@ export function MealGrid({
               scope="col"
               className="w-[120px] border-b border-r border-border bg-muted/40 p-3"
             />
-            {board.days.map((day) => (
-              <th
-                key={day.date}
-                scope="col"
-                className="border-b border-r border-border bg-muted/40 p-3 text-center text-sm font-semibold text-foreground last:border-r-0"
-              >
-                {dayName(day.date)}
-              </th>
-            ))}
+            {board.days.map((day) => {
+              const isToday = day.date === todayIso;
+
+              return (
+                <th
+                  key={day.date}
+                  scope="col"
+                  aria-label={fullWeekday(day.date)}
+                  aria-current={isToday ? "date" : undefined}
+                  className={cn(
+                    "border-b border-r border-border p-2 text-center text-sm font-semibold text-foreground last:border-r-0",
+                    isToday ? "bg-primary/10" : "bg-muted/40",
+                  )}
+                >
+                  <span className="flex items-center justify-center gap-1.5">
+                    <span
+                      className={cn(
+                        "text-xs font-semibold uppercase",
+                        isToday ? "text-primary" : "text-muted-foreground",
+                      )}
+                    >
+                      {shortWeekday(day.date)}
+                    </span>
+                    <span
+                      className={cn(
+                        "flex h-6 min-w-6 items-center justify-center rounded-full px-1 text-sm",
+                        isToday
+                          ? "bg-primary text-primary-foreground"
+                          : "text-foreground",
+                      )}
+                    >
+                      {parseLocalDate(day.date).getDate()}
+                    </span>
+                  </span>
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>
@@ -73,7 +110,10 @@ export function MealGrid({
                 return (
                   <td
                     key={`${day.date}-${mealType}`}
-                    className="border-b border-r border-border p-2 align-top last:border-r-0"
+                    className={cn(
+                      "border-b border-r border-border p-2 align-top last:border-r-0",
+                      day.date === todayIso ? "bg-primary/5" : null,
+                    )}
                   >
                     <MealSlotCard
                       slot={slot}
@@ -90,6 +130,7 @@ export function MealGrid({
                         planningTarget?.dayIndex === slot.dayIndex &&
                         planningTarget.mealType === slot.mealType
                       }
+                      dayLabel={fullWeekday(day.date)}
                       onSelectSlot={onSelectSlot}
                     />
                   </td>

--- a/src/components/meals/meal-slot-card.test.tsx
+++ b/src/components/meals/meal-slot-card.test.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
 import type { MealSlot, MealSlotEntry } from "@/lib/types";
-import { render, screen } from "@/test/test-utils";
+import { fireEvent, render, screen } from "@/test/test-utils";
 import type { MealPlanningDraft } from "./meal-planning-session";
 import { MealSlotCard } from "./meal-slot-card";
 
@@ -121,5 +121,51 @@ describe("MealSlotCard accessible label", () => {
     expect(
       screen.getByRole("button", { name: "Open dinner, Friday: extras" }),
     ).toBeInTheDocument();
+  });
+});
+
+describe("MealSlotCard image fallback", () => {
+  function primaryWithImage(imageUrl: string): MealSlotEntry {
+    return {
+      id: "primary-1",
+      role: "primary",
+      sourceType: "recipe",
+      recipeId: "r1",
+      title: "Adobo",
+      imageUrl,
+      note: null,
+    };
+  }
+
+  it("re-shows the image after the source changes following a load error", () => {
+    const { container, rerender } = render(
+      <MealSlotCard
+        slot={slot({ primary: primaryWithImage("https://img/a.jpg") })}
+        readOnly={false}
+        dayLabel="Friday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const firstImage = container.querySelector("img");
+    expect(firstImage).toHaveAttribute("src", "https://img/a.jpg");
+
+    // The first image fails to load and falls back to the placeholder tile.
+    fireEvent.error(firstImage as HTMLImageElement);
+    expect(container.querySelector("img")).toBeNull();
+
+    // A different meal (new image URL) must render, not stay stuck on fallback.
+    rerender(
+      <MealSlotCard
+        slot={slot({ primary: primaryWithImage("https://img/b.jpg") })}
+        readOnly={false}
+        dayLabel="Friday"
+        onSelectSlot={vi.fn()}
+      />,
+    );
+
+    const nextImage = container.querySelector("img");
+    expect(nextImage).not.toBeNull();
+    expect(nextImage).toHaveAttribute("src", "https://img/b.jpg");
   });
 });

--- a/src/components/meals/meal-slot-card.test.tsx
+++ b/src/components/meals/meal-slot-card.test.tsx
@@ -1,0 +1,125 @@
+import type { ComponentProps } from "react";
+import { describe, expect, it, vi } from "vitest";
+import type { MealSlot, MealSlotEntry } from "@/lib/types";
+import { render, screen } from "@/test/test-utils";
+import type { MealPlanningDraft } from "./meal-planning-session";
+import { MealSlotCard } from "./meal-slot-card";
+
+function entry(title: string, role: MealSlotEntry["role"]): MealSlotEntry {
+  return {
+    id: `${role}-1`,
+    role,
+    sourceType: "quick",
+    recipeId: null,
+    title,
+    imageUrl: null,
+    note: null,
+  };
+}
+
+function slot(
+  overrides: Partial<Pick<MealSlot, "primary" | "extras">> = {},
+): MealSlot {
+  return {
+    id: null,
+    weekStartDate: "2026-07-12",
+    dayIndex: 5,
+    mealType: "dinner",
+    primary: null,
+    extras: [],
+    note: null,
+    ...overrides,
+  };
+}
+
+function draft(title: string): MealPlanningDraft {
+  return {
+    target: { dayIndex: 5, mealType: "dinner" },
+    displayTitle: title,
+    displayImageUrl: null,
+    displayNote: null,
+    primary: {
+      sourceType: "quick",
+      recipeId: null,
+      title,
+      imageUrl: null,
+      note: null,
+    },
+    note: null,
+  };
+}
+
+function renderCard(
+  overrides: Partial<ComponentProps<typeof MealSlotCard>> = {},
+) {
+  render(
+    <MealSlotCard
+      slot={slot()}
+      readOnly={false}
+      dayLabel="Friday"
+      onSelectSlot={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe("MealSlotCard accessible label", () => {
+  it("treats an empty pending recipe ID as no pending recipe", () => {
+    renderCard({ pendingRecipeId: "" });
+
+    expect(
+      screen.getByRole("button", { name: "Add dinner meal, Friday" }),
+    ).toBeInTheDocument();
+  });
+
+  it("gives a draft precedence over primary and extra entries", () => {
+    renderCard({
+      slot: slot({
+        primary: entry("Stored primary", "primary"),
+        extras: [entry("Stored extra", "extra")],
+      }),
+      draft: draft("Draft meal"),
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Draft dinner, Friday: Draft meal",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("gives a primary entry precedence over extra entries", () => {
+    renderCard({
+      slot: slot({
+        primary: entry("Stored primary", "primary"),
+        extras: [entry("Stored extra", "extra")],
+      }),
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open dinner, Friday: Stored primary",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the first extra title when no draft or primary exists", () => {
+    renderCard({
+      slot: slot({ extras: [entry("Stored extra", "extra")] }),
+    });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Open dinner, Friday: extras - Stored extra",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits a falsy first extra title", () => {
+    renderCard({ slot: slot({ extras: [entry("", "extra")] }) });
+
+    expect(
+      screen.getByRole("button", { name: "Open dinner, Friday: extras" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import type { MealSlot } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { MealPlanningDraft } from "./meal-planning-session";
+import { emptySlotLabel, filledSlotLabel } from "./meal-slot-labels";
 import { formatMealType } from "./meal-type-utils";
 
 interface MealSlotCardProps {
@@ -36,7 +37,6 @@ export function MealSlotCard({
   const hasExtras = !draft && slot.extras.length > 0;
   const hasExtrasOnly = !primary && hasExtras;
   const firstExtraTitle = slot.extras[0]?.title;
-  const dayContext = dayLabel ? `, ${dayLabel}` : "";
 
   if (primary || hasExtrasOnly) {
     return (
@@ -50,15 +50,13 @@ export function MealSlotCard({
             : null,
         )}
         aria-current={isPlanningTarget ? "true" : undefined}
-        aria-label={
-          draft
-            ? `Draft ${slot.mealType}${dayContext}: ${draft.displayTitle}`
-            : primary
-              ? `Open ${slot.mealType}${dayContext}: ${primary.title}`
-              : firstExtraTitle
-                ? `Open ${slot.mealType}${dayContext}: extras - ${firstExtraTitle}`
-                : `Open ${slot.mealType}${dayContext}: extras`
-        }
+        aria-label={filledSlotLabel({
+          mealType: slot.mealType,
+          dayLabel,
+          draftTitle: draft ? draft.displayTitle : null,
+          primaryTitle: !draft && slot.primary ? slot.primary.title : null,
+          firstExtraTitle: firstExtraTitle ?? null,
+        })}
         onClick={() => onSelectSlot(slot)}
       >
         <div className="flex items-start gap-3">
@@ -143,11 +141,11 @@ export function MealSlotCard({
           : null,
       )}
       aria-current={isPlanningTarget ? "true" : undefined}
-      aria-label={
-        pendingRecipeId
-          ? `Add recipe to ${slot.mealType}${dayContext}`
-          : `Add ${slot.mealType} meal${dayContext}`
-      }
+      aria-label={emptySlotLabel({
+        mealType: slot.mealType,
+        dayLabel,
+        hasPendingRecipe: Boolean(pendingRecipeId),
+      })}
       onClick={() => onSelectSlot(slot)}
     >
       <div>

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -75,7 +75,7 @@ export function MealSlotCard({
             </div>
           )}
           <div className="min-w-0 flex-1">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <p className="truncate text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               {label}
             </p>
             {draft ? (

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -25,7 +25,7 @@ export function MealSlotCard({
   dayLabel,
   onSelectSlot,
 }: MealSlotCardProps) {
-  const [imgFailed, setImgFailed] = useState(false);
+  const [failedImageUrl, setFailedImageUrl] = useState<string | null>(null);
   const label = formatMealType(slot.mealType);
   const primary = draft
     ? {
@@ -34,6 +34,9 @@ export function MealSlotCard({
         note: draft.displayNote,
       }
     : slot.primary;
+  // Key the load-error fallback on the URL, not a sticky boolean, so a new
+  // image (edited meal / different draft) recovers instead of staying blanked.
+  const imageUrl = primary?.imageUrl ?? null;
   const hasExtras = !draft && slot.extras.length > 0;
   const hasExtrasOnly = !primary && hasExtras;
   const firstExtraTitle = slot.extras[0]?.title;
@@ -60,12 +63,12 @@ export function MealSlotCard({
         onClick={() => onSelectSlot(slot)}
       >
         <div className="flex items-start gap-3">
-          {primary?.imageUrl && !imgFailed ? (
+          {imageUrl && imageUrl !== failedImageUrl ? (
             <img
-              src={primary.imageUrl}
+              src={imageUrl}
               alt=""
               className="h-14 w-14 rounded-md object-cover"
-              onError={() => setImgFailed(true)}
+              onError={() => setFailedImageUrl(imageUrl)}
             />
           ) : (
             <div className="flex h-14 w-14 items-center justify-center rounded-md bg-muted text-xs font-semibold text-muted-foreground">

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -11,6 +11,7 @@ interface MealSlotCardProps {
   pendingRecipeId?: string | null;
   draft?: MealPlanningDraft | null;
   isPlanningTarget?: boolean;
+  dayLabel?: string;
   onSelectSlot: (slot: MealSlot) => void;
 }
 
@@ -20,6 +21,7 @@ export function MealSlotCard({
   pendingRecipeId = null,
   draft = null,
   isPlanningTarget = false,
+  dayLabel,
   onSelectSlot,
 }: MealSlotCardProps) {
   const [imgFailed, setImgFailed] = useState(false);
@@ -34,6 +36,7 @@ export function MealSlotCard({
   const hasExtras = !draft && slot.extras.length > 0;
   const hasExtrasOnly = !primary && hasExtras;
   const firstExtraTitle = slot.extras[0]?.title;
+  const dayContext = dayLabel ? `, ${dayLabel}` : "";
 
   if (primary || hasExtrasOnly) {
     return (
@@ -49,12 +52,12 @@ export function MealSlotCard({
         aria-current={isPlanningTarget ? "true" : undefined}
         aria-label={
           draft
-            ? `Draft ${slot.mealType}: ${draft.displayTitle}`
+            ? `Draft ${slot.mealType}${dayContext}: ${draft.displayTitle}`
             : primary
-              ? `Open ${slot.mealType}: ${primary.title}`
+              ? `Open ${slot.mealType}${dayContext}: ${primary.title}`
               : firstExtraTitle
-                ? `Open ${slot.mealType}: extras - ${firstExtraTitle}`
-                : `Open ${slot.mealType}: extras`
+                ? `Open ${slot.mealType}${dayContext}: extras - ${firstExtraTitle}`
+                : `Open ${slot.mealType}${dayContext}: extras`
         }
         onClick={() => onSelectSlot(slot)}
       >
@@ -142,8 +145,8 @@ export function MealSlotCard({
       aria-current={isPlanningTarget ? "true" : undefined}
       aria-label={
         pendingRecipeId
-          ? `Add recipe to ${slot.mealType}`
-          : `Add ${slot.mealType} meal`
+          ? `Add recipe to ${slot.mealType}${dayContext}`
+          : `Add ${slot.mealType}${dayContext} meal`
       }
       onClick={() => onSelectSlot(slot)}
     >

--- a/src/components/meals/meal-slot-card.tsx
+++ b/src/components/meals/meal-slot-card.tsx
@@ -146,7 +146,7 @@ export function MealSlotCard({
       aria-label={
         pendingRecipeId
           ? `Add recipe to ${slot.mealType}${dayContext}`
-          : `Add ${slot.mealType}${dayContext} meal`
+          : `Add ${slot.mealType} meal${dayContext}`
       }
       onClick={() => onSelectSlot(slot)}
     >

--- a/src/components/meals/meal-slot-labels.test.ts
+++ b/src/components/meals/meal-slot-labels.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { emptySlotLabel, filledSlotLabel } from "./meal-slot-labels";
+
+describe("filledSlotLabel", () => {
+  it("describes a draft slot", () => {
+    expect(
+      filledSlotLabel({
+        mealType: "dinner",
+        dayLabel: "Wednesday",
+        draftTitle: "Adobo",
+        primaryTitle: null,
+        firstExtraTitle: null,
+      }),
+    ).toBe("Draft dinner, Wednesday: Adobo");
+  });
+
+  it("describes a primary meal", () => {
+    expect(
+      filledSlotLabel({
+        mealType: "lunch",
+        dayLabel: "Monday",
+        draftTitle: null,
+        primaryTitle: "Sandwich",
+        firstExtraTitle: null,
+      }),
+    ).toBe("Open lunch, Monday: Sandwich");
+  });
+
+  it("describes extras-only slots", () => {
+    expect(
+      filledSlotLabel({
+        mealType: "breakfast",
+        dayLabel: "Sunday",
+        draftTitle: null,
+        primaryTitle: null,
+        firstExtraTitle: "Fruit",
+      }),
+    ).toBe("Open breakfast, Sunday: extras - Fruit");
+    expect(
+      filledSlotLabel({
+        mealType: "breakfast",
+        dayLabel: "Sunday",
+        draftTitle: null,
+        primaryTitle: null,
+        firstExtraTitle: null,
+      }),
+    ).toBe("Open breakfast, Sunday: extras");
+  });
+
+  it("omits an empty first extra title", () => {
+    expect(
+      filledSlotLabel({
+        mealType: "breakfast",
+        dayLabel: "Sunday",
+        draftTitle: null,
+        primaryTitle: null,
+        firstExtraTitle: "",
+      }),
+    ).toBe("Open breakfast, Sunday: extras");
+  });
+
+  it("omits day context when no dayLabel is given", () => {
+    expect(
+      filledSlotLabel({
+        mealType: "lunch",
+        draftTitle: null,
+        primaryTitle: "Soup",
+        firstExtraTitle: null,
+      }),
+    ).toBe("Open lunch: Soup");
+  });
+});
+
+describe("emptySlotLabel", () => {
+  it("describes an empty slot", () => {
+    expect(
+      emptySlotLabel({
+        mealType: "dinner",
+        dayLabel: "Friday",
+        hasPendingRecipe: false,
+      }),
+    ).toBe("Add dinner meal, Friday");
+  });
+
+  it("describes recipe placement", () => {
+    expect(
+      emptySlotLabel({
+        mealType: "dinner",
+        dayLabel: "Friday",
+        hasPendingRecipe: true,
+      }),
+    ).toBe("Add recipe to dinner, Friday");
+  });
+
+  it("omits day context when no dayLabel is given", () => {
+    expect(emptySlotLabel({ mealType: "lunch", hasPendingRecipe: false })).toBe(
+      "Add lunch meal",
+    );
+  });
+});

--- a/src/components/meals/meal-slot-labels.ts
+++ b/src/components/meals/meal-slot-labels.ts
@@ -1,0 +1,50 @@
+import type { MealSlot } from "@/lib/types";
+
+interface FilledSlotLabelInput {
+  mealType: MealSlot["mealType"];
+  dayLabel?: string;
+  draftTitle: string | null;
+  primaryTitle: string | null;
+  firstExtraTitle: string | null;
+}
+
+interface EmptySlotLabelInput {
+  mealType: MealSlot["mealType"];
+  dayLabel?: string;
+  hasPendingRecipe: boolean;
+}
+
+function dayContext(dayLabel?: string) {
+  return dayLabel ? `, ${dayLabel}` : "";
+}
+
+export function filledSlotLabel({
+  mealType,
+  dayLabel,
+  draftTitle,
+  primaryTitle,
+  firstExtraTitle,
+}: FilledSlotLabelInput): string {
+  const context = dayContext(dayLabel);
+  if (draftTitle !== null) {
+    return `Draft ${mealType}${context}: ${draftTitle}`;
+  }
+  if (primaryTitle !== null) {
+    return `Open ${mealType}${context}: ${primaryTitle}`;
+  }
+  if (firstExtraTitle) {
+    return `Open ${mealType}${context}: extras - ${firstExtraTitle}`;
+  }
+  return `Open ${mealType}${context}: extras`;
+}
+
+export function emptySlotLabel({
+  mealType,
+  dayLabel,
+  hasPendingRecipe,
+}: EmptySlotLabelInput): string {
+  const context = dayContext(dayLabel);
+  return hasPendingRecipe
+    ? `Add recipe to ${mealType}${context}`
+    : `Add ${mealType} meal${context}`;
+}

--- a/src/components/meals/meal-type-utils.test.ts
+++ b/src/components/meals/meal-type-utils.test.ts
@@ -1,0 +1,48 @@
+import { CookingPot, Croissant, Sandwich } from "lucide-react";
+import { describe, expect, it } from "vitest";
+import {
+  formatMealType,
+  mealTypeBandClasses,
+  mealTypeIcon,
+  mealTypeRailClasses,
+} from "./meal-type-utils";
+
+describe("formatMealType", () => {
+  it("capitalizes the meal type", () => {
+    expect(formatMealType("breakfast")).toBe("Breakfast");
+    expect(formatMealType("lunch")).toBe("Lunch");
+    expect(formatMealType("dinner")).toBe("Dinner");
+  });
+});
+
+describe("mealTypeIcon", () => {
+  it("maps each meal type to its glyph", () => {
+    expect(mealTypeIcon("breakfast")).toBe(Croissant);
+    expect(mealTypeIcon("lunch")).toBe(Sandwich);
+    expect(mealTypeIcon("dinner")).toBe(CookingPot);
+  });
+});
+
+describe("mealTypeBandClasses", () => {
+  it("returns the tinted band background and foreground", () => {
+    expect(mealTypeBandClasses("breakfast")).toBe(
+      "bg-meal-breakfast text-meal-breakfast-foreground",
+    );
+    expect(mealTypeBandClasses("lunch")).toBe(
+      "bg-meal-lunch text-meal-lunch-foreground",
+    );
+    expect(mealTypeBandClasses("dinner")).toBe(
+      "bg-meal-dinner text-meal-dinner-foreground",
+    );
+  });
+});
+
+describe("mealTypeRailClasses", () => {
+  it("returns the rail label foreground", () => {
+    expect(mealTypeRailClasses("breakfast")).toBe(
+      "text-meal-breakfast-foreground",
+    );
+    expect(mealTypeRailClasses("lunch")).toBe("text-meal-lunch-foreground");
+    expect(mealTypeRailClasses("dinner")).toBe("text-meal-dinner-foreground");
+  });
+});

--- a/src/components/meals/meal-type-utils.ts
+++ b/src/components/meals/meal-type-utils.ts
@@ -1,5 +1,38 @@
+import { CookingPot, Croissant, type LucideIcon, Sandwich } from "lucide-react";
 import type { MealSlot } from "@/lib/types";
 
 export function formatMealType(mealType: MealSlot["mealType"]): string {
   return mealType.charAt(0).toUpperCase() + mealType.slice(1);
+}
+
+const MEAL_TYPE_ICONS: Record<MealSlot["mealType"], LucideIcon> = {
+  breakfast: Croissant,
+  lunch: Sandwich,
+  dinner: CookingPot,
+};
+
+export function mealTypeIcon(mealType: MealSlot["mealType"]): LucideIcon {
+  return MEAL_TYPE_ICONS[mealType];
+}
+
+// Tailwind can't see interpolated class names, so each full class string is
+// written out literally.
+const MEAL_TYPE_BAND_CLASSES: Record<MealSlot["mealType"], string> = {
+  breakfast: "bg-meal-breakfast text-meal-breakfast-foreground",
+  lunch: "bg-meal-lunch text-meal-lunch-foreground",
+  dinner: "bg-meal-dinner text-meal-dinner-foreground",
+};
+
+export function mealTypeBandClasses(mealType: MealSlot["mealType"]): string {
+  return MEAL_TYPE_BAND_CLASSES[mealType];
+}
+
+const MEAL_TYPE_RAIL_CLASSES: Record<MealSlot["mealType"], string> = {
+  breakfast: "text-meal-breakfast-foreground",
+  lunch: "text-meal-lunch-foreground",
+  dinner: "text-meal-dinner-foreground",
+};
+
+export function mealTypeRailClasses(mealType: MealSlot["mealType"]): string {
+  return MEAL_TYPE_RAIL_CLASSES[mealType];
 }

--- a/src/components/meals/week-header.test.tsx
+++ b/src/components/meals/week-header.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { WeekHeader } from "./week-header";
+
+describe("WeekHeader", () => {
+  const props = {
+    weekStartDate: "2026-07-12",
+    readOnly: false,
+    onWeekChange: vi.fn(),
+  };
+
+  it("renders actions inside the toolbar alongside previous-week navigation", () => {
+    renderWithUser(
+      <WeekHeader
+        {...props}
+        actions={<button type="button">Fill empty slots</button>}
+      />,
+    );
+
+    const actionsButton = screen.getByRole("button", {
+      name: "Fill empty slots",
+    });
+    expect(actionsButton.closest('[data-slot="week-header"]')).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Previous week" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps navigation available without rendering an actions button", () => {
+    renderWithUser(<WeekHeader {...props} />);
+
+    expect(
+      screen.queryByRole("button", { name: "Fill empty slots" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Next week" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/meals/week-header.tsx
+++ b/src/components/meals/week-header.tsx
@@ -1,4 +1,5 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks";
 import {
@@ -6,6 +7,7 @@ import {
   formatLocalDate,
   parseLocalDate,
 } from "@/lib/time-utils";
+import { cn } from "@/lib/utils";
 
 function formatShortDate(date: Date) {
   return date.toLocaleDateString("en-US", {
@@ -25,18 +27,26 @@ interface WeekHeaderProps {
   weekStartDate: string;
   readOnly: boolean;
   onWeekChange: (weekStartDate: string) => void;
+  actions?: ReactNode;
 }
 
 export function WeekHeader({
   weekStartDate,
   readOnly,
   onWeekChange,
+  actions,
 }: WeekHeaderProps) {
   const isMobile = useIsMobile();
   const currentStart = parseLocalDate(weekStartDate);
 
   return (
-    <div className="flex items-start justify-between gap-3">
+    <div
+      data-slot="week-header"
+      className={cn(
+        "flex justify-between gap-3",
+        actions ? "items-center" : "items-start",
+      )}
+    >
       <div>
         <div className="flex flex-wrap items-center gap-2">
           {/* Title is redundant with the mobile module-aware header; desktop keeps it. */}
@@ -54,29 +64,32 @@ export function WeekHeader({
         </p>
       </div>
 
-      <div className="flex items-center gap-1">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Previous week"
-          onClick={() =>
-            onWeekChange(formatLocalDate(addWeeksLocal(currentStart, -1)))
-          }
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Next week"
-          onClick={() =>
-            onWeekChange(formatLocalDate(addWeeksLocal(currentStart, 1)))
-          }
-        >
-          <ChevronRight className="h-4 w-4" />
-        </Button>
+      <div className="flex items-center gap-2">
+        {actions}
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Previous week"
+            onClick={() =>
+              onWeekChange(formatLocalDate(addWeeksLocal(currentStart, -1)))
+            }
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Next week"
+            onClick={() =>
+              onWeekChange(formatLocalDate(addWeeksLocal(currentStart, 1)))
+            }
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,15 @@
   --color-pink: oklch(0.551 0.131 354);
   --color-orange: oklch(0.575 0.119 56);
 
+  /* Meal-type accents: soft banner tints + AA-contrast glyph/label foregrounds.
+     Used only where a meal photo is absent (placeholder band, rail label). */
+  --meal-breakfast: oklch(0.93 0.05 80);
+  --meal-breakfast-foreground: oklch(0.52 0.11 70);
+  --meal-lunch: oklch(0.93 0.05 150);
+  --meal-lunch-foreground: oklch(0.48 0.1 150);
+  --meal-dinner: oklch(0.93 0.05 285);
+  --meal-dinner-foreground: oklch(0.5 0.13 285);
+
   --radius: 0.75rem;
   --sidebar: oklch(1 0 0);
   --sidebar-foreground: oklch(0.25 0.02 250);
@@ -74,6 +83,12 @@
   --color-yellow: var(--color-yellow);
   --color-pink: var(--color-pink);
   --color-orange: var(--color-orange);
+  --color-meal-breakfast: var(--meal-breakfast);
+  --color-meal-breakfast-foreground: var(--meal-breakfast-foreground);
+  --color-meal-lunch: var(--meal-lunch);
+  --color-meal-lunch-foreground: var(--meal-lunch-foreground);
+  --color-meal-dinner: var(--meal-dinner);
+  --color-meal-dinner-foreground: var(--meal-dinner-foreground);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);


### PR DESCRIPTION
## Summary

- Makes the Meals week board full-width at lg+ with seven visible day columns, one-line Calendar-consistent headers, and a centered 1600px cap.
- Merges Add ingredients and Fill empty slots into the large-screen WeekHeader toolbar while preserving the standalone below-lg row and day-card layout.
- Adds real-browser geometry coverage and a 12-image visual matrix for full, empty, long-name, and past-week states.

## Contract links

- Story: https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-meals.md
- Spec: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-06-large-screen-meals-design.md
- Plan: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-07-11-large-screen-meals.md

## Issue

No assigned FE implementation Issue exists. The Issue-first gate was explicitly waived for this delivery, so no accurate `Closes #…` reference can be supplied.

## Verification

- `npm run build` — passed
- `npm run lint` — passed (existing Biome schema/deprecation informational notices only)
- `npm test -- --run` — passed
- `npm run test:e2e -- e2e/large-screen-meals.spec.ts --project=chromium` — v2 suite passed 4/4 (supersedes the earlier v1 3-test run)
- `npm run test:e2e -- e2e/mobile-meals.spec.ts --project="Mobile Chrome"` — Task 8 execution evidence: passed 6/6
- Real-browser verification used released `family-hub-api` v1.9.0.

## Geometry and visual QA

- Overflow geometry passed at 1024, 1280, 1440, and 1920px: no grid-wrapper or document horizontal overflow; table stays within viewport; all three rows fit at 1024px; 1920px cap is centered.
- 900px breakpoint test confirms the stacked day-card layout, seven dinner add controls, and standalone action row remain below lg.
- Reviewed 12 direct board captures: full week, empty week, long names, and past read-only week at 1024, 1440, and 1920px. No clipping, header wrapping, uneven cards, weak today cue, or centering issue remains.

## Requirement checklist

- [x] Seven day columns and three rows visible without horizontal scroll at lg+ — full-width fixed table plus geometry assertions.
- [x] Board centered under a generous 1600px cap — MealsView cap and 1920px centering assertion.
- [x] Calendar-style one-line Sun 5 headers with full weekday accessible names — MealGrid semantics/integration tests.
- [x] Today has header accent, filled date pill, column tint, and `aria-current="date"` — unit/integration and browser checks.
- [x] Focused grid slots expose meal type, full weekday, and untruncated title; below-lg labels stay unchanged — grid-only dayLabel plus regression tests.
- [x] Large-screen actions occupy one WeekHeader toolbar row; below-lg row remains standalone — shared MealBoardActions, header slot, breakpoint tests.
- [x] Add/edit/move/planning/recipe-link/ingredients flows remain intact — existing Meals integration and Mobile Chrome E2E coverage.
- [x] Screenshot matrix reviewed across all required states and widths — dedicated Playwright visual-matrix test.

## v2 revision — full-height board

- Design spec: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-12-large-screen-meals-v2-design.md
- Implementation plan: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-07-12-large-screen-meals-v2.md

### v2 contract mapped to commits

- [x] Full-height board at lg+, equal rows with a 170px floor, and section scrolling on short viewports without `min-h-0` on the grid root or body rowgroup — `5c04ddd`, `2a51344`; real-browser geometry and containment regression coverage — `78802f8`.
- [x] 2.25rem bottom-to-top sideways rail with real ARIA row headers, plus the labeled ARIA table, eight column headers, today-only `aria-current="date"`, and exact slot names — `e334728`, `5c04ddd`.
- [x] Grid-only banner cards with photo or tinted glyph band, two-line titles, bounded notes/extras chips, and no meal-type eyebrow — `eb5ac42`, integrated by `5c04ddd`.
- [x] Light-only breakfast/lunch/dinner tint tokens and static Tailwind v4-safe utility mappings, used by placeholder bands and rail labels — `76caf6a`, `d314f5c`.
- [x] Image-less planned meals remain clearly distinct from transparent dashed empty add targets — `eb5ac42`, with visual-matrix coverage in `78802f8`.
- [x] Shared byte-identical accessible-label logic with `MealSlotCard` and the complete mobile experience unchanged — `e334728`; confirmed by the Task 8 Mobile Chrome E2E run (6/6 passed).
- [x] Large-screen E2E selectors and vertical-fill assertions were refactored for the ARIA grid, and the 12-image full/empty/long-name/past × 1024/1440/1920 matrix was recaptured and reviewed — `78802f8`.

The previously failing v1 CI layout expectations are superseded by the refactored v2 tests in `78802f8`.
