### PR TITLE
fix(calendar): stop the event form clipping time labels

### DIFF
--- a/e2e/calendar-crud.spec.ts
+++ b/e2e/calendar-crud.spec.ts
@@ -136,4 +136,35 @@ test.describe("Calendar Event CRUD", () => {
     // Verify event is removed from calendar
     await expect(page.getByText("Updated Meeting")).not.toBeVisible();
   });
+
+  test("shows the full time label in the event form", async ({ page }) => {
+    // The desktop dialog is capped at max-w-md, so pairing Start/End side by
+    // side left each time trigger 88px — enough for the icon and padding but
+    // not for a label like "10:30 AM", whose nowrap text then spilled under the
+    // adjacent + button. Runs on every project, so the desktop dialog and the
+    // mobile sheet are both covered by the browser matrix.
+    await safeClick(page.getByRole("button", { name: "Add event" }));
+    const dialog = await waitForDialogReady(page);
+
+    const timeTriggers = dialog.getByRole("button", {
+      name: /^\d{1,2}:\d{2}\s(AM|PM)$/,
+    });
+    await expect(timeTriggers).toHaveCount(2);
+
+    for (const trigger of await timeTriggers.all()) {
+      const geometry = await trigger.evaluate((element) => ({
+        label: element.textContent ?? "",
+        // clientWidth/scrollWidth are untransformed layout metrics, so they are
+        // immune to the dialog's zoom-in enter animation, which does skew
+        // getBoundingClientRect on the opening frames.
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+      }));
+
+      expect(
+        geometry.scrollWidth,
+        `"${geometry.label.trim()}" is clipped inside its trigger`,
+      ).toBeLessThanOrEqual(geometry.clientWidth + 1);
+    }
+  });
 });

--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -87,7 +87,15 @@ function EventFormModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent aria-describedby={undefined}>
+      {/* The form grows well past a short laptop viewport once Add details is
+          expanded, and DialogContent is centred with `fixed`, so anything past
+          the fold — including the submit button — was unreachable. Matches the
+          bound the other form dialogs use via ResponsiveFormDialog. Both the
+          date and time popovers portal out, so they are not clipped by this. */}
+      <DialogContent
+        className="max-h-[90dvh] overflow-y-auto"
+        aria-describedby={undefined}
+      >
         <DialogHeader onClose={onClose}>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/calendar/components/event-form.tsx
+++ b/src/components/calendar/components/event-form.tsx
@@ -315,7 +315,15 @@ function EventForm({
 
       {/* Start/End Time */}
       {!isAllDayValue && (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        // Track sizing is driven by the space actually available, not by a
+        // viewport breakpoint: the desktop dialog is capped at max-w-md, so a
+        // `sm:grid-cols-2` pair only ever left the time trigger 88px — far too
+        // narrow for "10:30 AM" once the -/+ buttons (44px each) and the
+        // trigger's own icon and padding are subtracted, and the trigger's
+        // nowrap text spilled under the adjacent + button. auto-fit keeps the
+        // side-by-side pair wherever a column can hold a full time label and
+        // stacks them everywhere else.
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(15rem,1fr))] gap-4">
           <div className="space-y-2">
             <Label>Start Time</Label>
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problem

The Add Event modal truncated the time labels — "12:00 PM" rendered as "12:00 P". Reported for the desktop dialog, with the mobile sheet looking fine. Both halves of that report check out.

## Root cause

Measured in the browser rather than inferred:

| | |
|---|---|
| Dialog width | 448px (`max-w-md`), minus `sm:p-6` → **400px** of content |
| Time row | `sm:grid-cols-2` → two **192px** columns |
| Column contents | 44px `−` + 8px gap + **88px trigger** + 8px gap + 44px `+` |
| Trigger chrome | 24px padding + 2px border + 16px clock icon + 8px icon margin = 50px |
| Left for the label | **38px** |
| Widest real label ("10:30 AM") | **67.1px** |

The trigger is `whitespace-nowrap` with `overflow: visible`, so the text did not truncate — it spilled out of its box and the adjacent opaque `+` button painted over it, which reads as a clean truncation.

Two columns simply cannot fit in `max-w-md`: a column needs 221px, so the pair needs 458px against 400px available. Widening to `max-w-lg` would leave 2.9px of slack — one font tweak from breaking again.

Introduced by e2e0259 ("preserve event duration when changing start time"), which added the ± nudge buttons that consume 104px of each column.

Mobile was never affected because `MobileSheet` is full-bleed: 254px trigger at 390px, 220px at 700px.

## Changes

**1. Size the time tracks from available space, not a viewport breakpoint** (`event-form.tsx`)

`grid-cols-[repeat(auto-fit,minmax(15rem,1fr))]` keeps the side-by-side pair wherever a column can hold a full label and stacks otherwise. Verified: dialog → 1 column, 294px trigger; sheet at 700px → 2 columns preserved, 220px; sheet at 390px → 1 column, 252px. This also drops a latent trap — `sm:` is 640px but `useIsMobile` swaps sheet/dialog at 768px, so the old rule made a layout decision on a breakpoint that did not match the surface it was deciding for.

**2. Bound the dialog height** (`event-form-modal.tsx`)

Found while verifying the first fix, and coupled to it — stacking adds ~88px of height. `DialogContent` is centred with `fixed` and had no height bound, so with "Add details" expanded the form stood 820px tall: at 1280×700 it sat at −60..760, overflowing both edges with the submit button below the fold and nothing to scroll, since a fixed element does not extend the document. **The form was unsubmittable on a short laptop viewport.** Now capped at `max-h-[90dvh] overflow-y-auto`, matching what the other form dialogs already use via `ResponsiveFormDialog`. Both the date and time popovers render through a portal, so neither is clipped by the new scroll container.

## Verification

- New Playwright test asserts `scrollWidth <= clientWidth` on both time triggers; it runs on every project, so the desktop dialog and mobile sheet are both covered by the browser matrix.
- **Confirmed the test catches the bug**: reverting the grid change fails it with `"12:30 PM" is clipped inside its trigger — Expected: <= 87, Received: 110`.
- 28 passed / 0 failed across the 8 event-form-related specs (`calendar-crud`, `calendar-navigation`, `calendar-recurring`, `mobile-calendar`, `mobile-bottom-nav`, `mobile-home-dashboard`, `quick-capture`, `family-management`) on chromium + Mobile Chrome, against the real backend (BE 1.9.0).
- `npm run lint` clean, 1608 unit tests pass, `npm run build` (tsc) clean. Confirmed the arbitrary Tailwind value survives the production build.

## Other things found, not fixed here

1. **The dialog height bound should probably be the default, not opt-in.** Five call sites opt in via `ResponsiveFormDialog`; **ten do not** and share the exact shape just fixed. The ones that can realistically grow: `event-detail-modal.tsx:127` (long descriptions), `meal-editor-sheet.tsx:452` and `meal-composer-sheet.tsx:410` (content-heavy forms), `google-calendar-picker-modal.tsx:97` (unbounded calendar list). Worth doing in `DialogContent` itself, but it touches every dialog so it deserves its own PR and full E2E run.

2. **Same `sm:`-inside-a-capped-dialog pattern elsewhere.** `meal-editor-sheet.tsx:377` and `meal-composer-sheet.tsx:330` both use `sm:grid-cols-2` inside a `DialogContent` — the same viewport-breakpoint-decides-layout-in-a-width-capped-box shape that caused this bug. Whether they actually clip depends on their content; worth a look.

3. **`EventFormModal` hand-rolls the sheet/dialog split** that `ResponsiveFormDialog` exists to own. Adopting the wrapper would have given it the height bound for free and is why this modal drifted from the others.

4. **The time trigger fails deceptively rather than loudly.** `whitespace-nowrap` + visible overflow means any future squeeze silently paints text under adjacent controls instead of truncating. A `truncate` or explicit min-width on the trigger would degrade honestly.
