### PR TITLE
fix(calendar): honour prefers-reduced-motion in day auto-scroll

### DIFF
--- a/src/components/calendar/components/current-time-indicator.test.tsx
+++ b/src/components/calendar/components/current-time-indicator.test.tsx
@@ -1,22 +1,32 @@
 import { renderHook } from "@testing-library/react";
 import { useRef } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { useAutoScrollToMinutes } from "./current-time-indicator";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useAutoScrollToMinutes,
+  useAutoScrollToNow,
+} from "./current-time-indicator";
+
+function mockReducedMotion(matches: boolean) {
+  vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+    matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+// setup.ts's afterEach uses clearAllMocks, which clears calls but keeps mock
+// implementations — a mockReducedMotion(true) would otherwise leak into every
+// later test in this file. Reset the preference explicitly before each test.
+beforeEach(() => {
+  mockReducedMotion(false);
+});
 
 describe("useAutoScrollToMinutes", () => {
-  function mockReducedMotion(matches: boolean) {
-    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
-      matches: query === "(prefers-reduced-motion: reduce)" ? matches : false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-  }
-
   it("scrolls to the target row minus a lead offset", () => {
     const el = document.createElement("div");
     const scrollTo = vi.spyOn(el, "scrollTo");
@@ -66,5 +76,83 @@ describe("useAutoScrollToMinutes", () => {
     });
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 320, behavior: "auto" });
+  });
+});
+
+describe("useAutoScrollToNow", () => {
+  /**
+   * Only Date is faked: setTimeout/setInterval stay real so renderHook's act()
+   * scheduling is untouched. setup.ts's afterEach restores real timers.
+   */
+  function freezeClockAt(hours: number, minutes: number) {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(2026, 0, 15, hours, minutes, 0));
+  }
+
+  it("scrolls to the current time minus a lead offset", () => {
+    freezeClockAt(13, 30);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToNow(ref); // defaults: 6am start, 80px rows
+    });
+
+    // 7h30m after start -> (450/60)*80 - 200 = 600 - 200 = 400
+    expect(scrollTo).toHaveBeenCalledWith({ top: 400, behavior: "smooth" });
+  });
+
+  it("clamps to the top of the grid early in the day", () => {
+    freezeClockAt(6, 30);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToNow(ref);
+    });
+
+    // 30m after start -> (30/60)*80 - 200 = 40 - 200 = -160 -> clamped to 0
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "smooth" });
+  });
+
+  it("does nothing when the container ref is empty", () => {
+    freezeClockAt(13, 30);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    // Day views pass { current: null } when the shown day is not today.
+    renderHook(() => useAutoScrollToNow({ current: null }));
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("uses instant scroll when reduced motion is requested", () => {
+    mockReducedMotion(true);
+    freezeClockAt(16, 0);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToNow(ref, 6, 52);
+    });
+
+    // 10h after start -> (600/60)*52 - 200 = 520 - 200 = 320
+    expect(scrollTo).toHaveBeenCalledWith({ top: 320, behavior: "auto" });
+  });
+
+  it("uses smooth scroll when motion is allowed", () => {
+    freezeClockAt(16, 0);
+    const el = document.createElement("div");
+    const scrollTo = vi.spyOn(el, "scrollTo");
+
+    renderHook(() => {
+      const ref = useRef<HTMLDivElement>(el);
+      useAutoScrollToNow(ref, 6, 52);
+    });
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 320, behavior: "smooth" });
   });
 });

--- a/src/components/calendar/components/current-time-indicator.tsx
+++ b/src/components/calendar/components/current-time-indicator.tsx
@@ -51,6 +51,42 @@ export function CurrentTimeIndicator({
   );
 }
 
+/** Pixels of grid left visible above the target, so it is not flush to the top. */
+const SCROLL_LEAD_PX = 200;
+
+/**
+ * Scroll `container` so the row `targetMinutes` past the grid's start hour sits
+ * SCROLL_LEAD_PX below the top, honouring the user's motion preference.
+ *
+ * Both auto-scroll hooks route through here so they cannot drift apart: an
+ * unconditional `behavior: "smooth"` animates past a reduced-motion request and
+ * also makes screenshot tests nondeterministic, since a capture taken shortly
+ * after mount lands at a different point on the easing curve each run.
+ *
+ * The preference is read at scroll time rather than via usePrefersReducedMotion
+ * so that toggling it mid-session does not re-run the effect and yank the grid
+ * out from under the user.
+ */
+function scrollToMinutes(
+  container: HTMLElement,
+  targetMinutes: number,
+  rowHeight: number,
+) {
+  const prefersReducedMotion = window.matchMedia(
+    "(prefers-reduced-motion: reduce)",
+  ).matches;
+  const scrollPosition = (targetMinutes / 60) * rowHeight - SCROLL_LEAD_PX;
+
+  container.scrollTo({
+    top: Math.max(0, scrollPosition),
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+  });
+}
+
+/**
+ * Scroll the grid so the current time is comfortably in view. Pass a ref whose
+ * `current` is null to skip (e.g. the shown day is not today).
+ */
 export function useAutoScrollToNow(
   containerRef: React.RefObject<HTMLElement | null>,
   startHour = 6,
@@ -60,25 +96,18 @@ export function useAutoScrollToNow(
     if (!containerRef.current) return;
 
     const now = new Date();
-    const hours = now.getHours();
-    const minutes = now.getMinutes();
+    const minutesFromStart =
+      (now.getHours() - startHour) * 60 + now.getMinutes();
 
-    const hourOffset = hours - startHour;
-    const minuteOffset = minutes / 60;
-    const scrollPosition = (hourOffset + minuteOffset) * rowHeight - 200;
-
-    containerRef.current.scrollTo({
-      top: Math.max(0, scrollPosition),
-      behavior: "smooth",
-    });
+    scrollToMinutes(containerRef.current, minutesFromStart, rowHeight);
   }, [containerRef, startHour, rowHeight]);
 }
 
 /**
  * Scroll the grid so a target time is comfortably in view. `targetMinutes` is
  * minutes from the grid's start hour; pass null to skip (e.g. no events and not
- * today). Mirrors useAutoScrollToNow's 200px lead but takes an explicit target
- * so callers can choose "now" or "first event" (spec Section 3, Week auto-scroll).
+ * today). Mirrors useAutoScrollToNow but takes an explicit target so callers can
+ * choose "now" or "first event" (spec Section 3, Week auto-scroll).
  */
 export function useAutoScrollToMinutes(
   containerRef: React.RefObject<HTMLElement | null>,
@@ -88,13 +117,6 @@ export function useAutoScrollToMinutes(
   useEffect(() => {
     if (!containerRef.current || targetMinutes == null) return;
 
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    const scrollPosition = (targetMinutes / 60) * rowHeight - 200;
-    containerRef.current.scrollTo({
-      top: Math.max(0, scrollPosition),
-      behavior: prefersReducedMotion ? "auto" : "smooth",
-    });
+    scrollToMinutes(containerRef.current, targetMinutes, rowHeight);
   }, [containerRef, targetMinutes, rowHeight]);
 }


### PR DESCRIPTION
## Problem

`useAutoScrollToNow` called `scrollTo({ behavior: "smooth" })` unconditionally, while its sibling `useAutoScrollToMinutes` in the same file first checked `window.matchMedia("(prefers-reduced-motion: reduce)")`.

Two consequences:

1. **Accessibility inconsistency.** The Day view (`DailyCalendar`, `MobileDailyView`) animated a smooth scroll on mount even when the user had asked for reduced motion. The Week view honoured it.
2. **Nondeterministic screenshots.** A capture taken shortly after mount lands at a different point on the easing curve each run — observed as a ~3px vertical offset between otherwise byte-identical runs of the same source.

This was explicitly out of scope for #293 (large-screen Month/Schedule), which is why it was left alone there; it is a deliberate behavioural change to Day/Week and gets its own scope here.

## Change

Extracted the shared logic — scroll to minutes-from-start-hour, apply the 200px lead, clamp at 0, pick behaviour from the motion preference — into a module-level `scrollToMinutes` helper. Both hooks now route through the same call site, so they cannot drift apart again.

`useAutoScrollToNow`'s math changed shape from `(hourOffset + minuteOffset) * rowHeight` to `(minutesFromStart / 60) * rowHeight`. These are arithmetically identical (and identical in floating point); the characterization tests below pin the exact offsets.

The preference is read at scroll time rather than through the existing `usePrefersReducedMotion` hook: subscribing would put the value in the effect deps and re-scroll the grid if the user toggled the preference mid-session, yanking the view out from under them. This also matches the approach `useAutoScrollToMinutes` already used.

## Tests

Added a `useAutoScrollToNow` suite mirroring the existing `useAutoScrollToMinutes` one — reduced motion → `behavior: "auto"`, motion allowed → `"smooth"`, plus the lead-offset math, the clamp-at-top case, and the empty-ref skip that Day views rely on when the shown day is not today.

The reduced-motion test was written first and failed for the right reason (`top: 320` already correct, only `behavior` wrong: `"smooth"` where `"auto"` was expected). The other five passed against the old implementation, pinning behaviour through the refactor.

Also lifted `mockReducedMotion` to module scope with a `beforeEach` reset. `setup.ts`'s `afterEach` uses `clearAllMocks`, which clears calls but keeps mock implementations — a `mockReducedMotion(true)` would otherwise leak into every later test in the file.

## Verification

- `npm run lint` — exit 0 (the 2 infos are a pre-existing Biome config-schema notice; identical on a stashed tree)
- `npm test -- --run` — 165 files, 1615 tests, all passing
- `npm run build` — type-check + build clean

Not verified in a browser preview: reduced motion cannot be emulated through the preview tools, and the Day view needs a running backend to render. The unit tests cover both settings deterministically, including the exact scroll offsets.

## Follow-up (not in this PR)

`e2e/calendar-preservation-visual.spec.ts` and its `waitForScrollSettled` helper exist only on `feat/large-screen-month-schedule` (#293), not on `main`, so they cannot be touched from this branch.

**The helper should be kept.** It polls every scroller on the page, not just the calendar grid, and it also guards against capturing before a scroll has finished — that protection is still wanted. What should change once both land is its doc comment, which currently describes this bug as live ("`useAutoScrollToNow` passes `behavior: "smooth"` unconditionally — it does not consult reduced-motion the way its sibling does"). That is stale as of this PR.

Worth noting: `playwright.config.ts` already sets `reducedMotion: "reduce"` globally, so after this merges every E2E run gets instant auto-scroll on Day and Week — which is exactly what makes the #293 screenshot gate deterministic.