### PR TITLE
feat(recipes): large-screen responsive card grid

### DIFF
--- a/e2e/large-screen-recipes.spec.ts
+++ b/e2e/large-screen-recipes.spec.ts
@@ -132,6 +132,20 @@ test.describe("Large-screen Recipes", () => {
     });
     await authenticateAndOpenRecipes(page, registration);
 
+    await page.setViewportSize({ width: 800, height: 768 });
+    const tabletFocusRows = await page
+      .getByTestId("recipes-desktop-toolbar")
+      .evaluate((toolbar) =>
+        Array.from(toolbar.querySelectorAll<HTMLElement>("input, button")).map(
+          (element) => element.getBoundingClientRect().top,
+        ),
+      );
+    expect(
+      tabletFocusRows.every(
+        (top, index) => index === 0 || top >= tabletFocusRows[index - 1] - 1,
+      ),
+    ).toBe(true);
+
     for (const { width, columns } of ACCEPTANCE_WIDTHS) {
       await page.setViewportSize({
         width,
@@ -262,6 +276,7 @@ test.describe("Large-screen Recipes", () => {
   });
 
   test("preserves the 375px horizontal cards and FAB", async ({
+    browserName,
     page,
     request,
   }) => {
@@ -274,7 +289,7 @@ test.describe("Large-screen Recipes", () => {
       imageUrl: LOCAL_RECIPE_IMAGE,
       ingredients: ["Mobile ingredient"],
       instructions: ["Mobile instruction"],
-      tags: ["Mobile"],
+      tags: ["Mobile", "Quick", "Dinner", "Family", "Weeknight", "Favorite"],
       favorite: false,
     });
     await authenticateAndOpenRecipes(page, registration);
@@ -293,6 +308,26 @@ test.describe("Large-screen Recipes", () => {
     await expect(
       page.getByRole("button", { name: "Add recipe", exact: true }),
     ).toBeVisible();
+
+    const mobileFilterScroller = page
+      .getByTestId("recipe-filter-bar")
+      .locator(".overflow-x-auto");
+    const mobileFilterOverflow = await mobileFilterScroller.evaluate(
+      (element) => ({
+        classNames: element.className.split(/\s+/),
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        scrollbarWidth: window.getComputedStyle(element).scrollbarWidth,
+      }),
+    );
+    expect(mobileFilterOverflow.scrollWidth).toBeGreaterThan(
+      mobileFilterOverflow.clientWidth,
+    );
+    expect(mobileFilterOverflow.classNames).not.toContain("scrollbar-hide");
+    if (browserName === "chromium") {
+      expect(mobileFilterOverflow.scrollbarWidth).not.toBe("none");
+    }
+
     await attachRecipesScreenshot(page, "mobile-regression", 375);
   });
 });

--- a/e2e/large-screen-recipes.spec.ts
+++ b/e2e/large-screen-recipes.spec.ts
@@ -1,0 +1,298 @@
+import {
+  type APIRequestContext,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import {
+  createRecipe,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+const ACCEPTANCE_WIDTHS = [
+  { width: 1024, columns: 2 },
+  { width: 1280, columns: 3 },
+  { width: 1440, columns: 4 },
+] as const;
+const LOCAL_RECIPE_IMAGE = "http://localhost:5173/icons/icon-512.png";
+
+async function openRecipes(page: Page) {
+  const nav = page.getByRole("navigation", { name: "Primary" });
+  await safeClick(nav.getByRole("button", { name: "Recipes", exact: true }));
+  await expect(
+    page.getByRole("heading", { name: "Recipes", level: 1, exact: true }),
+  ).toBeVisible();
+}
+
+async function authenticateAndOpenRecipes(
+  page: Page,
+  registration: Awaited<ReturnType<typeof registerFamily>>,
+) {
+  await clearStorage(page);
+  await seedBrowserAuth(page, registration);
+  await page.reload();
+  await waitForHydration(page);
+  await openRecipes(page);
+}
+
+async function attachRecipesScreenshot(
+  page: Page,
+  name: string,
+  width: number,
+) {
+  await page.setViewportSize({
+    width,
+    height: width === 1024 ? 768 : 900,
+  });
+  const container = page.getByTestId("recipes-view-container");
+  await expect(container).toBeVisible();
+  const section = page.locator("section", { has: container });
+  await expect(section).toBeVisible();
+  await section.evaluate((element) => element.scrollTo({ top: 0 }));
+  await page.evaluate(() =>
+    Promise.all(
+      document
+        .getAnimations({ subtree: true })
+        .map((animation) => animation.finished.catch(() => undefined)),
+    ).then(() => undefined),
+  );
+  await test.info().attach(`${name}-${width}`, {
+    body: await section.screenshot(),
+    contentType: "image/png",
+  });
+}
+
+async function expectGridColumns(
+  page: Page,
+  expectedColumns: number,
+  expectedCards: number,
+) {
+  const grid = page.getByTestId("recipe-library-grid");
+  await expect(grid).toBeVisible();
+  await expect(grid.getByRole("article")).toHaveCount(expectedCards);
+
+  const geometry = await grid.evaluate((element) => {
+    const style = window.getComputedStyle(element);
+    return {
+      columns: style.gridTemplateColumns.split(" ").length,
+      width: element.getBoundingClientRect().width,
+    };
+  });
+
+  expect(geometry.columns).toBe(expectedColumns);
+  expect(geometry.width).toBeLessThanOrEqual(1201);
+}
+
+async function seedRemainingRecipes(request: APIRequestContext, token: string) {
+  for (let index = 2; index <= 12; index += 1) {
+    const recipeNumber = String(index).padStart(2, "0");
+    const favorite = index % 3 === 0;
+    await createRecipe(request, token, {
+      title: `Recipe ${recipeNumber}`,
+      imageUrl: index % 2 === 0 ? null : LOCAL_RECIPE_IMAGE,
+      ingredients: [`Ingredient ${recipeNumber}`],
+      instructions: [`Instruction ${recipeNumber}`],
+      tags: [favorite ? "Favorite set" : "Weeknight", `Tag ${recipeNumber}`],
+      favorite,
+    });
+  }
+}
+
+test.describe("Large-screen Recipes", () => {
+  test.beforeEach(async ({ page, isMobile }) => {
+    test.skip(isMobile, "Large-screen only");
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/");
+    await clearStorage(page);
+  });
+
+  test("verifies the grid, toolbar, detail width, and visual state matrix", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120000);
+
+    const registration = await registerFamily(request, {
+      familyName: "Large Recipes Matrix",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await createRecipe(request, registration.token, {
+      title: "Recipe 01",
+      imageUrl: LOCAL_RECIPE_IMAGE,
+      ingredients: ["Ingredient 01"],
+      instructions: ["Instruction 01"],
+      tags: ["Weeknight", "Tag 01"],
+      favorite: false,
+    });
+    await authenticateAndOpenRecipes(page, registration);
+
+    for (const { width, columns } of ACCEPTANCE_WIDTHS) {
+      await page.setViewportSize({
+        width,
+        height: width === 1024 ? 768 : 900,
+      });
+      await expectGridColumns(page, columns, 1);
+
+      const gridBox = await page
+        .getByTestId("recipe-library-grid")
+        .boundingBox();
+      const cardBox = await page.getByRole("article").boundingBox();
+      expect(gridBox).not.toBeNull();
+      expect(cardBox).not.toBeNull();
+      expect(cardBox!.width).toBeLessThan(gridBox!.width * 0.75);
+
+      await attachRecipesScreenshot(page, "one-recipe", width);
+    }
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await safeClick(
+      page.getByRole("button", {
+        name: "Open recipe: Recipe 01",
+        exact: true,
+      }),
+    );
+    await expect(
+      page.getByRole("button", { name: "Back to recipes", exact: true }),
+    ).toBeVisible();
+    const detailContainerBox = await page
+      .getByTestId("recipes-view-container")
+      .boundingBox();
+    expect(detailContainerBox).not.toBeNull();
+    expect(detailContainerBox!.width).toBeLessThanOrEqual(769);
+    await safeClick(
+      page.getByRole("button", { name: "Back to recipes", exact: true }),
+    );
+
+    await seedRemainingRecipes(request, registration.token);
+    await safeClick(
+      page.getByRole("button", {
+        name: "Open recipe: Recipe 01",
+        exact: true,
+      }),
+    );
+    const favoriteRecipe = page.getByRole("button", {
+      name: "Favorite recipe: Recipe 01",
+      exact: true,
+    });
+    await safeClick(favoriteRecipe);
+    await expect(favoriteRecipe).toHaveAttribute("aria-pressed", "true");
+    await safeClick(
+      page.getByRole("button", { name: "Back to recipes", exact: true }),
+    );
+    await expect(page.getByRole("article")).toHaveCount(12);
+
+    for (const { width, columns } of ACCEPTANCE_WIDTHS) {
+      await page.setViewportSize({
+        width,
+        height: width === 1024 ? 768 : 900,
+      });
+      await expectGridColumns(page, columns, 12);
+
+      const recipe11Card = page.getByRole("article", {
+        name: "Recipe card: Recipe 11",
+        exact: true,
+      });
+      const recipe12Card = page.getByRole("article", {
+        name: "Recipe card: Recipe 12",
+        exact: true,
+      });
+      const imageBox = await recipe11Card
+        .getByRole("img", { name: "Recipe 11", exact: true })
+        .locator("..")
+        .boundingBox();
+      const placeholderBox = await recipe12Card
+        .getByText("No photo", { exact: true })
+        .locator("..")
+        .locator("..")
+        .boundingBox();
+      expect(imageBox).not.toBeNull();
+      expect(placeholderBox).not.toBeNull();
+      expect(imageBox!.width / imageBox!.height).toBeGreaterThan(1.3);
+      expect(imageBox!.width / imageBox!.height).toBeLessThan(1.37);
+      expect(placeholderBox!.width / placeholderBox!.height).toBeGreaterThan(
+        1.3,
+      );
+      expect(placeholderBox!.width / placeholderBox!.height).toBeLessThan(1.37);
+
+      const toolbarBox = await page
+        .getByTestId("recipes-desktop-toolbar")
+        .boundingBox();
+      const searchBox = await page.getByLabel("Search recipes").boundingBox();
+      const favoritesBox = await page
+        .getByRole("button", { name: "Favorites only", exact: true })
+        .boundingBox();
+      const addRecipeBox = await page
+        .getByRole("button", { name: "Add recipe", exact: true })
+        .boundingBox();
+      expect(toolbarBox).not.toBeNull();
+      expect(searchBox).not.toBeNull();
+      expect(favoritesBox).not.toBeNull();
+      expect(addRecipeBox).not.toBeNull();
+      expect(toolbarBox!.height).toBeLessThanOrEqual(48);
+      expect(searchBox!.width).toBeGreaterThanOrEqual(250);
+      expect(searchBox!.width).toBeLessThanOrEqual(258);
+      expect(searchBox!.height).toBeGreaterThanOrEqual(44);
+      expect(favoritesBox!.height).toBeGreaterThanOrEqual(44);
+      expect(addRecipeBox!.height).toBeGreaterThanOrEqual(44);
+
+      await attachRecipesScreenshot(page, "twelve-recipes", width);
+    }
+
+    await safeClick(
+      page.getByRole("button", { name: "Favorites only", exact: true }),
+    );
+    await expect(page.getByRole("article")).toHaveCount(5);
+    for (const { width } of ACCEPTANCE_WIDTHS) {
+      await attachRecipesScreenshot(page, "favorites-only", width);
+    }
+
+    await page.getByLabel("Search recipes").fill("definitely-no-match");
+    await expect(
+      page.getByText("No recipes match those filters", { exact: true }),
+    ).toBeVisible();
+    for (const { width } of ACCEPTANCE_WIDTHS) {
+      await attachRecipesScreenshot(page, "no-results", width);
+    }
+  });
+
+  test("preserves the 375px horizontal cards and FAB", async ({
+    page,
+    request,
+  }) => {
+    const registration = await registerFamily(request, {
+      familyName: "Recipes Mobile Regression",
+      members: [{ name: "Sam", color: "teal" }],
+    });
+    await createRecipe(request, registration.token, {
+      title: "Mobile Recipe",
+      imageUrl: LOCAL_RECIPE_IMAGE,
+      ingredients: ["Mobile ingredient"],
+      instructions: ["Mobile instruction"],
+      tags: ["Mobile"],
+      favorite: false,
+    });
+    await authenticateAndOpenRecipes(page, registration);
+
+    await page.setViewportSize({ width: 375, height: 812 });
+    const mobileCard = page.getByRole("article", {
+      name: "Recipe card: Mobile Recipe",
+      exact: true,
+    });
+    await expect(mobileCard).toBeVisible();
+    expect(
+      await mobileCard.evaluate(
+        (element) => window.getComputedStyle(element).flexDirection,
+      ),
+    ).toBe("row");
+    await expect(
+      page.getByRole("button", { name: "Add recipe", exact: true }),
+    ).toBeVisible();
+    await attachRecipesScreenshot(page, "mobile-regression", 375);
+  });
+});

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -59,6 +59,7 @@ describe("RecipesView", () => {
     const detailContainer = screen.getByTestId("recipes-view-container");
     expect(detailContainer).toHaveClass("w-full", "max-w-3xl");
     expect(detailContainer).not.toHaveClass("lg:max-w-[1200px]");
+    expect(screen.queryByTestId("recipe-filter-bar")).not.toBeInTheDocument();
   });
 
   it("adds a recipe to meals from detail and stores a library handoff draft", async () => {
@@ -216,6 +217,28 @@ describe("RecipesView", () => {
     expect(grid).toHaveClass("lg:grid-cols-2");
     expect(grid).toHaveClass("xl:grid-cols-3");
     expect(grid).toHaveClass("min-[1440px]:grid-cols-4");
+  });
+
+  it("composes the large-screen controls into one foundations toolbar", async () => {
+    viewport.isMobile = false;
+    seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
+    render(<RecipesView />);
+    await screen.findByRole("article", {
+      name: "Recipe card: Sheet Pan Salmon",
+    });
+    const toolbar = screen.getByTestId("recipes-desktop-toolbar");
+    const search = screen.getByRole("searchbox", { name: "Search recipes" });
+    const favorites = screen.getByRole("button", { name: "Favorites only" });
+    const add = screen.getByRole("button", { name: "Add recipe" });
+    expect(toolbar).toHaveClass("lg:flex-nowrap");
+    expect(toolbar).toContainElement(search);
+    expect(toolbar).toContainElement(favorites);
+    expect(toolbar).toContainElement(add);
+    expect(screen.getAllByTestId("recipe-filter-bar")).toHaveLength(1);
+    expect(screen.getByTestId("recipe-filter-bar")).toHaveClass("lg:flex");
+    expect(search).toHaveClass("lg:h-11");
+    expect(favorites).toHaveClass("lg:min-h-11");
+    expect(add).toHaveClass("lg:min-h-11");
   });
 
   it("opens recipe detail from the library with cook-first content order and returns back", async () => {
@@ -1043,6 +1066,7 @@ describe("RecipesView", () => {
         name: `Open recipe: ${testRecipeDetail.title}`,
       });
       const fab = screen.getByRole("button", { name: "Add recipe" });
+      expect(screen.getAllByTestId("recipe-filter-bar")).toHaveLength(1);
       expect(fab).toHaveClass("fixed");
     });
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -182,6 +182,35 @@ describe("RecipesView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("centers the empty state within the widened library", async () => {
+    viewport.isMobile = false;
+    seedMockRecipes([]);
+    render(<RecipesView />);
+    const heading = await screen.findByText("No recipes yet");
+    const panel = heading.closest("div");
+    expect(panel).toHaveClass("mx-auto");
+    expect(panel).toHaveClass("w-full");
+    expect(panel).toHaveClass("max-w-xl");
+  });
+
+  it("centers the no-results state within the widened library", async () => {
+    viewport.isMobile = false;
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(<RecipesView />);
+    await screen.findByRole("article", {
+      name: "Recipe card: Sheet Pan Salmon",
+    });
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search recipes" }),
+      "definitely-not-a-recipe",
+    );
+    const heading = await screen.findByText("No recipes match those filters");
+    const panel = heading.closest("div");
+    expect(panel).toHaveClass("mx-auto");
+    expect(panel).toHaveClass("w-full");
+    expect(panel).toHaveClass("max-w-xl");
+  });
+
   it("renders summary cards with image, title, tags, and favorite state", async () => {
     seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -245,7 +245,7 @@ describe("RecipesView", () => {
     expect(grid).toHaveClass("grid-cols-1");
     expect(grid).toHaveClass("lg:grid-cols-2");
     expect(grid).toHaveClass("xl:grid-cols-3");
-    expect(grid).toHaveClass("min-[1440px]:grid-cols-4");
+    expect(grid).toHaveClass("min-[1440px]:grid-cols-4!");
   });
 
   it("composes the large-screen controls into one foundations toolbar", async () => {

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -188,6 +188,20 @@ describe("RecipesView", () => {
     ).toBeInTheDocument();
   });
 
+  it("lays the large-screen library out as a responsive card grid", async () => {
+    viewport.isMobile = false;
+    seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
+    render(<RecipesView />);
+    await screen.findByRole("article", {
+      name: "Recipe card: Sheet Pan Salmon",
+    });
+    const grid = screen.getByTestId("recipe-library-grid");
+    expect(grid).toHaveClass("grid-cols-1");
+    expect(grid).toHaveClass("lg:grid-cols-2");
+    expect(grid).toHaveClass("xl:grid-cols-3");
+    expect(grid).toHaveClass("min-[1440px]:grid-cols-4");
+  });
+
   it("opens recipe detail from the library with cook-first content order and returns back", async () => {
     seedMockRecipes([testRecipeDetail, importedRecipeDetail]);
 

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -45,6 +45,22 @@ describe("RecipesView", () => {
     viewport.isMobile = false;
   });
 
+  it("widens the container for the grid but keeps recipe detail at reading width", async () => {
+    viewport.isMobile = false;
+    seedMockRecipes([testRecipeDetail]);
+    const { user } = renderWithUser(<RecipesView />);
+    const openButton = await screen.findByRole("button", {
+      name: `Open recipe: ${testRecipeDetail.title}`,
+    });
+    const container = screen.getByTestId("recipes-view-container");
+    expect(container).toHaveClass("w-full", "max-w-3xl", "lg:max-w-[1200px]");
+    await user.click(openButton);
+    await screen.findByRole("button", { name: "Back to recipes" });
+    const detailContainer = screen.getByTestId("recipes-view-container");
+    expect(detailContainer).toHaveClass("w-full", "max-w-3xl");
+    expect(detailContainer).not.toHaveClass("lg:max-w-[1200px]");
+  });
+
   it("adds a recipe to meals from detail and stores a library handoff draft", async () => {
     const fixedNow = new Date(2026, 5, 10, 9, 15, 0);
     const RealDate = Date;

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -158,7 +158,13 @@ export function RecipesView() {
         paddingBottom: isMobile ? MOBILE_FAB_SCROLL_PADDING : undefined,
       }}
     >
-      <div className="mx-auto flex max-w-3xl flex-col gap-4">
+      <div
+        data-testid="recipes-view-container"
+        className={cn(
+          "mx-auto flex w-full max-w-3xl flex-col gap-4",
+          selectedRecipeId === null && "lg:max-w-[1200px]",
+        )}
+      >
         {!isMobile && (
           <div className="flex items-start justify-between gap-3">
             <div>

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -201,13 +201,13 @@ export function RecipesView() {
                 onTagChange={setSelectedTag}
                 searchValue={searchValue}
                 selectedTag={selectedTag}
-                className="order-3 w-full lg:order-none lg:w-auto"
+                className="w-full lg:w-auto"
               />
             ) : null}
             {selectedRecipeId === null ? (
               <Button
                 type="button"
-                className="lg:min-h-11"
+                className="ml-auto lg:min-h-11"
                 onClick={() => setIsCreateSheetOpen(true)}
               >
                 Add recipe

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -247,7 +247,7 @@ export function RecipesView() {
               <p className="text-sm font-medium text-muted-foreground">
                 Loading recipes...
               </p>
-              <div className="grid gap-3">
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4">
                 {Array.from({ length: 3 }, (_, index) => (
                   <div
                     key={`recipe-loading-${index}`}
@@ -326,7 +326,10 @@ export function RecipesView() {
                   </p>
                 </div>
               ) : (
-                <div className="grid gap-3">
+                <div
+                  data-testid="recipe-library-grid"
+                  className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4"
+                >
                   {filteredRecipes.map((recipe) => (
                     <div key={recipe.id} className={cn("min-w-0")}>
                       <RecipeLibraryCard

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -286,7 +286,7 @@ export function RecipesView() {
               <p className="text-sm font-medium text-muted-foreground">
                 Loading recipes...
               </p>
-              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4">
+              <div className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4!">
                 {Array.from({ length: 3 }, (_, index) => (
                   <div
                     key={`recipe-loading-${index}`}
@@ -369,7 +369,7 @@ export function RecipesView() {
               ) : (
                 <div
                   data-testid="recipe-library-grid"
-                  className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4"
+                  className="grid grid-cols-1 gap-3 lg:grid-cols-2 lg:gap-4 xl:grid-cols-3 min-[1440px]:grid-cols-4!"
                 >
                   {filteredRecipes.map((recipe) => (
                     <div key={recipe.id} className={cn("min-w-0")}>

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -341,7 +341,7 @@ export function RecipesView() {
               ) : null}
 
               {recipes.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                <div className="mx-auto w-full max-w-xl rounded-lg border border-dashed border-border bg-card p-6 text-center">
                   <h2 className="text-lg font-semibold text-foreground">
                     No recipes yet
                   </h2>
@@ -358,7 +358,7 @@ export function RecipesView() {
                   </div>
                 </div>
               ) : filteredRecipes.length === 0 ? (
-                <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">
+                <div className="mx-auto w-full max-w-xl rounded-lg border border-dashed border-border bg-card p-6 text-center">
                   <h2 className="text-lg font-semibold text-foreground">
                     No recipes match those filters
                   </h2>

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -101,6 +101,12 @@ export function RecipesView() {
   const searchQuery = normalizeValue(searchValue);
   const selectedRecipeData = selectedRecipe.data?.data ?? null;
   const updateSelectedRecipe = useUpdateRecipe(selectedRecipeId ?? "none");
+  const showDesktopLibraryFilters =
+    !isMobile &&
+    selectedRecipeId === null &&
+    !isLoading &&
+    !isError &&
+    data !== undefined;
 
   const availableTags = useMemo(() => {
     const tagMap = new Map<string, RecipeTagFilterOption>();
@@ -166,17 +172,44 @@ export function RecipesView() {
         )}
       >
         {!isMobile && (
-          <div className="flex items-start justify-between gap-3">
-            <div>
+          <div
+            data-testid="recipes-desktop-toolbar"
+            className={cn(
+              "flex flex-wrap items-start justify-between gap-3",
+              selectedRecipeId === null && "lg:flex-nowrap lg:items-center",
+            )}
+          >
+            <div className="min-w-0 shrink-0">
               <h1 className="text-2xl font-semibold text-foreground">
                 Recipes
               </h1>
-              <p className="text-sm text-muted-foreground">
+              <p
+                className={cn(
+                  "text-sm text-muted-foreground",
+                  selectedRecipeId === null && "lg:hidden",
+                )}
+              >
                 Save family favorites and discover what to cook next.
               </p>
             </div>
+            {showDesktopLibraryFilters ? (
+              <RecipeFilterBar
+                availableTags={availableTags}
+                favoritesOnly={favoritesOnly}
+                onFavoritesOnlyChange={setFavoritesOnly}
+                onSearchChange={setSearchValue}
+                onTagChange={setSelectedTag}
+                searchValue={searchValue}
+                selectedTag={selectedTag}
+                className="order-3 w-full lg:order-none lg:w-auto"
+              />
+            ) : null}
             {selectedRecipeId === null ? (
-              <Button type="button" onClick={() => setIsCreateSheetOpen(true)}>
+              <Button
+                type="button"
+                className="lg:min-h-11"
+                onClick={() => setIsCreateSheetOpen(true)}
+              >
                 Add recipe
               </Button>
             ) : null}
@@ -295,15 +328,17 @@ export function RecipesView() {
             <OfflineUnavailable label="recipes" />
           ) : (
             <>
-              <RecipeFilterBar
-                availableTags={availableTags}
-                favoritesOnly={favoritesOnly}
-                onFavoritesOnlyChange={setFavoritesOnly}
-                onSearchChange={setSearchValue}
-                onTagChange={setSelectedTag}
-                searchValue={searchValue}
-                selectedTag={selectedTag}
-              />
+              {isMobile ? (
+                <RecipeFilterBar
+                  availableTags={availableTags}
+                  favoritesOnly={favoritesOnly}
+                  onFavoritesOnlyChange={setFavoritesOnly}
+                  onSearchChange={setSearchValue}
+                  onTagChange={setSelectedTag}
+                  searchValue={searchValue}
+                  selectedTag={selectedTag}
+                />
+              ) : null}
 
               {recipes.length === 0 ? (
                 <div className="rounded-lg border border-dashed border-border bg-card p-6 text-center">

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -49,7 +49,7 @@ export function RecipeFilterBar({
         />
       </div>
 
-      <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide lg:min-w-0 lg:flex-1 lg:pb-0">
+      <div className="flex items-center gap-2 overflow-x-auto pb-1 lg:min-w-0 lg:flex-1 lg:pb-0 lg:[scrollbar-width:none] lg:[&::-webkit-scrollbar]:hidden">
         <Button
           type="button"
           variant={favoritesOnly ? "default" : "outline"}

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -10,6 +10,7 @@ export interface RecipeTagFilterOption {
 
 interface RecipeFilterBarProps {
   availableTags: RecipeTagFilterOption[];
+  className?: string;
   favoritesOnly: boolean;
   onFavoritesOnlyChange: (favoritesOnly: boolean) => void;
   onSearchChange: (value: string) => void;
@@ -20,6 +21,7 @@ interface RecipeFilterBarProps {
 
 export function RecipeFilterBar({
   availableTags,
+  className,
   favoritesOnly,
   onFavoritesOnlyChange,
   onSearchChange,
@@ -28,8 +30,14 @@ export function RecipeFilterBar({
   selectedTag,
 }: RecipeFilterBarProps) {
   return (
-    <div className="space-y-3">
-      <div className="relative">
+    <div
+      data-testid="recipe-filter-bar"
+      className={cn(
+        "space-y-3 lg:flex lg:min-w-0 lg:flex-1 lg:items-center lg:gap-3 lg:space-y-0",
+        className,
+      )}
+    >
+      <div className="relative lg:w-64 lg:shrink-0">
         <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="search"
@@ -37,17 +45,17 @@ export function RecipeFilterBar({
           value={searchValue}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder="Search titles or tags"
-          className="pl-9"
+          className="pl-9 lg:h-11"
         />
       </div>
 
-      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+      <div className="flex items-center gap-2 overflow-x-auto pb-1 scrollbar-hide lg:min-w-0 lg:flex-1 lg:pb-0">
         <Button
           type="button"
           variant={favoritesOnly ? "default" : "outline"}
           size="sm"
           onClick={() => onFavoritesOnlyChange(!favoritesOnly)}
-          className="shrink-0"
+          className="shrink-0 lg:min-h-11"
         >
           <Heart className={cn("h-4 w-4", favoritesOnly && "fill-current")} />
           Favorites only
@@ -58,7 +66,7 @@ export function RecipeFilterBar({
           variant={selectedTag === null ? "secondary" : "outline"}
           size="sm"
           onClick={() => onTagChange(null)}
-          className="shrink-0"
+          className="shrink-0 lg:min-h-11"
         >
           All
         </Button>
@@ -72,7 +80,7 @@ export function RecipeFilterBar({
             onClick={() =>
               onTagChange(selectedTag === tag.value ? null : tag.value)
             }
-            className="shrink-0"
+            className="shrink-0 lg:min-h-11"
           >
             {tag.label}
           </Button>


### PR DESCRIPTION
Closes #290

## Summary

- Turns the Recipes index into a viewport-keyed 2/3/4-column grid inside a list-only ~1200px container.
- Composes title, bounded search, filter chips, and Add recipe into one non-wrapping `lg+` toolbar with 44px controls.
- Preserves recipe detail width, display-only index hearts, filtering behavior, centered states, and the 375px mobile composition.
- Adds deterministic released-backend Playwright geometry coverage and a 13-image screenshot evidence matrix.

## Execution contract checklist

- [x] **Index composition only:** the diff is limited to `recipes-view.tsx`, `recipe-filter-bar.tsx`, `recipes-view.test.tsx`, and the new E2E spec. `recipe-library-card.tsx`, `recipe-detail-view.tsx`, add/edit/import flows, API types, and backend code are untouched.
- [x] **List-only width:** `recipes-view-container` retains base `max-w-3xl` and adds `lg:max-w-[1200px]` only while no recipe is selected. Unit coverage checks both modes; Playwright checks the grid cap and detail width `<=769px`.
- [x] **2/3/4 viewport tiers:** loaded and loading grids use 2 columns at 1024, 3 at 1280, and an important 4-column override at 1440. Playwright asserts browser-computed column counts at all three widths.
- [x] **Single-row `lg+` toolbar:** title, `w-64` search, horizontally scrolling favorites/tag chips, and Add recipe share one `lg:flex-nowrap` row. Unit and browser checks cover ownership, search width, row height, and `>=44px` controls.
- [x] **Existing card/media reused:** `RecipeLibraryCard` is unchanged. Playwright checks real-image and `No photo` media at the same ~4:3 ratio and confirms no singleton card fills the grid.
- [x] **Display-only index heart:** the card component is unchanged; the real-backend flow favorites Recipe 01 from detail and then verifies the index favorites filter.
- [x] **Mobile unchanged:** mobile retains one filter inside `ScreenTransition`, a horizontal card, and the Add recipe FAB. Unit ownership assertions and the reviewed 375px attachment cover the regression.
- [x] **Centered states:** both existing dashed panels use `mx-auto w-full max-w-xl`; unit tests cover empty and no-results, and reviewed screenshots cover no-results at all desktop widths.
- [x] **Real-backend evidence:** `e2e/large-screen-recipes.spec.ts` ran against released backend `family-hub-api:1.9.0`, asserting geometry, width cap, media ratios, toolbar/control sizes, detail width, filters, and mobile composition.
- [x] **No new features/API changes:** no collections, sorting, non-tag filters, import changes, backend changes, or API-type changes.

## Screenshot evidence reviewed

The attached PR comment contains all 13 Playwright attachments:

- one recipe at 1024 / 1280 / 1440
- twelve recipes (including image-less cards) at 1024 / 1280 / 1440
- favorites-only at 1024 / 1280 / 1440
- no-results at 1024 / 1280 / 1440
- mobile regression at 375

Review findings: toolbars remain one row; chip overflow clips/scrolls before Add without overlap; cards and image-less placeholders are uniform; no-results remains centered; the 375px card, filter placement, image, and FAB remain intact.

## Verification

- `npm run lint` — passed (471 files, no errors; 2 existing Biome config info notices)
- `npm test -- --run src/components/recipes-view.test.tsx` — passed (41/41)
- `npx playwright test e2e/large-screen-recipes.spec.ts --project=chromium` — passed (2/2, 20.9s)
- `npm run build` — passed (`tsc -b` + Vite production build)

## Approved-plan conflicts discovered during browser verification

- Tailwind 4.3.1 emitted the original `min-[1440px]:grid-cols-4` rule before the later `xl:grid-cols-3` rule, so the browser computed 3 columns at 1440. The narrow trailing important modifier (`min-[1440px]:grid-cols-4!`) is required to satisfy the approved runtime contract.
- The plan's `127.0.0.1:5173` seeded image URL was unreachable through the Playwright/Vite `localhost:5173` server binding and silently produced placeholders. The E2E seed uses `localhost:5173` so photo and no-photo evidence is genuine.

Canonical root Story/Spec/Plan files were not modified.
