### PR TITLE
fix(calendar): name a removed member on large-screen Schedule rows

### DIFF
--- a/src/components/calendar/views/schedule-calendar.test.tsx
+++ b/src/components/calendar/views/schedule-calendar.test.tsx
@@ -322,6 +322,72 @@ describe("ScheduleCalendar", () => {
       );
     });
 
+    /**
+     * A removed member is reachable, not hypothetical: the calendar store
+     * persists `filter.selectedMembers`, so an id can outlive the member it
+     * named and keep letting that member's events through the filter. The
+     * fixture therefore keeps the stale id selected.
+     */
+    function renderWithRemovedMember() {
+      const events = [
+        createTestEvent({
+          id: "kept",
+          title: "Kept Event",
+          date: fixedNow,
+          memberId: testMembers[0].id,
+        }),
+        createTestEvent({
+          id: "orphan",
+          title: "Orphan Event",
+          date: fixedNow,
+          memberId: "removed-member",
+        }),
+      ];
+      return render(
+        <ScheduleCalendar
+          events={events}
+          currentDate={fixedNow}
+          filter={{
+            ...defaultFilter,
+            selectedMembers: [
+              ...defaultFilter.selectedMembers,
+              "removed-member",
+            ],
+          }}
+        />,
+      );
+    }
+
+    it("names a member who is no longer in the family", () => {
+      renderWithRemovedMember();
+      const row = screen.getByRole("button", { name: /Orphan Event/ });
+      // Same string as month-overflow-popover.tsx, so the two surfaces agree.
+      expect(within(row).getByText("Unknown member")).toBeInTheDocument();
+    });
+
+    it("omits the avatar for a removed member but keeps it for a real one", () => {
+      const { container } = renderWithRemovedMember();
+      const orphan = screen.getByRole("button", { name: /Orphan Event/ });
+      const kept = screen.getByRole("button", { name: /Kept Event/ });
+      // MemberAvatar is the only rounded-full element inside an event row, and
+      // it needs a real FamilyColor — so the fallback must not render one.
+      expect(kept.querySelector(".rounded-full")).not.toBeNull();
+      expect(orphan.querySelector(".rounded-full")).toBeNull();
+      expect(container.querySelectorAll(".rounded-full")).toHaveLength(1);
+    });
+
+    it("gives the fallback the same treatment as a real member name", () => {
+      renderWithRemovedMember();
+      const fallback = within(
+        screen.getByRole("button", { name: /Orphan Event/ }),
+      ).getByText("Unknown member");
+      const real = within(
+        screen.getByRole("button", { name: /Kept Event/ }),
+      ).getByText(testMembers[0].name);
+      // Identity must not visually downgrade when the member is missing.
+      expect(fallback.className).toBe(real.className);
+    });
+
     it("colours the left border with the member's colour", () => {
       renderSchedule();
       const row = screen.getByRole("button", { name: /Test Event/ });

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -459,18 +459,29 @@ function ScheduleCalendarLarge({
                           )}
                         </div>
                       </div>
-                      {member && (
-                        <span className="ml-auto flex shrink-0 items-center gap-2">
-                          <span className="text-sm font-medium text-foreground">
-                            {member.name}
-                          </span>
+                      {/*
+                        An event can outlive the member it names — the calendar
+                        store persists `filter.selectedMembers`, so a stale id
+                        still passes the filter. Without a fallback the row
+                        would carry no member identity in any channel: the
+                        border falls back to the default colour and the
+                        background to `bg-muted`. The wording matches
+                        month-overflow-popover.tsx. The avatar is dropped
+                        rather than given a stand-in colour, because
+                        `MemberAvatar` needs a real `FamilyColor`.
+                      */}
+                      <span className="ml-auto flex shrink-0 items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">
+                          {member?.name ?? "Unknown member"}
+                        </span>
+                        {member && (
                           <MemberAvatar
                             name={member.name}
                             color={member.color}
                             size="md"
                           />
-                        </span>
-                      )}
+                        )}
+                      </span>
                     </button>
                   );
                 })}


### PR DESCRIPTION
Closes #303

## Summary

A large-screen Schedule row whose event references a member no longer in the
family rendered **no member identity in any channel**: the trailing block was
gated behind `{member && ...}` so there was no name and no avatar, the coloured
left border fell back to the theme default (`borderLeftColor: undefined`), and
the background fell back to `bg-muted`. This renders `Unknown member` instead.

This is the second of two follow-ups falling out of #293 / PR #301. It ships
first because it provably moves no gated pixels; the compact-border fix (#304)
lands on top of it and deliberately does move mobile pixels, so keeping them
apart is what keeps that rebaseline reviewable.

## Links

- Story: https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-calendar-month-schedule.md
- Spec: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-18-large-screen-calendar-month-schedule-design.md

Not recorded in spec Section 11 — it came out of the PR #301 review. Section 11
gets the write-up once #304 lands, in the root repo.

## Why this is reachable, not hypothetical

`calendar-store.ts` persists `filter` (including `selectedMembers`) under
`family-hub-calendar`. A member id can therefore outlive the member it named,
stay selected, and keep letting that member's events through
`buildScheduleRows`' `filter.selectedMembers.includes(event.memberId)` check —
straight into a row that `getFamilyMember` can no longer resolve.

## The change

```diff
-{member && (
-  <span className="ml-auto flex shrink-0 items-center gap-2">
-    <span className="text-sm font-medium text-foreground">{member.name}</span>
-    <MemberAvatar name={member.name} color={member.color} size="md" />
-  </span>
-)}
+<span className="ml-auto flex shrink-0 items-center gap-2">
+  <span className="text-sm font-medium text-foreground">
+    {member?.name ?? "Unknown member"}
+  </span>
+  {member && (
+    <MemberAvatar name={member.name} color={member.color} size="md" />
+  )}
+</span>
```

- **Wording reused, not invented.** `Unknown member` is copied verbatim from
  `month-overflow-popover.tsx:91`, so the two surfaces that name a missing
  member agree. (`month-event-chip.tsx:27` uses `Unknown` because it renders
  *first names* only, and this row renders full names.)
- **No avatar in the fallback.** `MemberAvatar` requires a real `FamilyColor`;
  a stand-in colour would be a lie in the one channel this fix exists to stop
  lying in.
- **No visual downgrade.** The fallback keeps `text-sm font-medium
  text-foreground`, byte-identical to a real member name.

## Contrast

`--foreground` `oklch(0.25 0.02 250)` (`#1a222b`) over `--muted`
`oklch(0.94 0.02 85)` (`#f1eadc`) = **13.40:1**, against a WCAG AA floor of
4.5:1 for 14px normal-weight text. The row background is `bg-muted` precisely
because there is no member tint to apply, so `bg-muted` is the correct
backdrop to measure.

## Scope: no gate can move

The edit is inside `ScheduleCalendarLarge`, which `ScheduleCalendar` only
reaches when `useIsLargeScreen()` (>=1024px) is true. `ScheduleCalendarCompact`
is not touched — see the diff, which is two files and 84 insertions total.

The preservation matrix (375x812, 768x1024, 769x1024) and the mobile Schedule
parity captures (375x812) all sit below 1024px, so none of them can observe
this change. No rebaseline is requested or needed by this PR.

## Verification

| Command | Result |
| --- | --- |
| `npx biome check src e2e scripts ./*.ts ./*.js ./*.json` | 488 files, 0 errors — 1 pre-existing `useOptionalChain` warning in `month-event-chip.test.tsx`, 2 pre-existing `biome.json` schema-version infos |
| `npm test -- --run` | **174 test files, 1733 tests, all passed** |
| `npm run build` | exit 0 (`tsc -b` clean, built in 7.23s) |

Lint was run scoped rather than as `npm run lint` (`biome check .`) because a
stale local git worktree under `.claude/worktrees/` carries its own
`biome.json`, and Biome aborts on the nested root config before checking
anything. That is local environment state, not a repo condition — CI's checkout
has no such directory, so `npm run lint` is unaffected there. The scoped
invocation covers every file `biome check .` would: all of `src`, `e2e`,
`scripts` and the root-level `.ts`/`.js`/`.json` files.

### Tests — 3 added, all in the existing `describe("large screen")` block

No third parallel describe block; the block PR #301 folded stays folded.

| Test | Pins |
| --- | --- |
| *names a member who is no longer in the family* | the `Unknown member` string is present in the row |
| *omits the avatar for a removed member but keeps it for a real one* | exactly one `MemberAvatar` across a two-row render — present on the real member's row, absent on the orphan's |
| *gives the fallback the same treatment as a real member name* | `fallback.className === real.className`, so size/weight cannot silently diverge |

Honest note on the middle test: it passes against `main` too, because today the
orphan row renders nothing at all. It is a **constraint** test rather than a
red-first one — it exists to fail the obvious wrong fix (handing `MemberAvatar`
a placeholder colour so the fallback gets an avatar). The other two were
watched failing first, both with *"Unable to find an element with the text:
Unknown member"*.

Both fixtures render a real-member row **and** an orphan row in the same tree,
so every assertion is a comparison rather than an isolated snapshot.
