### PR TITLE
fix(ui): bound every dialog to the viewport by default

### DIFF
--- a/src/components/calendar/components/event-form-modal.tsx
+++ b/src/components/calendar/components/event-form-modal.tsx
@@ -87,15 +87,9 @@ function EventFormModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      {/* The form grows well past a short laptop viewport once Add details is
-          expanded, and DialogContent is centred with `fixed`, so anything past
-          the fold — including the submit button — was unreachable. Matches the
-          bound the other form dialogs use via ResponsiveFormDialog. Both the
-          date and time popovers portal out, so they are not clipped by this. */}
-      <DialogContent
-        className="max-h-[90dvh] overflow-y-auto"
-        aria-describedby={undefined}
-      >
+      {/* Height is bounded and scrolled by DialogContent itself, so the form
+          stays reachable once "Add details" expands past a short viewport. */}
+      <DialogContent aria-describedby={undefined}>
         <DialogHeader onClose={onClose}>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>

--- a/src/components/lists/category-manager.tsx
+++ b/src/components/lists/category-manager.tsx
@@ -596,7 +596,6 @@ export function CategoryManager({
           onOpenChange(newOpen);
         }}
         title={`${kindLabel[kind]} categories`}
-        dialogClassName="max-w-md max-h-[90dvh] overflow-y-auto"
         focusTitleOnOpen
         mobileNestedDialogOpenRef={nestedDialogOpenRef}
         returnFocusRef={returnFocusRef}

--- a/src/components/onboarding/member-form-modal.tsx
+++ b/src/components/onboarding/member-form-modal.tsx
@@ -81,7 +81,7 @@ export function MemberFormModal({
       onOpenChange={onOpenChange}
       title={mode === "add" ? "Add Family Member" : "Edit Family Member"}
       initialHeight="half"
-      dialogClassName="w-full max-w-md mx-4 sm:mx-auto max-h-[90dvh] overflow-y-auto"
+      dialogClassName="w-full max-w-md mx-4 sm:mx-auto"
     >
       <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-6">
         <div className="space-y-2">

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -120,7 +120,7 @@ export function FamilySettingsModal({
         onOpenChange={onOpenChange}
         title="Family Settings"
         initialHeight="full"
-        dialogClassName="max-w-lg max-h-[90dvh] overflow-y-auto"
+        dialogClassName="max-w-lg"
         titleClassName="text-xl"
         desktopHeaderRight={
           <Button

--- a/src/components/settings/member-profile-modal.tsx
+++ b/src/components/settings/member-profile-modal.tsx
@@ -137,7 +137,7 @@ export function MemberProfileModal({
       onOpenChange={onOpenChange}
       title="Member Profile"
       initialHeight="full"
-      dialogClassName="max-w-sm max-h-[90dvh] overflow-y-auto"
+      dialogClassName="max-w-sm"
       titleClassName="text-xl"
       desktopHeaderRight={
         <Button

--- a/src/components/settings/preferences-sheet.tsx
+++ b/src/components/settings/preferences-sheet.tsx
@@ -85,7 +85,7 @@ export function PreferencesSheet({
       onOpenChange={onOpenChange}
       title="Preferences"
       initialHeight="full"
-      dialogClassName="max-w-lg max-h-[90dvh] overflow-y-auto"
+      dialogClassName="max-w-lg"
       titleClassName="text-xl"
       desktopHeaderRight={
         <Button

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -35,3 +35,36 @@ describe("DialogContent mobile sizing contract", () => {
     expect(content.className).toContain("max-w-lg");
   });
 });
+
+describe("DialogContent viewport height bound", () => {
+  function renderContent(className?: string) {
+    render(
+      <Dialog open>
+        <DialogContent className={className}>
+          <DialogTitle>Bounded</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    return screen.getByRole("dialog");
+  }
+
+  it("bounds its height to the viewport and scrolls overflow by default", () => {
+    // A fixed, centered dialog does not extend the document, so content that
+    // grows past the viewport pushes the submit button below the fold with
+    // nothing to scroll. The bound must be the DialogContent default so every
+    // caller is safe without opting in per-site.
+    const content = renderContent();
+
+    expect(content.className).toContain("max-h-[90dvh]");
+    expect(content.className).toContain("overflow-y-auto");
+  });
+
+  it("lets callers override the height cap via twMerge", () => {
+    // The default is a floor, not a cage: a caller that needs a different
+    // height cap can still pass one and win the conflict.
+    const content = renderContent("max-h-screen");
+
+    expect(content.className).toContain("max-h-screen");
+    expect(content.className).not.toContain("max-h-[90dvh]");
+  });
+});

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,6 +40,14 @@ function DialogContent({
           // edge at narrow phone widths. Combining w-full with external margins
           // (mx-4) overflowed because margins don't shrink a full-width box.
           "fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2",
+          // Bound height to the viewport and scroll internally so content taller
+          // than the screen stays reachable. A fixed, centered box does not
+          // extend the document, so without this anything past the fold — the
+          // submit button included — is unreachable and unscrollable. Callers
+          // can still override the cap via className (twMerge). Popovers/selects
+          // inside dialogs portal out (or are OS-native), so they are not
+          // clipped by this scroll container.
+          "max-h-[90dvh] overflow-y-auto",
           "bg-card rounded-xl shadow-2xl p-5 sm:p-6",
           "duration-200",
           "data-[state=open]:animate-in data-[state=closed]:animate-out",

--- a/src/components/ui/responsive-form-dialog.tsx
+++ b/src/components/ui/responsive-form-dialog.tsx
@@ -18,7 +18,11 @@ interface ResponsiveFormDialogProps {
   title: string;
   /** Mobile sheet open height. Desktop is unaffected. Defaults to "full". */
   initialHeight?: MobileSheetHeight;
-  /** Desktop DialogContent classes (e.g. "max-w-lg max-h-[90dvh] overflow-y-auto"). */
+  /**
+   * Extra desktop DialogContent classes, e.g. a width override like "max-w-lg".
+   * The viewport height bound and internal scroll are DialogContent defaults,
+   * so callers no longer pass "max-h-[90dvh] overflow-y-auto" here.
+   */
   dialogClassName?: string;
   /**
    * Desktop DialogTitle classes. Defaults to the DialogTitle primitive size;


### PR DESCRIPTION
## Problem

`DialogContent` (`src/components/ui/dialog.tsx`) is centered with `fixed left-1/2 top-1/2 -translate-*` and set no `max-height`/`overflow`. A fixed element does not extend the document, so any dialog whose content grows past the viewport pushes content — including the submit button — below the fold with **nothing to scroll**. It becomes unreachable.

This was just fixed for the Add Event dialog per-call-site in #296. Five other dialogs already opted into the same `max-h-[90dvh] overflow-y-auto` bound via `ResponsiveFormDialog`. **Ten more were one long field away from the identical bug** (e.g. a long event description in `event-detail-modal`, an unbounded calendar list in `google-calendar-picker-modal`).

## Change

- Make `max-h-[90dvh] overflow-y-auto` a **`DialogContent` default**, so every dialog is viewport-bounded and scrollable without opting in.
- Drop the now-redundant per-caller opt-ins (the `event-form-modal` fix from #296 + 5 `ResponsiveFormDialog` sites), keeping only genuine width overrides (`max-w-lg`, `max-w-sm`, …).
- Update the `ResponsiveFormDialog` `dialogClassName` doc so future callers don't re-add the bound.

The 10 previously-unbounded dialogs now inherit the fix for free.

## Clipping safety — does the scroll container clip popovers/selects inside a dialog?

No. `overflow-y-auto` makes `overflow-x` compute to `auto` as well, so it clips **any** non-portalled floating descendant. A codebase-wide sweep found none:

- **Radix Popover / calendar** render through `PopoverPrimitive.Portal` → mounted on `document.body`, so they are not descendants of `DialogContent` and `overflow` there cannot clip them (definitional, not luck).
- **Native `<select>`** dropdowns are OS-rendered — unaffected by CSS overflow.
- **`MemberSelector`** is inline flex-wrap chips, not floating.

`role="listbox|menu|combobox"` and `createPortal` return **zero hits** outside `popover.tsx`. The exact bound was already live on `event-form-modal` (date/time popovers) and `preferences` (native `<select>`) before this change, so it's proven — this PR just generalizes it.

## Verification

- `npm run lint` — clean
- `npm test -- --run` — **1610 passed** (incl. 2 new tests: the bound is the `DialogContent` default; a caller can still override it via twMerge)
- `npm run build` — type-check + build clean
- **Playwright** (real `1.9.0` backend): the 7 failures seen under the full 5-project parallel matrix were backend-contention timeouts (local `retries: 0`, a single `-Xmx256m` API container). **All 7 pass in isolation** (`--workers=1`) — including the webkit calendar-dialog trio and the vaul mobile sheet (which this PR does not touch), confirming they are pre-existing flakes, not regressions.
