### PR TITLE
fix(calendar): resolve the Schedule member border below 1024px

### DIFF
--- a/e2e/mobile-calendar.spec.ts
+++ b/e2e/mobile-calendar.spec.ts
@@ -1,8 +1,15 @@
 import { expect, test } from "@playwright/test";
-import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import { colorMap } from "../src/lib/types";
+import {
+  createCalendarEvent,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
 import {
   clearStorage,
+  getTodayDateString,
   safeClick,
+  switchCalendarView,
   waitForCalendarReady,
   waitForHydration,
 } from "./helpers/test-helpers";
@@ -126,5 +133,70 @@ test.describe("Mobile Calendar Views", () => {
     // Bob's filter dot should also be present
     const bobDot = page.getByRole("button", { name: /Bob filter/i }).first();
     await expect(bobDot).toBeVisible();
+  });
+});
+
+/**
+ * The compact Schedule row's coloured left border.
+ *
+ * Its own describe because the fixture ordering is load-bearing: the event must
+ * exist *before* the app's first authenticated calendar load. Seeding it after
+ * that load and reloading does not work — successful queries are persisted to
+ * IndexedDB by `PersistQueryClientProvider`, `clearStorage` clears only
+ * local/sessionStorage, and the restored empty result is seconds old against a
+ * 5-minute `staleTime`, so TanStack treats it as fresh and never refetches.
+ * Schedule then renders "No upcoming events" while the event sits in the
+ * backend. Same ordering as `calendar-preservation-visual.spec.ts`.
+ */
+test.describe("Mobile Schedule member border", () => {
+  test("Schedule rows resolve the member's coloured left border", async ({
+    page,
+    request,
+    isMobile,
+  }) => {
+    test.skip(!isMobile, "Mobile-only test");
+
+    await page.goto("/");
+    await clearStorage(page);
+
+    const reg = await registerFamily(request, {
+      familyName: "Schedule Border",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await createCalendarEvent(request, reg.token, {
+      title: "Border Probe",
+      date: getTodayDateString(),
+      startTime: "9:00 AM",
+      endTime: "10:00 AM",
+      memberId: reg.family.members[0].id,
+      isAllDay: false,
+    });
+
+    await seedBrowserAuth(page, reg);
+    await page.reload();
+    await waitForHydration(page);
+    await waitForCalendarReady(page);
+    await switchCalendarView(page, "schedule");
+
+    // Assert on the loaded surface, never on an empty one: reading geometry off
+    // a row that has not rendered yet fails for the wrong reason.
+    const row = page.getByRole("button", { name: /Border Probe/ });
+    await expect(row).toBeVisible();
+
+    // The *resolved* values, not `element.style`. jsdom cannot stand in for
+    // this: it loads no Tailwind stylesheet, so `border-l-4` never resolves
+    // there and the width half of the guard only holds against real CSS.
+    const actual = await row.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return { color: style.borderLeftColor, width: style.borderLeftWidth };
+    });
+    const expected = await page.evaluate((hex) => {
+      const probe = document.createElement("div");
+      probe.style.borderLeftColor = hex;
+      return probe.style.borderLeftColor;
+    }, colorMap.coral.hex);
+
+    expect(actual.color).toBe(expected);
+    expect(actual.width).toBe("4px");
   });
 });

--- a/src/components/calendar/views/schedule-calendar.test.tsx
+++ b/src/components/calendar/views/schedule-calendar.test.tsx
@@ -26,6 +26,14 @@ function setMobile(isMobile: boolean) {
   setViewportWidth(isMobile ? 390 : 1024);
 }
 
+/** jsdom reports resolved colours as `rgb(r, g, b)`, never as the source hex. */
+function hexToRgb(hex: string): string {
+  const channels = hex.replace("#", "").match(/[0-9a-f]{2}/gi);
+  if (channels?.length !== 3) throw new Error(`Invalid hex: ${hex}`);
+  const [red, green, blue] = channels.map((c) => Number.parseInt(c, 16));
+  return `rgb(${red}, ${green}, ${blue})`;
+}
+
 describe("ScheduleCalendar", () => {
   beforeEach(() => {
     seedFamilyStore({
@@ -193,6 +201,70 @@ describe("ScheduleCalendar", () => {
       expect(scrollArea).toHaveStyle({
         paddingBottom: expectedBottomPadding,
       });
+    });
+
+    it("colours the left border with the member's colour", () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      render(
+        <ScheduleCalendar
+          events={[testEvents[0]]}
+          currentDate={today}
+          filter={defaultFilter}
+        />,
+      );
+
+      // The *resolved* value, not `element.style`: reading the inline
+      // declaration back would pass even if another rule won the cascade.
+      //
+      // The matching `border-left-width: 4px` guard cannot live here. jsdom
+      // loads no Tailwind stylesheet, so `border-l-4` never resolves and
+      // `getComputedStyle(row).borderLeftWidth` returns the UA default `2px`
+      // for a <button> whether or not the class is present — pinning it would
+      // prove nothing. That half is enforced in `e2e/mobile-calendar.spec.ts`
+      // against real CSS, mirroring what the lg+ branch does in
+      // `e2e/large-screen-calendar-schedule.spec.ts`.
+      const row = screen.getByRole("button", { name: /Morning Meeting/ });
+      expect(getComputedStyle(row).borderLeftColor).toBe(
+        hexToRgb(colorMap[testMembers[0].color].hex),
+      );
+      // `colorMap[x].bg` and `colorMap[x].light` are both `bg-*` utilities, so
+      // twMerge collapses them and the border colour class disappears. The
+      // background must survive the fix that restores the border.
+      expect(row).toHaveClass(colorMap[testMembers[0].color].light);
+    });
+
+    it("leaves a member-less row on the default border colour", () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const orphan = createTestEvent({
+        id: "orphan",
+        title: "Orphan Event",
+        date: today,
+        memberId: "removed-member",
+      });
+
+      render(
+        <ScheduleCalendar
+          events={[orphan]}
+          currentDate={today}
+          filter={{
+            ...defaultFilter,
+            selectedMembers: [
+              ...defaultFilter.selectedMembers,
+              "removed-member",
+            ],
+          }}
+        />,
+      );
+
+      // `border-muted-foreground` is a *border* utility, so it never collided
+      // with `bg-muted` and this branch already renders as intended. Fixing the
+      // member branch must not disturb it.
+      const row = screen.getByRole("button", { name: /Orphan Event/ });
+      expect(row).toHaveClass("border-muted-foreground", "bg-muted");
+      expect(row.style.borderLeftColor).toBe("");
     });
   });
 

--- a/src/components/calendar/views/schedule-calendar.tsx
+++ b/src/components/calendar/views/schedule-calendar.tsx
@@ -149,15 +149,29 @@ function ScheduleCalendarCompact({
                       type="button"
                       key={getEventKey(event)}
                       onClick={() => onEventClick?.(event)}
+                      // The border colour has to be an inline style, exactly as
+                      // in the lg+ branch. Passing `colorMap[x].bg` through
+                      // `cn()` alongside `colorMap[x].light` does not work:
+                      // both are `bg-*` utilities, so twMerge treats them as
+                      // conflicting and keeps only the last, leaving no border
+                      // colour at all. Reordering only swaps which background
+                      // wins; an inline style is what twMerge cannot collapse.
+                      style={{
+                        borderLeftColor: member
+                          ? colorMap[member.color].hex
+                          : undefined,
+                      }}
                       className={cn(
                         "flex min-h-14 w-full cursor-pointer items-center rounded-xl p-3 text-left",
                         "transition-all hover:shadow-md hover:scale-[1.005]",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
                         "border-l-4 ring-1 ring-inset ring-black/5",
+                        // `border-muted-foreground` is a border utility, so the
+                        // member-less row never had the collision and already
+                        // rendered as intended. It keeps its shipped classes.
                         member
-                          ? colorMap[member.color]?.bg
-                          : "border-muted-foreground",
-                        member ? colorMap[member.color]?.light : "bg-muted",
+                          ? colorMap[member.color].light
+                          : "border-muted-foreground bg-muted",
                       )}
                     >
                       <div className="flex min-w-0 flex-1 flex-col">


### PR DESCRIPTION
Closes #304

> **Stacked on #305.** Base is `fix/schedule-unknown-member-row` so this diff is
> *only* the border change — one commit, three files. GitHub retargets to `main`
> automatically when #305 merges. Merge #305 first.
>
> Consequence worth knowing: `.github/workflows/ci.yml` triggers on
> `pull_request: branches: [main]`, so the `check` job does **not** run while
> this PR points at another branch. It fires on retarget. Every gate it would
> run has been run locally and is recorded under Verification below.

## Summary

`ScheduleCalendarCompact` passed both `colorMap[member.color].bg` and
`colorMap[member.color].light` into `cn()`. Both are `bg-*` utilities
(`bg-[#b95443]` and `bg-[#fbe9e6]`), so `twMerge` treated them as conflicting
and kept only the last. Every member row was left with **no border-colour class
at all**, and `border-l-4` rendered in the theme's default `--border`.

The fix is the one the `lg+` branch already carries: set the colour from the
member's `hex` via an inline style, which `twMerge` cannot collapse.

**This is a deliberate, visible mobile change** — it is the reason #293 refused
to do it and the reason this is its own PR. Spec Section 11 asks that review of
this change be about that visual delta specifically, so the diff is one
component and one test file and contains nothing else.

## Links

- Story: https://github.com/joe-bor/family-hub/blob/main/docs/product/backlog/large-screen-ux/large-screen-calendar-month-schedule.md
- Spec: https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-18-large-screen-calendar-month-schedule-design.md
  (Section 5.1 describes the collapse; Section 11 records the limitation this closes)

## The change

```diff
+  style={{
+    borderLeftColor: member ? colorMap[member.color].hex : undefined,
+  }}
   className={cn(
     "border-l-4 ring-1 ring-inset ring-black/5",
-    member ? colorMap[member.color]?.bg : "border-muted-foreground",
-    member ? colorMap[member.color]?.light : "bg-muted",
+    member ? colorMap[member.color].light : "border-muted-foreground bg-muted",
   )}
```

The dead `.bg` argument is removed rather than reordered — reordering only swaps
which background wins, and leaving it in would keep a class in the source that
`twMerge` silently discards.

**The member-less branch is untouched by design.** `border-muted-foreground` is
a *border* utility, so it never collided with `bg-muted`; a member-less row
already rendered its intended border. Its two classes are merged into one
argument, and its resolved appearance is unchanged (test below pins this).

## Visual delta

Only the 4px left border. Everything else — layout, backgrounds, type, spacing,
avatars — is identical, which the hash tables below make exact rather than
asserted.

| | Before | After |
| --- | --- | --- |
| Alice's row | default `--border` (`oklch(0.88 0.02 85)`) | coral `#b95443` |
| Bob's row | default `--border` | teal `#2f827f` |

The E2E assertion reads exactly this: before the fix it failed with
`Expected: "rgb(185, 84, 67)"` / `Received: "oklch(0.88 0.02 85)"`.

## Preservation gate — twelve pairs, three rebaselined

Captured with `e2e/calendar-preservation-visual.spec.ts` under
`scripts/run-calendar-e2e.sh` (released backend), `--project=chromium
--workers=1`, from this branch and from its base commit `38677be`, with the
spec's own deterministic-rasterisation flags.

**The nine non-Schedule pairs are byte-identical, and their hashes match the
values PR #301 recorded** — so the baseline reproduces #301's captures exactly
and the only thing that moved is what this PR intends to move.

| Capture | baseline SHA-256 | current SHA-256 | |
| --- | --- | --- | --- |
| `monthly-375x812.png` | `7e202755cee9145fd9e66d991caf5334dd4ca51377b1c90cef0e6fe4b6623158` | `7e202755cee9145fd9e66d991caf5334dd4ca51377b1c90cef0e6fe4b6623158` | identical |
| `monthly-768x1024.png` | `a69074851f21789789bb944ac1f050c35f6e093d484eed6062ed8616048bc69c` | `a69074851f21789789bb944ac1f050c35f6e093d484eed6062ed8616048bc69c` | identical |
| `monthly-769x1024.png` | `bd00a1c713865a0de9fc88958554122e02ee506c76a968a7cd286a4ebdbecdf8` | `bd00a1c713865a0de9fc88958554122e02ee506c76a968a7cd286a4ebdbecdf8` | identical |
| `weekly-375x812.png` | `eadecd812838f8cf41a92cf10c5e9bcb4e528684f5b8d8cee3a74a7db234062f` | `eadecd812838f8cf41a92cf10c5e9bcb4e528684f5b8d8cee3a74a7db234062f` | identical |
| `weekly-768x1024.png` | `e837155511ad359e4c4fe0cade047a159bc27b62ca5d8011978f3a7ec2c2ee4d` | `e837155511ad359e4c4fe0cade047a159bc27b62ca5d8011978f3a7ec2c2ee4d` | identical |
| `weekly-769x1024.png` | `83aad1b57561946083727edc875c671dafc9733879e1ddca08ff3797b9da43ab` | `83aad1b57561946083727edc875c671dafc9733879e1ddca08ff3797b9da43ab` | identical |
| `daily-375x812.png` | `c8c20b49dfb76f733997c49e20934c7cfbc94ddda1f942444189b3ebd45419f3` | `c8c20b49dfb76f733997c49e20934c7cfbc94ddda1f942444189b3ebd45419f3` | identical |
| `daily-768x1024.png` | `d7bf55eabdcc66cc2fcc9f5b0332f4737107034a8997b237860a42d4ebfad083` | `d7bf55eabdcc66cc2fcc9f5b0332f4737107034a8997b237860a42d4ebfad083` | identical |
| `daily-769x1024.png` | `66b426d67928471f46a09ccd17d82377fe8b4f1af99d48647e6155d8e7b165d9` | `66b426d67928471f46a09ccd17d82377fe8b4f1af99d48647e6155d8e7b165d9` | identical |
| `schedule-375x812.png` | `63ba898d97de8be83391f5245172eb591739f48fe5fcaa5e9915b7f5a5acd751` | `3779df1fb9b215840b53b591fc355f6d6a66fab32aacaeefaca3d4d49fad1eb6` | **rebaselined** |
| `schedule-768x1024.png` | `68567523dc9f58286fbd0f8a018a272471980f1716016b2daf0e12007da62459` | `66f6ecef6c23447879806c089169b2136f607c2c931f54042d691fa519133b6e` | **rebaselined** |
| `schedule-769x1024.png` | `5f1a160bf98948905b3fb3fb11d81cdf713a5499b8da5678e90cdd215bb14a6e` | `c955780b4d3bf28897584565e767da600a15494870b6255d5e842a12c85b533d` | **rebaselined** |

## Mobile Schedule parity — empty unchanged, populated rebaselined

The tracked visual harness captures `empty-window.png` only at
`scenarioViewports` (1280x800, 1440x900), so there is no 375x812 empty capture
in the repo. The dedicated pair from #301 was recreated as a throwaway spec —
same determinism recipe as the preservation spec, run on both sides, **not
committed**.

| Capture | baseline SHA-256 | current SHA-256 | |
| --- | --- | --- | --- |
| `mobile-schedule-empty.png` | `c89ee6e6d733970cbcd05911f6d8f80e4b6850011de021e7fd1d97a6f8312973` | `c89ee6e6d733970cbcd05911f6d8f80e4b6850011de021e7fd1d97a6f8312973` | identical |
| `mobile-schedule-populated.png` | `2cdadcd9f7334202c1bc9ecdebda90d8c25050d264d069d12760cf6833c84d66` | `382f138bf1159cd69554289d46ed6e8264d8191c2cb23de031e87dcd4ec48f2d` | **rebaselined** |

The empty capture staying byte-identical is the point: with no events there are
no rows, so there is no border to change. Measured, not assumed.

## The 1024px gate holds — proven, not asserted

`e2e/large-screen-calendar-visual.spec.ts` photographs Schedule across eight
viewports. Run on both sides, the split lands exactly on the breakpoint:

| Capture | Result |
| --- | --- |
| `schedule/375x812/populated.png` | **changed** (base `23a54c44…` → `d1bd409d…`) |
| `schedule/768x1024/populated.png` | **changed** (base `412aceae…` → `93030b75…`) |
| `schedule/769x1024/populated.png` | **changed** (base `d324dd6e…` → `22e00398…`) |
| `schedule/1024x768/populated.png` | identical `d4dbb3d4758f5a3938e62f2ef6e43f54a36019a92b59e85c4a0763e559f1594f` |
| `schedule/1280x800/populated.png` | identical `7aa03f6b4f213b53467ed78fd1342063f9123552e23a06ad15830d75c9ed4406` |
| `schedule/1440x900/populated.png` | identical |
| `schedule/1920x1080/populated.png` | identical |
| `schedule/2560x1440/populated.png` | identical |
| `schedule/1440x900/sticky-gutter.png` | identical |
| `schedule/1440x900/past-after-previous.png` | identical |
| `schedule/1920x1080/full-width-rows.png` | identical |
| `schedule/2560x1440/full-width-rows.png` | identical |
| `schedule/1280x800/empty-window.png` | identical |
| `schedule/1440x900/empty-window.png` | identical |
| `schedule/width-proof.json` | identical |

Every capture below 1024px moved; every capture at 1024px and above did not.
That is the `useIsLargeScreen()` gate demonstrated at the pixel level, and it
also confirms the `lg+` branch was not touched.

## Verification

| Command | Result |
| --- | --- |
| `npx biome check src e2e scripts ./*.ts ./*.js ./*.json` | 488 files, 0 errors — 1 pre-existing `useOptionalChain` warning, 2 pre-existing `biome.json` schema infos |
| `npm test -- --run` | **174 test files, 1735 tests, all passed** |
| `npm run build` | exit 0 |
| `./scripts/run-calendar-e2e.sh npx playwright test e2e/mobile-calendar.spec.ts e2e/large-screen-calendar-schedule.spec.ts --workers=1` | **30 passed, 26 skipped, 0 failed** |

Lint is run scoped rather than as `npm run lint` (`biome check .`) because a
stale local git worktree under `.claude/worktrees/` carries its own
`biome.json` and Biome aborts on the nested root config. Local environment
state only — CI's checkout has no such directory. The scoped run covers every
file `biome check .` would.

### Tests

Component tests extend the existing `describe("compact")` block — no third
parallel describe block.

| Test | Pins |
| --- | --- |
| *colours the left border with the member's colour* | resolved `getComputedStyle(row).borderLeftColor === "rgb(185, 84, 67)"`, plus `toHaveClass(colorMap[…].light)` so restoring the border cannot cost the background |
| *leaves a member-less row on the default border colour* | `border-muted-foreground bg-muted` still applied and **no** inline `borderLeftColor` — the branch that was already correct stays correct |

**The `border-left-width: 4px` half of the guard cannot live in Vitest.** jsdom
loads no Tailwind stylesheet, so `border-l-4` never resolves there:
`getComputedStyle(row).borderLeftWidth` returns the UA default **`2px`** for a
`<button>` whether or not the class is present, so asserting on it would prove
nothing. It is enforced instead in `e2e/mobile-calendar.spec.ts` against real
CSS, mirroring exactly what the `lg+` branch does in
`e2e/large-screen-calendar-schedule.spec.ts` — resolved colour compared against
a live `borderLeftColor` round-trip of the hex, plus `width === "4px"`. That
test is CI-enforced, unlike the opt-in capture harnesses.

Its fixture ordering is load-bearing and commented in place: the event must
exist *before* the app's first authenticated calendar load. Seeding it
afterwards and reloading does not work — successful queries persist to IndexedDB
via `PersistQueryClientProvider`, `clearStorage` clears only
local/sessionStorage, and the restored empty result is seconds old against a
5-minute `staleTime`, so TanStack treats it as fresh and never refetches. The
first draft of this test failed that way, on "No upcoming events" rather than on
the border.
