### PR TITLE
feat(chores): add full-height large-screen board

### DIFF
--- a/src/components/chores-view.test.tsx
+++ b/src/components/chores-view.test.tsx
@@ -23,7 +23,10 @@ import {
 } from "@/test/test-utils";
 import { ChoresView } from "./chores-view";
 
-const viewport = vi.hoisted(() => ({ isMobile: false }));
+const viewport = vi.hoisted(() => ({
+  isMobile: false,
+  isLargeScreen: false,
+}));
 const mockToast = vi.hoisted(() => vi.fn());
 
 vi.mock("@/hooks", async (importOriginal) => {
@@ -31,6 +34,7 @@ vi.mock("@/hooks", async (importOriginal) => {
   return {
     ...actual,
     useIsMobile: () => viewport.isMobile,
+    useIsLargeScreen: () => viewport.isLargeScreen,
   };
 });
 
@@ -144,6 +148,7 @@ describe("ChoresView", () => {
 
   beforeEach(() => {
     viewport.isMobile = false;
+    viewport.isLargeScreen = false;
     mockToast.mockClear();
     seedFamilyStore({
       members: [
@@ -495,6 +500,72 @@ describe("ChoresView", () => {
 
     await waitFor(() => {
       expect(capturedUpdateBody).toEqual({ archived: true });
+    });
+  });
+
+  describe("ChoresView large screen (full-height board)", () => {
+    beforeEach(() => {
+      viewport.isLargeScreen = true;
+    });
+
+    it("renders the full-height board with Today emphasized", async () => {
+      seedMockChoresBoard(sampleChoresBoard());
+
+      render(<ChoresView />);
+
+      const today = await screen.findByRole("region", { name: "Today" });
+      const thisWeek = screen.getByRole("region", { name: "This Week" });
+      const thisMonth = screen.getByRole("region", { name: "This Month" });
+
+      expect(today).toBeVisible();
+      expect(thisWeek).toBeVisible();
+      expect(thisMonth).toBeVisible();
+      expect(today).toHaveAttribute("data-emphasis", "true");
+      expect(thisWeek).not.toHaveAttribute("data-emphasis");
+    });
+
+    it("completes a Today routine through the full-height board", async () => {
+      let capturedCompletionBody: UpdateCurrentPeriodCompletionRequest | null =
+        null;
+      server.use(
+        http.put(
+          `${API_BASE}/chores/templates/brush-teeth-id/current-period-completion`,
+          async ({ request }) => {
+            capturedCompletionBody =
+              (await request.json()) as UpdateCurrentPeriodCompletionRequest;
+            return HttpResponse.json({
+              data: {
+                scope: "TODAY",
+                periodStartDate: "2026-05-17",
+                periodEndDate: "2026-05-17",
+                item: {
+                  templateId: "brush-teeth-id",
+                  title: "Brush teeth",
+                  cadence: "DAILY",
+                  assignedToMemberId: "leo",
+                  completed: true,
+                  completedAt: "2026-05-17T09:30:00Z",
+                },
+              },
+            });
+          },
+        ),
+      );
+      seedMockChoresBoard(sampleChoresBoard());
+      const { user } = renderWithUser(<ChoresView />);
+
+      await user.click(
+        await screen.findByRole("button", {
+          name: /mark brush teeth complete/i,
+        }),
+      );
+
+      await waitFor(() => {
+        expect(capturedCompletionBody).toEqual({
+          scope: "TODAY",
+          periodStartDate: "2026-05-17",
+        });
+      });
     });
   });
 });

--- a/src/components/chores-view.test.tsx
+++ b/src/components/chores-view.test.tsx
@@ -522,6 +522,7 @@ describe("ChoresView", () => {
       expect(thisMonth).toBeVisible();
       expect(today).toHaveAttribute("data-emphasis", "true");
       expect(thisWeek).not.toHaveAttribute("data-emphasis");
+      expect(thisMonth).not.toHaveAttribute("data-emphasis");
     });
 
     it("completes a Today routine through the full-height board", async () => {

--- a/src/components/chores-view.tsx
+++ b/src/components/chores-view.tsx
@@ -10,6 +10,7 @@ import {
   useUpdateChoreTemplate,
 } from "@/api";
 import { ChoreFormSheet } from "@/components/chores/chore-form-sheet";
+import { ChoresBoardLarge } from "@/components/chores/chores-board-large";
 import { ChoreScopeColumn } from "@/components/chores/chores-scope-column";
 import {
   type ChoreScopeKey,
@@ -22,7 +23,7 @@ import {
 } from "@/components/shared";
 import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/toaster";
-import { useIsMobile } from "@/hooks";
+import { useIsLargeScreen, useIsMobile } from "@/hooks";
 import type { ChoreBoardItem, ChoreScopeBoard, ChoresBoard } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import type { ChoreFormData } from "@/lib/validations";
@@ -51,6 +52,7 @@ function showStalePeriodRecovery(error: ApiException) {
 
 export function ChoresView() {
   const isMobile = useIsMobile();
+  const isLargeScreen = useIsLargeScreen();
   const [selectedScopeKey, setSelectedScopeKey] =
     useState<ChoreScopeKey>("today");
   const [isCreateOpen, setCreateOpen] = useState(false);
@@ -116,13 +118,23 @@ export function ChoresView() {
   return (
     <>
       <div
-        className="flex-1 overflow-y-auto p-4 sm:p-6"
+        className={cn(
+          "flex-1 p-4 sm:p-6",
+          isLargeScreen ? "flex min-h-0 flex-col" : "overflow-y-auto",
+        )}
         style={{
           paddingBottom: isMobile ? MOBILE_FAB_SCROLL_PADDING : undefined,
         }}
       >
-        <div className="mx-auto max-w-6xl">
-          <div className="mb-6 flex items-start justify-between gap-3">
+        <div
+          className={cn(
+            "mx-auto",
+            isLargeScreen
+              ? "flex min-h-0 w-full max-w-[1600px] flex-1 flex-col"
+              : "max-w-6xl",
+          )}
+        >
+          <div className="mb-6 flex shrink-0 items-start justify-between gap-3">
             <div className="space-y-3">
               {!isMobile && (
                 <h1 className="text-[24px] leading-8 font-semibold text-foreground">
@@ -178,20 +190,33 @@ export function ChoresView() {
             </div>
           )}
 
-          {!isLoading && !isError && board && hasRoutines && (
-            <div className={cn("grid gap-4", !isMobile && "lg:grid-cols-3")}>
-              {visibleScopes.map((scope) => (
-                <ChoreScopeColumn
-                  key={scope.scope}
-                  scope={scope}
-                  showHeading={!isMobile}
-                  onArchive={handleArchive}
-                  onComplete={handleComplete}
-                  onUncomplete={handleUncomplete}
-                />
-              ))}
-            </div>
-          )}
+          {!isLoading &&
+            !isError &&
+            board &&
+            hasRoutines &&
+            (isLargeScreen ? (
+              <ChoresBoardLarge
+                today={board.today}
+                thisWeek={board.thisWeek}
+                thisMonth={board.thisMonth}
+                onArchive={handleArchive}
+                onComplete={handleComplete}
+                onUncomplete={handleUncomplete}
+              />
+            ) : (
+              <div className={cn("grid gap-4", !isMobile && "lg:grid-cols-3")}>
+                {visibleScopes.map((scope) => (
+                  <ChoreScopeColumn
+                    key={scope.scope}
+                    scope={scope}
+                    showHeading={!isMobile}
+                    onArchive={handleArchive}
+                    onComplete={handleComplete}
+                    onUncomplete={handleUncomplete}
+                  />
+                ))}
+              </div>
+            ))}
         </div>
       </div>
 

--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -44,3 +44,16 @@ describe("ChoreRow haptics", () => {
     expect(success).not.toHaveBeenCalled();
   });
 });
+
+it("grows the checkoff control to at least 44px at lg+", () => {
+  render(<ChoreRow chore={baseChore} />);
+
+  const checkoff = screen.getByRole("button", {
+    name: /mark dishes complete/i,
+  });
+
+  expect(checkoff.className).toContain("h-9");
+  expect(checkoff.className).toContain("w-9");
+  expect(checkoff.className).toContain("lg:h-11");
+  expect(checkoff.className).toContain("lg:w-11");
+});

--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -46,7 +46,9 @@ describe("ChoreRow haptics", () => {
 });
 
 it("grows the checkoff control to at least 44px at lg+", () => {
-  render(<ChoreRow chore={baseChore} />);
+  render(
+    <ChoreRow chore={baseChore} onComplete={vi.fn()} onUncomplete={vi.fn()} />,
+  );
 
   const checkoff = screen.getByRole("button", {
     name: /mark dishes complete/i,

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -56,16 +56,16 @@ export function ChoreRow({
           }
         }}
         className={cn(
-          "flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+          "flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 transition-colors lg:h-11 lg:w-11",
           chore.completed
             ? "border-primary bg-primary text-primary-foreground"
             : "border-border bg-background text-muted-foreground hover:border-primary hover:text-primary",
         )}
       >
         {chore.completed ? (
-          <Check className="h-4 w-4" />
+          <Check className="h-4 w-4 lg:h-5 lg:w-5" />
         ) : (
-          <Circle className="h-4 w-4" />
+          <Circle className="h-4 w-4 lg:h-5 lg:w-5" />
         )}
       </button>
 

--- a/src/components/chores/chores-board-large.test.tsx
+++ b/src/components/chores/chores-board-large.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChoreScopeBoard } from "@/lib/types";
+import { renderWithUser, screen } from "@/test/test-utils";
+import { ChoresBoardLarge } from "./chores-board-large";
+
+function scopeBoard(
+  scope: ChoreScopeBoard["scope"],
+  total: number,
+): ChoreScopeBoard {
+  return {
+    scope,
+    periodStartDate: "2026-06-11",
+    periodEndDate: "2026-06-11",
+    summary: { total, completed: 0, remaining: total },
+    assignees:
+      total === 0
+        ? []
+        : [
+            {
+              member: { id: "leo", name: "Leo", color: "coral" },
+              summary: { total: 1, completed: 0, remaining: 1 },
+              chores: [
+                {
+                  templateId: `${scope}-c1`,
+                  title: `${scope} chore`,
+                  cadence: "DAILY",
+                  assignedToMemberId: "leo",
+                  completed: false,
+                  completedAt: null,
+                },
+              ],
+            },
+          ],
+  };
+}
+
+describe("ChoresBoardLarge", () => {
+  it("renders all three scope columns", () => {
+    renderWithUser(
+      <ChoresBoardLarge
+        today={scopeBoard("TODAY", 0)}
+        thisWeek={scopeBoard("THIS_WEEK", 0)}
+        thisMonth={scopeBoard("THIS_MONTH", 0)}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: "Today" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "This Week" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "This Month" }),
+    ).toBeInTheDocument();
+  });
+
+  it("weights and emphasizes Today", () => {
+    renderWithUser(
+      <ChoresBoardLarge
+        today={scopeBoard("TODAY", 0)}
+        thisWeek={scopeBoard("THIS_WEEK", 0)}
+        thisMonth={scopeBoard("THIS_MONTH", 0)}
+      />,
+    );
+
+    const today = screen.getByRole("region", { name: "Today" });
+    const thisWeek = screen.getByRole("region", { name: "This Week" });
+
+    expect(today).toHaveAttribute("data-emphasis", "true");
+    expect(today).toHaveClass("flex-[1.4]");
+    expect(thisWeek).not.toHaveAttribute("data-emphasis");
+    expect(thisWeek).toHaveClass("flex-1");
+  });
+
+  it("forwards completion with the scope and chore", async () => {
+    const onComplete = vi.fn();
+    const { user } = renderWithUser(
+      <ChoresBoardLarge
+        today={scopeBoard("TODAY", 1)}
+        thisWeek={scopeBoard("THIS_WEEK", 0)}
+        thisMonth={scopeBoard("THIS_MONTH", 0)}
+        onComplete={onComplete}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /mark TODAY chore complete/i }),
+    );
+
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(onComplete.mock.calls[0]?.[0].scope).toBe("TODAY");
+    expect(onComplete.mock.calls[0]?.[1].templateId).toBe("TODAY-c1");
+  });
+});

--- a/src/components/chores/chores-board-large.tsx
+++ b/src/components/chores/chores-board-large.tsx
@@ -1,0 +1,51 @@
+import type { ChoreBoardItem, ChoreScopeBoard } from "@/lib/types";
+import { ChoreScopeColumn } from "./chores-scope-column";
+
+interface ChoresBoardLargeProps {
+  today: ChoreScopeBoard;
+  thisWeek: ChoreScopeBoard;
+  thisMonth: ChoreScopeBoard;
+  onArchive?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
+  onComplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
+  onUncomplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
+}
+
+export function ChoresBoardLarge({
+  today,
+  thisWeek,
+  thisMonth,
+  onArchive,
+  onComplete,
+  onUncomplete,
+}: ChoresBoardLargeProps) {
+  const shared = {
+    fillHeight: true as const,
+    showHeading: true as const,
+    onArchive,
+    onComplete,
+    onUncomplete,
+  };
+
+  return (
+    // At lg+, fill the viewport with internally scrolling columns and give Today
+    // extra weight; below lg stays in ChoresView, while min-w-0 contains long titles.
+    <div className="flex min-h-0 flex-1 gap-4">
+      <ChoreScopeColumn
+        {...shared}
+        scope={today}
+        emphasis
+        className="min-w-0 flex-[1.4]"
+      />
+      <ChoreScopeColumn
+        {...shared}
+        scope={thisWeek}
+        className="min-w-0 flex-1"
+      />
+      <ChoreScopeColumn
+        {...shared}
+        scope={thisMonth}
+        className="min-w-0 flex-1"
+      />
+    </div>
+  );
+}

--- a/src/components/chores/chores-scope-column.test.tsx
+++ b/src/components/chores/chores-scope-column.test.tsx
@@ -26,3 +26,46 @@ describe("ChoreScopeColumn", () => {
     expect(screen.getByText(/1 left of 2/i)).toBeInTheDocument();
   });
 });
+
+describe("ChoreScopeColumn large-screen props", () => {
+  it("preserves the default section layout", () => {
+    render(<ChoreScopeColumn scope={board} />);
+
+    const region = screen.getByRole("region", { name: "Today" });
+
+    expect(region).toHaveClass("p-4");
+    expect(region).not.toHaveClass("min-h-0");
+    expect(region).not.toHaveAttribute("data-emphasis");
+  });
+
+  it("fills the available height with an internally scrolling body", () => {
+    const { container } = render(<ChoreScopeColumn scope={board} fillHeight />);
+
+    const region = screen.getByRole("region", { name: "Today" });
+    const body = container.querySelector('[data-slot="scope-body"]');
+
+    expect(region).toHaveClass("flex", "min-h-0");
+    expect(region).not.toHaveClass("p-4");
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveClass("overflow-y-auto");
+  });
+
+  it("emphasizes the section and heading", () => {
+    render(<ChoreScopeColumn scope={board} emphasis />);
+
+    const region = screen.getByRole("region", { name: "Today" });
+    const heading = screen.getByRole("heading", { name: "Today" });
+
+    expect(region).toHaveAttribute("data-emphasis", "true");
+    expect(region).toHaveClass("bg-primary/5");
+    expect(heading).toHaveClass("text-xl");
+  });
+
+  it("merges a custom section class name", () => {
+    render(<ChoreScopeColumn scope={board} className="flex-[1.4]" />);
+
+    expect(screen.getByRole("region", { name: "Today" })).toHaveClass(
+      "flex-[1.4]",
+    );
+  });
+});

--- a/src/components/chores/chores-scope-column.tsx
+++ b/src/components/chores/chores-scope-column.tsx
@@ -1,9 +1,16 @@
 import type { ChoreBoardItem, ChoreScopeBoard } from "@/lib/types";
+import { cn } from "@/lib/utils";
 import { ChoreAssigneeGroup } from "./chore-assignee-group";
 
 interface ChoreScopeColumnProps {
   scope: ChoreScopeBoard;
   showHeading?: boolean;
+  /** Fill the parent height and scroll the chore groups within the section. */
+  fillHeight?: boolean;
+  /** Apply a subtle primary treatment and larger heading. */
+  emphasis?: boolean;
+  /** Additional classes for sizing or positioning the section. */
+  className?: string;
   onArchive?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
   onComplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
   onUncomplete?: (scope: ChoreScopeBoard, chore: ChoreBoardItem) => void;
@@ -18,6 +25,9 @@ function scopeHeading(scope: ChoreScopeBoard["scope"]): string {
 export function ChoreScopeColumn({
   scope,
   showHeading = true,
+  fillHeight = false,
+  emphasis = false,
+  className,
   onArchive,
   onComplete,
   onUncomplete,
@@ -27,47 +37,77 @@ export function ChoreScopeColumn({
   const isFullyComplete =
     scope.summary.total > 0 && scope.summary.remaining === 0;
 
+  const headerContent = showHeading ? (
+    <header className={cn(!fillHeight && "mb-4")}>
+      <h2
+        id={`${scope.scope}-heading`}
+        className={cn(
+          "font-semibold text-foreground",
+          emphasis ? "text-xl" : "text-lg",
+        )}
+      >
+        {heading}
+      </h2>
+      <p className="mt-1 text-sm text-muted-foreground">{summary}</p>
+    </header>
+  ) : (
+    <p className={cn(!fillHeight && "mb-4", "text-sm text-muted-foreground")}>
+      {summary}
+    </p>
+  );
+
+  const bodyContent =
+    scope.summary.total === 0 ? (
+      <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
+        No routines in this timeframe
+      </p>
+    ) : (
+      <div className="space-y-5">
+        {isFullyComplete && (
+          <p className="rounded-lg bg-muted px-3 py-2 text-sm font-medium text-muted-foreground">
+            All caught up
+          </p>
+        )}
+        {scope.assignees.map((group) => (
+          <ChoreAssigneeGroup
+            key={group.member.id}
+            group={group}
+            onArchive={(chore) => onArchive?.(scope, chore)}
+            onComplete={(chore) => onComplete?.(scope, chore)}
+            onUncomplete={(chore) => onUncomplete?.(scope, chore)}
+          />
+        ))}
+      </div>
+    );
+
   return (
     <section
       aria-label={showHeading ? undefined : heading}
       aria-labelledby={showHeading ? `${scope.scope}-heading` : undefined}
-      className="rounded-lg border bg-card p-4 shadow-sm"
-    >
-      {showHeading ? (
-        <header className="mb-4">
-          <h2
-            id={`${scope.scope}-heading`}
-            className="text-lg font-semibold text-foreground"
-          >
-            {heading}
-          </h2>
-          <p className="mt-1 text-sm text-muted-foreground">{summary}</p>
-        </header>
-      ) : (
-        <p className="mb-4 text-sm text-muted-foreground">{summary}</p>
+      className={cn(
+        "rounded-lg border bg-card",
+        emphasis && "border-primary/30 bg-primary/5",
+        fillHeight ? "flex min-h-0 flex-col" : "p-4",
+        "shadow-sm",
+        className,
       )}
-
-      {scope.summary.total === 0 ? (
-        <p className="rounded-lg border border-dashed border-border p-4 text-sm text-muted-foreground">
-          No routines in this timeframe
-        </p>
+      data-emphasis={emphasis || undefined}
+    >
+      {fillHeight ? (
+        <>
+          <div className="shrink-0 p-4 pb-3">{headerContent}</div>
+          <div
+            className="min-h-0 flex-1 overflow-y-auto px-4 pb-4"
+            data-slot="scope-body"
+          >
+            {bodyContent}
+          </div>
+        </>
       ) : (
-        <div className="space-y-5">
-          {isFullyComplete && (
-            <p className="rounded-lg bg-muted px-3 py-2 text-sm font-medium text-muted-foreground">
-              All caught up
-            </p>
-          )}
-          {scope.assignees.map((group) => (
-            <ChoreAssigneeGroup
-              key={group.member.id}
-              group={group}
-              onArchive={(chore) => onArchive?.(scope, chore)}
-              onComplete={(chore) => onComplete?.(scope, chore)}
-              onUncomplete={(chore) => onUncomplete?.(scope, chore)}
-            />
-          ))}
-        </div>
+        <>
+          {headerContent}
+          {bodyContent}
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
## Summary

- fills the large-screen Chores surface with a full-height, independently scrolling three-column board
- makes Today the primary column through additional width, tint, border, and stronger heading treatment
- grows large-screen checkoff controls to 44px while preserving the existing tablet/mobile layouts and flows

## Story / spec / plan

- [Story](https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-chores.md)
- [Design spec](https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-06-large-screen-chores-design.md)
- [Implementation plan](https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-07-13-large-screen-chores.md)

## Verification

- `npm run build` on Node 22.22.1 — passed; 3,169 modules transformed
- `npm run lint` — passed; 470 files checked
- `npm test -- --run` — passed; 165 files and 1,603 tests
- real-browser matrix at 1024px and 1440px: busy, all-done, empty, and six-member boards
- direct feature-vs-`origin/main` geometry comparison at 900px and 375px

## Acceptance checklist

- [x] Widened `max-w-[1600px]` container and full-height board at 1024px/1440px
- [x] Today is primary through `flex-[1.4]`, emphasis tint, border, and larger heading
- [x] Checkoff controls measure 44px at `lg+`
- [x] Assignee avatar, name, member color, and progress remain intact
- [x] Existing single toolbar row and create/edit/complete/uncomplete/archive/stale-period flows are preserved
- [x] Mobile and portrait-tablet paths remain unchanged
- [x] Screenshot matrix covers busy, all-done, empty, and 5+ member states