### PR TITLE
feat(mobile): wayfinding and microcopy polish

### DIFF
--- a/e2e/large-screen-home.spec.ts
+++ b/e2e/large-screen-home.spec.ts
@@ -264,8 +264,8 @@ test.describe("Large-screen Home", () => {
 
     const home = page.getByTestId("large-home-dashboard");
     await expect(home).toBeVisible();
-    // No events anywhere today: hero reads "All clear today".
-    await expect(home.getByText("All clear today")).toBeVisible();
+    // No events anywhere today. Same wording as the mobile hero by design.
+    await expect(home.getByText("Nothing on the calendar today")).toBeVisible();
     await expect(home.getByText(/dinner not planned/i)).toBeVisible();
     await expect(home.getByText(/chores done/i)).toBeVisible();
     await expect(home.getByText(/lists quiet/i)).toBeVisible();
@@ -274,7 +274,7 @@ test.describe("Large-screen Home", () => {
     await context.setOffline(true);
     await page.evaluate(() => window.dispatchEvent(new Event("offline")));
     await expect(home).toBeVisible();
-    await expect(home.getByText("All clear today")).toBeVisible();
+    await expect(home.getByText("Nothing on the calendar today")).toBeVisible();
     await context.setOffline(false);
   });
 

--- a/e2e/meals-today.spec.ts
+++ b/e2e/meals-today.spec.ts
@@ -1,0 +1,67 @@
+import { expect, type Page, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  safeClick,
+  waitForHydration,
+  waitForSheetSettled,
+} from "./helpers/test-helpers";
+
+/**
+ * Navigate to the weekly Meals board via the bottom-nav "More" sheet — Meals is
+ * not a top-level tab on mobile (mobile-meals.spec.ts:18-28).
+ */
+async function openMealsBoard(page: Page) {
+  const nav = page.getByRole("navigation", { name: /primary/i });
+  await safeClick(nav.getByRole("button", { name: "More" }));
+  const moreSheet = page.getByRole("dialog", { name: "More" });
+  await waitForSheetSettled(moreSheet);
+  await safeClick(moreSheet.getByRole("button", { name: "Meals" }));
+  await expect(moreSheet).toBeHidden();
+  await expect(
+    page.getByRole("heading", { name: "Meals", level: 1, exact: true }),
+  ).toBeVisible();
+}
+
+test.describe("mobile meals lands on today", () => {
+  test.beforeEach(async ({ page, request, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+
+    const reg = await registerFamily(request, {
+      familyName: "Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+
+    await page.reload();
+    await waitForHydration(page);
+  });
+
+  test("opens with today's card in view and the week still starting Sunday", async ({
+    page,
+  }) => {
+    await openMealsBoard(page);
+
+    const dayCards = page.locator('section[aria-labelledby^="meal-day-"]');
+    // Gate on the loaded stack before asserting geometry — an absent card would
+    // otherwise make the viewport check vacuous.
+    await expect(dayCards.first()).toBeVisible();
+    await expect(dayCards).toHaveCount(7);
+
+    const todayCard = page.locator('[aria-current="date"]').first();
+    await expect(todayCard).toBeVisible();
+    await expect(todayCard).toBeInViewport();
+
+    // It is genuinely today's card, not just any marked card.
+    const todayWeekday = new Date().toLocaleDateString("en-US", {
+      weekday: "long",
+    });
+    await expect(todayCard).toContainText(todayWeekday);
+
+    // The visible week must still begin on Sunday — the cross-stack BE contract.
+    await expect(dayCards.first()).toContainText("Sunday");
+  });
+});

--- a/e2e/mobile-calendar-navigation.spec.ts
+++ b/e2e/mobile-calendar-navigation.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "@playwright/test";
+import { registerFamily, seedBrowserAuth } from "./helpers/api-helpers";
+import {
+  clearStorage,
+  switchCalendarView,
+  waitForCalendarReady,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+// Schedule has no swipe at all (calendar-module.tsx:546), so prev/next is the
+// only navigation affordance for the mobile smart-default view.
+test.describe("mobile calendar period navigation", () => {
+  test.beforeEach(async ({ page, request, isMobile }) => {
+    test.skip(!isMobile, "Mobile-only tests");
+
+    await page.goto("/");
+    await clearStorage(page);
+
+    const reg = await registerFamily(request, {
+      familyName: "Test Family",
+      members: [{ name: "Alice", color: "coral" }],
+    });
+    await seedBrowserAuth(page, reg);
+
+    await page.reload();
+    await waitForHydration(page);
+    await waitForCalendarReady(page);
+  });
+
+  for (const view of ["daily", "weekly", "monthly", "schedule"] as const) {
+    test(`prev/next change the context label in ${view}`, async ({ page }) => {
+      await switchCalendarView(page, view);
+
+      const label = page.locator(
+        '[data-testid="app-header-context"][data-module="calendar"]',
+      );
+      const before = (await label.textContent())?.trim() ?? "";
+
+      await page.getByRole("button", { name: "Next" }).click();
+      await expect(label).not.toHaveText(before);
+
+      await page.getByRole("button", { name: "Previous" }).click();
+      await expect(label).toHaveText(before);
+    });
+  }
+});

--- a/e2e/mobile-chores.spec.ts
+++ b/e2e/mobile-chores.spec.ts
@@ -42,11 +42,14 @@ test.describe("Mobile Chores", () => {
     await expect(dialog).toBeHidden();
 
     await page.getByRole("button", { name: "Week" }).click();
-    await expect(page.getByRole("region", { name: "This Week" })).toBeVisible();
+    const weekRegion = page.getByRole("region", { name: "This Week" });
+    await expect(weekRegion).toBeVisible();
     await expect(page.getByRole("heading", { name: "This Week" })).toHaveCount(
       0,
     );
-    await expect(page.getByText("1 left of 1")).toBeVisible();
+    // The column's own summary is a direct child <p>; the assignee group inside
+    // now states progress the same way, so an unscoped match is ambiguous.
+    await expect(weekRegion.locator("> p")).toHaveText("0 of 1 done");
 
     const row = page
       .locator('[data-testid^="chore-row-"]')

--- a/src/components/calendar/calendar-module.test.tsx
+++ b/src/components/calendar/calendar-module.test.tsx
@@ -713,7 +713,10 @@ describe("CalendarModule", () => {
 
     it("renders date navigation in the toolbar for the schedule view", async () => {
       seedMockEvents([]);
-      seedCalendarStore({ calendarView: "schedule" });
+      seedCalendarStore({
+        calendarView: "schedule",
+        currentDate: new Date(2026, 5, 1),
+      });
 
       renderWithUser(<CalendarModule />);
 
@@ -725,7 +728,8 @@ describe("CalendarModule", () => {
         screen.getByRole("button", { name: /previous/i }),
       ).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
-      expect(screen.getByText("Upcoming")).toBeInTheDocument();
+      // Schedule's label reflects its visible 14-day window, so paging it is visible.
+      expect(screen.getByText("Jun 1 – 14")).toBeInTheDocument();
     });
   });
 

--- a/src/components/calendar/components/mobile-toolbar.test.tsx
+++ b/src/components/calendar/components/mobile-toolbar.test.tsx
@@ -66,3 +66,46 @@ describe("MobileToolbar period navigation", () => {
     expect(useCalendarStore.getState().currentDate.getDate()).toBe(2);
   });
 });
+
+// Prev/next costs the row a fixed 90px, which pushed the member dots past the
+// right edge of an overflow-hidden ancestor (unreachable, not scrollable): 25px
+// lost at 375px with three members, 113px with five. jsdom resolves no Tailwind,
+// so geometry is unassertable here — pin the classes that make the group elastic
+// instead, the same way chore-row.test.tsx pins its lg: touch sizing.
+describe("MobileToolbar narrow-viewport layout", () => {
+  const family = [
+    { id: "m1", name: "Alice", color: "coral" as const },
+    { id: "m2", name: "Bob", color: "teal" as const },
+    { id: "m3", name: "Cass", color: "green" as const },
+    { id: "m4", name: "Dev", color: "purple" as const },
+  ];
+
+  it("lets the member dots scroll instead of clipping them", () => {
+    render(<MobileToolbar members={family} />);
+    const group = screen.getByRole("button", { name: "Alice filter" })
+      .parentElement as HTMLElement;
+
+    expect(group.className).toContain("overflow-x-auto");
+    expect(group.className).toContain("min-w-0");
+  });
+
+  it("keeps the switcher and prev/next from being squeezed instead", () => {
+    render(<MobileToolbar members={family} />);
+    const switcher = screen.getByRole("button", { name: /daily/i })
+      .parentElement as HTMLElement;
+    const nav = screen.getByRole("button", { name: "Previous" })
+      .parentElement as HTMLElement;
+
+    expect(switcher.className).toContain("shrink-0");
+    expect(nav.className).toContain("shrink-0");
+  });
+
+  it("keeps every member dot at its full touch size while scrolling", () => {
+    render(<MobileToolbar members={family} />);
+    for (const member of family) {
+      expect(
+        screen.getByRole("button", { name: `${member.name} filter` }).className,
+      ).toContain("shrink-0");
+    }
+  });
+});

--- a/src/components/calendar/components/mobile-toolbar.test.tsx
+++ b/src/components/calendar/components/mobile-toolbar.test.tsx
@@ -1,3 +1,5 @@
+import { userEvent } from "@testing-library/user-event";
+import { useCalendarStore } from "@/stores";
 import { render, screen } from "@/test/test-utils";
 import { MobileToolbar } from "./mobile-toolbar";
 
@@ -35,5 +37,32 @@ describe("MobileToolbar", () => {
     expect(
       screen.queryByRole("button", { name: /menu/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("MobileToolbar period navigation", () => {
+  const members = [{ id: "m1", name: "Alice", color: "coral" as const }];
+
+  it("renders previous and next controls", () => {
+    render(<MobileToolbar members={members} />);
+    expect(
+      screen.getByRole("button", { name: "Previous" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument();
+  });
+
+  it("does not render a second Today control (AppHeader owns it)", () => {
+    render(<MobileToolbar members={members} />);
+    expect(screen.queryByRole("button", { name: /today/i })).toBeNull();
+  });
+
+  it("moves the store date forward when Next is pressed", async () => {
+    useCalendarStore.setState({
+      calendarView: "daily",
+      currentDate: new Date(2026, 5, 1),
+    });
+    render(<MobileToolbar members={members} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next" }));
+    expect(useCalendarStore.getState().currentDate.getDate()).toBe(2);
   });
 });

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -48,7 +48,7 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
     // no taller than the old two-row toolbar.
     <div className="flex items-center justify-between gap-3 border-b border-border bg-background px-4 py-1">
       {/* View Switcher */}
-      <div className="flex items-center gap-0.5 rounded-xl bg-muted p-1">
+      <div className="flex shrink-0 items-center gap-0.5 rounded-xl bg-muted p-1">
         {VIEW_PILLS.map(({ view, label, ariaLabel }) => (
           <button
             key={view}
@@ -69,7 +69,7 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
 
       {/* Period navigation — Today deliberately lives in the shared AppHeader
           (app-header.tsx:74-87), so this row owns prev/next only. */}
-      <div className="flex items-center gap-0.5">
+      <div className="flex shrink-0 items-center gap-0.5">
         <button
           type="button"
           aria-label="Previous"
@@ -88,8 +88,13 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
         </button>
       </div>
 
-      {/* Member Filter Dots */}
-      <div className="flex items-center gap-1">
+      {/* Member Filter Dots — the only elastic group in the row. The switcher and
+          prev/next are fixed-width essentials, and the row's ancestor is
+          overflow-hidden (calendar-module.tsx), so without min-w-0 + a scroller
+          here the last members' dots are clipped and unreachable: at 375px a
+          three-member family loses 25px, a five-member one 113px. Same
+          scroll-don't-clip pattern as MemberChipRow on Home. */}
+      <div className="flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-hide">
         {members.map((member) => {
           const isIncluded = filter.selectedMembers.includes(member.id);
           return (
@@ -98,7 +103,7 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
               type="button"
               onClick={() => toggleMember(member.id)}
               aria-label={`${member.name} filter`}
-              className="rounded-full p-2 transition-colors hover:bg-muted"
+              className="shrink-0 rounded-full p-2 transition-colors hover:bg-muted"
             >
               <MemberAvatar
                 name={member.name}

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect } from "react";
 import type { FamilyMember } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -23,6 +24,8 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
   const initializeSelectedMembers = useCalendarStore(
     (s) => s.initializeSelectedMembers,
   );
+  const goToPrevious = useCalendarStore((s) => s.goToPrevious);
+  const goToNext = useCalendarStore((s) => s.goToNext);
 
   // Initialize selected members on first load or when persisted filter is stale
   useEffect(() => {
@@ -62,6 +65,27 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
             {label}
           </button>
         ))}
+      </div>
+
+      {/* Period navigation — Today deliberately lives in the shared AppHeader
+          (app-header.tsx:74-87), so this row owns prev/next only. */}
+      <div className="flex items-center gap-0.5">
+        <button
+          type="button"
+          aria-label="Previous"
+          onClick={goToPrevious}
+          className="flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </button>
+        <button
+          type="button"
+          aria-label="Next"
+          onClick={goToNext}
+          className="flex h-11 w-11 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronRight className="h-5 w-5" />
+        </button>
       </div>
 
       {/* Member Filter Dots */}

--- a/src/components/calendar/utils/context-label.test.ts
+++ b/src/components/calendar/utils/context-label.test.ts
@@ -1,0 +1,21 @@
+import { getContextLabel } from "./context-label";
+
+describe("getContextLabel — schedule", () => {
+  it("labels the visible 14-day window rather than a constant", () => {
+    expect(getContextLabel("schedule", new Date(2026, 5, 1))).toBe(
+      "Jun 1 – 14",
+    );
+  });
+
+  it("spans a month boundary with both month names", () => {
+    expect(getContextLabel("schedule", new Date(2026, 5, 25))).toBe(
+      "Jun 25 – Jul 8",
+    );
+  });
+
+  it("changes when the date pages forward by a week", () => {
+    const first = getContextLabel("schedule", new Date(2026, 5, 1));
+    const next = getContextLabel("schedule", new Date(2026, 5, 8));
+    expect(next).not.toBe(first);
+  });
+});

--- a/src/components/calendar/utils/context-label.ts
+++ b/src/components/calendar/utils/context-label.ts
@@ -3,7 +3,7 @@ import type { CalendarViewType } from "@/lib/types";
 
 /**
  * Human-readable label describing the calendar's current view + date context
- * (e.g. "June 2026", "Jun 1 – 7", "Mon, Jun 1", "Upcoming"). Shared by the
+ * (e.g. "June 2026", "Jun 1 – 7", "Mon, Jun 1", "Jun 1 – 14"). Shared by the
  * module-aware app header and the calendar mobile toolbar so both render one
  * consistent label.
  */
@@ -24,8 +24,16 @@ export function getContextLabel(
     }
     case "daily":
       return format(currentDate, "EEE, MMM d");
-    case "schedule":
-      return "Upcoming";
+    case "schedule": {
+      // Schedule renders a 14-day window starting at currentDate (offsets 0-13,
+      // schedule-calendar.tsx:73-75).
+      const windowEnd = new Date(currentDate);
+      windowEnd.setDate(currentDate.getDate() + 13);
+      const sameMonth = currentDate.getMonth() === windowEnd.getMonth();
+      return sameMonth
+        ? `${format(currentDate, "MMM d")} – ${format(windowEnd, "d")}`
+        : `${format(currentDate, "MMM d")} – ${format(windowEnd, "MMM d")}`;
+    }
     default:
       return format(currentDate, "MMMM yyyy");
   }

--- a/src/components/chores/chore-assignee-group.tsx
+++ b/src/components/chores/chore-assignee-group.tsx
@@ -49,8 +49,7 @@ export function ChoreAssigneeGroup({
               {group.member.name}
             </h3>
             <p className="text-xs font-medium text-muted-foreground">
-              {group.summary.completed} of{" "}
-              {group.summary.completed + group.summary.remaining} done
+              {group.summary.completed} of {group.summary.total} done
             </p>
           </div>
         </div>

--- a/src/components/chores/chore-assignee-group.tsx
+++ b/src/components/chores/chore-assignee-group.tsx
@@ -45,7 +45,8 @@ export function ChoreAssigneeGroup({
               {group.member.name}
             </h3>
             <p className="text-xs font-medium text-muted-foreground">
-              {group.summary.remaining} left, {group.summary.completed} done
+              {group.summary.completed} of{" "}
+              {group.summary.completed + group.summary.remaining} done
             </p>
           </div>
         </div>

--- a/src/components/chores/chore-assignee-group.tsx
+++ b/src/components/chores/chore-assignee-group.tsx
@@ -1,6 +1,7 @@
 import type {
   ChoreAssigneeGroup as ChoreAssigneeGroupData,
   ChoreBoardItem,
+  ChoreScope,
 } from "@/lib/types";
 import { colorMap } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -8,6 +9,8 @@ import { ChoreRow } from "./chore-row";
 
 interface ChoreAssigneeGroupProps {
   group: ChoreAssigneeGroupData;
+  /** Forwarded to each row so a cadence the scope already implies is suppressed. */
+  activeScope?: ChoreScope;
   onArchive?: (chore: ChoreBoardItem) => void;
   onComplete?: (chore: ChoreBoardItem) => void;
   onUncomplete?: (chore: ChoreBoardItem) => void;
@@ -15,6 +18,7 @@ interface ChoreAssigneeGroupProps {
 
 export function ChoreAssigneeGroup({
   group,
+  activeScope,
   onArchive,
   onComplete,
   onUncomplete,
@@ -70,6 +74,7 @@ export function ChoreAssigneeGroup({
           <ChoreRow
             key={chore.templateId}
             chore={chore}
+            activeScope={activeScope}
             onArchive={() => onArchive?.(chore)}
             onComplete={() => onComplete?.(chore)}
             onUncomplete={() => onUncomplete?.(chore)}

--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -59,3 +59,28 @@ it("grows the checkoff control to at least 44px at lg+", () => {
   expect(checkoff.className).toContain("lg:h-11");
   expect(checkoff.className).toContain("lg:w-11");
 });
+
+describe("ChoreRow cadence label", () => {
+  it("hides the cadence label when the active scope already implies it", () => {
+    render(
+      <ChoreRow chore={baseChore} activeScope="TODAY" onComplete={() => {}} />,
+    );
+    expect(screen.queryByText("Daily")).toBeNull();
+  });
+
+  it("shows the cadence label when the scope does not imply it", () => {
+    render(
+      <ChoreRow
+        chore={baseChore}
+        activeScope="THIS_WEEK"
+        onComplete={() => {}}
+      />,
+    );
+    expect(screen.getByText("Daily")).toBeInTheDocument();
+  });
+
+  it("shows the cadence label when no scope is supplied", () => {
+    render(<ChoreRow chore={baseChore} onComplete={() => {}} />);
+    expect(screen.getByText("Daily")).toBeInTheDocument();
+  });
+});

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -1,11 +1,14 @@
 import { Archive, Check, Circle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { haptics } from "@/lib/haptics";
-import type { ChoreBoardItem } from "@/lib/types";
+import type { ChoreBoardItem, ChoreCadence, ChoreScope } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 interface ChoreRowProps {
   chore: ChoreBoardItem;
+  /** Active scope tab. When it already implies the chore's cadence the label is
+   * redundant (e.g. "Daily" inside the Today column) and is suppressed. */
+  activeScope?: ChoreScope;
   onArchive?: () => void;
   onComplete?: () => void;
   onUncomplete?: () => void;
@@ -17,12 +20,21 @@ function cadenceLabel(cadence: ChoreBoardItem["cadence"]): string {
   return "Monthly";
 }
 
+const IMPLIED_BY: Record<ChoreCadence, ChoreScope> = {
+  DAILY: "TODAY",
+  WEEKLY: "THIS_WEEK",
+  MONTHLY: "THIS_MONTH",
+};
+
 export function ChoreRow({
   chore,
+  activeScope,
   onArchive,
   onComplete,
   onUncomplete,
 }: ChoreRowProps) {
+  const showCadence = IMPLIED_BY[chore.cadence] !== activeScope;
+
   return (
     <div
       data-testid={`chore-row-${chore.templateId}`}
@@ -78,9 +90,11 @@ export function ChoreRow({
         >
           {chore.title}
         </p>
-        <p className="mt-1 text-xs font-medium text-muted-foreground">
-          {cadenceLabel(chore.cadence)}
-        </p>
+        {showCadence && (
+          <p className="mt-1 text-xs font-medium text-muted-foreground">
+            {cadenceLabel(chore.cadence)}
+          </p>
+        )}
       </div>
 
       <Button

--- a/src/components/chores/chores-scope-column.test.tsx
+++ b/src/components/chores/chores-scope-column.test.tsx
@@ -23,7 +23,7 @@ describe("ChoreScopeColumn", () => {
 
     expect(screen.queryByRole("heading", { name: "Today" })).toBeNull();
     expect(screen.getByRole("region", { name: "Today" })).toBeInTheDocument();
-    expect(screen.getByText(/1 left of 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 of 2 done/i)).toBeInTheDocument();
   });
 });
 

--- a/src/components/chores/chores-scope-column.tsx
+++ b/src/components/chores/chores-scope-column.tsx
@@ -33,7 +33,7 @@ export function ChoreScopeColumn({
   onUncomplete,
 }: ChoreScopeColumnProps) {
   const heading = scopeHeading(scope.scope);
-  const summary = `${scope.summary.remaining} left of ${scope.summary.total}`;
+  const summary = `${scope.summary.total - scope.summary.remaining} of ${scope.summary.total} done`;
   const isFullyComplete =
     scope.summary.total > 0 && scope.summary.remaining === 0;
 

--- a/src/components/chores/chores-scope-column.tsx
+++ b/src/components/chores/chores-scope-column.tsx
@@ -72,6 +72,7 @@ export function ChoreScopeColumn({
           <ChoreAssigneeGroup
             key={group.member.id}
             group={group}
+            activeScope={scope.scope}
             onArchive={(chore) => onArchive?.(scope, chore)}
             onComplete={(chore) => onComplete?.(scope, chore)}
             onUncomplete={(chore) => onUncomplete?.(scope, chore)}

--- a/src/components/chores/chores-scope-column.tsx
+++ b/src/components/chores/chores-scope-column.tsx
@@ -33,7 +33,9 @@ export function ChoreScopeColumn({
   onUncomplete,
 }: ChoreScopeColumnProps) {
   const heading = scopeHeading(scope.scope);
-  const summary = `${scope.summary.total - scope.summary.remaining} of ${scope.summary.total} done`;
+  // Both counts come straight from the API summary rather than being derived from
+  // `total - remaining`, so this can never disagree with the assignee groups below.
+  const summary = `${scope.summary.completed} of ${scope.summary.total} done`;
   const isFullyComplete =
     scope.summary.total > 0 && scope.summary.remaining === 0;
 

--- a/src/components/home/components/activity-feed.test.tsx
+++ b/src/components/home/components/activity-feed.test.tsx
@@ -117,3 +117,47 @@ describe("ActivityFeed", () => {
     expect(onSelect).toHaveBeenCalledWith(feed.groups[1].rows[0]);
   });
 });
+
+describe("ActivityFeed first run", () => {
+  const EMPTY: Feed = { groups: [], dividerAfter: -1, overflow: 0 };
+
+  it("does not claim a previous visit on first run with no activity", () => {
+    render(<ActivityFeed feed={EMPTY} onSelectRow={() => {}} isFirstRun />);
+    expect(screen.queryByText(/since you last opened/i)).toBeNull();
+  });
+
+  it("does not claim a previous visit on first run WITH activity", () => {
+    const firstRunFeed: Feed = {
+      groups: [
+        {
+          id: "lists:1",
+          module: "lists",
+          summary: "Groceries · +1 item",
+          rows: [
+            {
+              storeKey: "r1",
+              kind: "added",
+              label: "Milk",
+              module: "lists",
+            },
+          ],
+          rowsOverflow: 0,
+          newest: Date.now(),
+        },
+      ],
+      dividerAfter: -1,
+      overflow: 0,
+    };
+    render(
+      <ActivityFeed feed={firstRunFeed} onSelectRow={() => {}} isFirstRun />,
+    );
+    expect(screen.queryByText(/since you last opened/i)).toBeNull();
+  });
+
+  it("still says 'since you last opened' on a return visit", () => {
+    render(
+      <ActivityFeed feed={EMPTY} onSelectRow={() => {}} isFirstRun={false} />,
+    );
+    expect(screen.getByText(/since you last opened/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/home/components/activity-feed.tsx
+++ b/src/components/home/components/activity-feed.tsx
@@ -13,8 +13,8 @@ interface ActivityFeedProps {
   memberColorOf?: MemberColorOf;
   /** Bumped on each meaningful open; remounts groups so expansion is ephemeral (§5). */
   meaningfulOpenId?: number;
-  /** True only on a genuine first open — derived from getLastSeen(), never from
-   * a null persisted state, which also means "IndexedDB unavailable". */
+  /** No previous open on record — derived from getLastSeen() (see use-activity-feed
+   * for why an unwritable localStorage intentionally reads as first-run too). */
   isFirstRun?: boolean;
 }
 

--- a/src/components/home/components/activity-feed.tsx
+++ b/src/components/home/components/activity-feed.tsx
@@ -13,6 +13,9 @@ interface ActivityFeedProps {
   memberColorOf?: MemberColorOf;
   /** Bumped on each meaningful open; remounts groups so expansion is ephemeral (§5). */
   meaningfulOpenId?: number;
+  /** True only on a genuine first open — derived from getLastSeen(), never from
+   * a null persisted state, which also means "IndexedDB unavailable". */
+  isFirstRun?: boolean;
 }
 
 // Shared field styling. min-h-11 = 44px touch target (spec §9). Easing/durations
@@ -24,15 +27,20 @@ export function ActivityFeed({
   onSelectRow,
   memberColorOf,
   meaningfulOpenId = 0,
+  isFirstRun = false,
 }: ActivityFeedProps) {
+  // "What's new" rather than "Recent changes": the <section> already carries that
+  // aria-label, and reusing the string would duplicate the accessible name.
+  const heading = isFirstRun ? "What's new" : "Since you last opened";
+
   if (feed.groups.length === 0) {
     return (
       <section className="px-4 pt-6" aria-label="Recent changes">
-        <h2 className="text-sm font-medium text-muted-foreground">
-          Since you last opened
-        </h2>
+        <h2 className="text-sm font-medium text-muted-foreground">{heading}</h2>
         <p className="pt-2 text-sm text-muted-foreground">
-          You're all caught up.
+          {isFirstRun
+            ? "Changes your family makes will show up here."
+            : "You're all caught up."}
         </p>
       </section>
     );
@@ -40,9 +48,7 @@ export function ActivityFeed({
 
   return (
     <section className="px-4 pt-6" aria-label="Recent changes">
-      <h2 className="text-sm font-medium text-muted-foreground">
-        Since you last opened
-      </h2>
+      <h2 className="text-sm font-medium text-muted-foreground">{heading}</h2>
       <ul className="pt-2">
         {feed.groups.map((group, index) => (
           <li key={group.id}>

--- a/src/components/home/components/large-now-hero.test.tsx
+++ b/src/components/home/components/large-now-hero.test.tsx
@@ -78,3 +78,24 @@ describe("LargeNowHero", () => {
     expect(onOpenEvent).toHaveBeenCalledWith(event);
   });
 });
+
+// The two heroes render the same HeroState on different surfaces, so a family
+// that moves between phone and tablet must not be told two different things
+// about the same cleared day. Rendering both and comparing keeps that honest —
+// a comment claiming the wording matches cannot.
+describe("LargeNowHero cleared-day titles match the mobile hero", () => {
+  it.each([
+    ["REST_OF_DAY_CLEAR", "All clear for the rest of today"],
+    ["ALL_CLEAR_TODAY", "Nothing on the calendar today"],
+  ] as const)("renders %s as the same title HeroCard uses", (kind, title) => {
+    render(
+      <LargeNowHero
+        state={{ kind }}
+        now={new Date(2026, 6, 5, 20, 0)}
+        onOpenEvent={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+});

--- a/src/components/home/components/large-now-hero.tsx
+++ b/src/components/home/components/large-now-hero.tsx
@@ -19,7 +19,11 @@ function titleFor(state: HeroState) {
     case "ALL_DAY_ONLY":
       return state.event.title;
     case "REST_OF_DAY_CLEAR":
-      return "Rest of day clear";
+      // Same wording as the mobile hero (hero-card.tsx getTitle) so both surfaces
+      // agree about what a cleared day means. ALL_CLEAR_TODAY stays as-is: it is
+      // only returned when there were no events at all, so no past event can sit
+      // beneath it (hero-state.ts:40-48).
+      return "All clear for the rest of today";
     case "ALL_CLEAR_TODAY":
       return "All clear today";
   }

--- a/src/components/home/components/large-now-hero.tsx
+++ b/src/components/home/components/large-now-hero.tsx
@@ -18,14 +18,15 @@ function titleFor(state: HeroState) {
     case "UP_NEXT":
     case "ALL_DAY_ONLY":
       return state.event.title;
+    // Both cleared-day titles match the mobile hero verbatim (hero-card.tsx
+    // getTitle), so the same day never reads two ways across surfaces. Only the
+    // past-event marking in TodayList is REST_OF_DAY_CLEAR-specific —
+    // ALL_CLEAR_TODAY is returned only when there were no events at all, so no
+    // elapsed event can sit beneath it (hero-state.ts:40-48).
     case "REST_OF_DAY_CLEAR":
-      // Same wording as the mobile hero (hero-card.tsx getTitle) so both surfaces
-      // agree about what a cleared day means. ALL_CLEAR_TODAY stays as-is: it is
-      // only returned when there were no events at all, so no past event can sit
-      // beneath it (hero-state.ts:40-48).
       return "All clear for the rest of today";
     case "ALL_CLEAR_TODAY":
-      return "All clear today";
+      return "Nothing on the calendar today";
   }
 }
 

--- a/src/components/home/components/today-list.test.tsx
+++ b/src/components/home/components/today-list.test.tsx
@@ -105,4 +105,60 @@ describe("TodayList", () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  it("marks events that have already finished", () => {
+    const pastEvent = createEvent({
+      id: "past",
+      title: "Morning run",
+      startTime: "8:00 AM",
+      endTime: "9:00 AM",
+    });
+    const futureEvent = createEvent({
+      id: "future",
+      title: "Dinner",
+      startTime: "6:00 PM",
+      endTime: "7:00 PM",
+    });
+
+    renderWithUser(
+      <TodayList
+        currentDate={new Date(2026, 3, 25, 15, 0)}
+        events={[pastEvent, futureEvent]}
+        members={testMembers}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const past = screen
+      .getByText(pastEvent.title)
+      .closest("[data-past]") as HTMLElement | null;
+    expect(past).toHaveAttribute("data-past", "true");
+
+    // The future event must not be marked.
+    expect(
+      screen.getByText(futureEvent.title).closest("[data-past]"),
+    ).toBeNull();
+  });
+
+  it("conveys finished state to assistive tech, not by opacity alone", () => {
+    renderWithUser(
+      <TodayList
+        currentDate={new Date(2026, 3, 25, 15, 0)}
+        events={[
+          createEvent({
+            id: "past",
+            title: "Morning run",
+            startTime: "8:00 AM",
+            endTime: "9:00 AM",
+          }),
+        ]}
+        members={testMembers}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /morning run.*done/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/home/components/today-list.test.tsx
+++ b/src/components/home/components/today-list.test.tsx
@@ -140,7 +140,7 @@ describe("TodayList", () => {
     ).toBeNull();
   });
 
-  it("conveys finished state to assistive tech, not by opacity alone", () => {
+  it("conveys elapsed state to assistive tech, not by opacity alone", () => {
     renderWithUser(
       <TodayList
         currentDate={new Date(2026, 3, 25, 15, 0)}
@@ -158,7 +158,10 @@ describe("TodayList", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: /morning run.*done/i }),
+      screen.getByRole("button", { name: /morning run.*ended/i }),
     ).toBeInTheDocument();
+    // "done" belongs to completion copy ("2 of 6 done") — an elapsed event was
+    // not completed by anyone, so it must not borrow the word.
+    expect(screen.queryByText(/·\s*done/i)).toBeNull();
   });
 });

--- a/src/components/home/components/today-list.tsx
+++ b/src/components/home/components/today-list.tsx
@@ -97,10 +97,13 @@ export const TodayList = memo(function TodayList({
                     {event.title}
                   </span>
                   {/* Opacity alone conveys nothing to assistive tech or to anyone
-                      who cannot compare rows side by side, so mark it in text. */}
+                      who cannot compare rows side by side, so mark it in text.
+                      "ended", not "done": nobody completed this event, it merely
+                      elapsed, and "done" means completed everywhere else in the
+                      app ("2 of 6 done"). */}
                   {isPast && (
                     <span className="shrink-0 text-[13px] leading-5 text-foreground/55">
-                      · done
+                      · ended
                     </span>
                   )}
                 </div>

--- a/src/components/home/components/today-list.tsx
+++ b/src/components/home/components/today-list.tsx
@@ -61,13 +61,23 @@ export const TodayList = memo(function TodayList({
           const member = getFamilyMember(members, event.memberId);
           const colors = member ? colorMap[member.color] : colorMap.coral;
           const affix = getSpanAffix(event, currentDate);
+          // Under a cleared hero ("All clear for the rest of today") these events
+          // are the ones already behind us, and were previously indistinguishable
+          // from upcoming ones.
+          const isPast =
+            !event.isAllDay &&
+            getEventDateTime(event, "end").getTime() < currentDate.getTime();
 
           return (
             <button
               key={getEventKey(event)}
               type="button"
               onClick={() => onSelect(event)}
-              className="flex min-h-12 w-full items-start gap-3 rounded-xl px-1 py-2.5 text-left transition-transform duration-[150ms] ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98] motion-reduce:transition-none"
+              data-past={isPast ? "true" : undefined}
+              className={cn(
+                "flex min-h-12 w-full items-start gap-3 rounded-xl px-1 py-2.5 text-left transition-transform duration-[150ms] ease-[cubic-bezier(0.32,0.72,0,1)] active:scale-[0.98] motion-reduce:transition-none",
+                isPast && "opacity-60",
+              )}
             >
               <div className="pt-1.5">
                 <span
@@ -86,6 +96,13 @@ export const TodayList = memo(function TodayList({
                   <span className="truncate text-[17px] leading-6 font-semibold text-foreground">
                     {event.title}
                   </span>
+                  {/* Opacity alone conveys nothing to assistive tech or to anyone
+                      who cannot compare rows side by side, so mark it in text. */}
+                  {isPast && (
+                    <span className="shrink-0 text-[13px] leading-5 text-foreground/55">
+                      · done
+                    </span>
+                  )}
                 </div>
 
                 {(affix || event.location) && (

--- a/src/components/home/home-dashboard.test.tsx
+++ b/src/components/home/home-dashboard.test.tsx
@@ -289,8 +289,11 @@ describe("HomeDashboard", () => {
   it("renders the activity feed region on mobile", async () => {
     setViewportWidth(768);
     render(<HomeDashboard nowOverride={new Date(2026, 5, 21, 12)} />);
+    // Assert the region, not its heading: the heading is first-run dependent
+    // ("What's new" until the lastSeen marker is written), and this test is about
+    // the feed rendering at all. First-run copy is covered in activity-feed.test.tsx.
     expect(
-      await screen.findByText(/Since you last opened/i),
+      await screen.findByRole("region", { name: "Recent changes" }),
     ).toBeInTheDocument();
   });
 

--- a/src/components/home/hooks/use-activity-feed.ts
+++ b/src/components/home/hooks/use-activity-feed.ts
@@ -110,9 +110,12 @@ export function useActivityFeed({
   const lists = listsQuery.data?.data ?? EMPTY_LISTS;
 
   const [feed, setFeed] = useState<Feed>(EMPTY_FEED);
-  // getLastSeen() is 0 only when the marker was never written, i.e. a true first
-  // open. It reads localStorage, so it is unaffected by IndexedDB availability —
-  // unlike loadState(), which returns null for both "never opened" and "no store".
+  // 0 means the marker was never written: a true first open, or a browser where
+  // localStorage throws (markers.ts readNum swallows and returns 0 — private mode,
+  // some webviews). We accept that conflation deliberately: when storage is dead
+  // setLastSeen never sticks either, so such a family keeps seeing the first-run
+  // copy, which is the honest failure. The alternative — loadState() returning
+  // null — conflates the same two cases AND is gated on IndexedDB.
   const [isFirstRun] = useState(() => io.getLastSeen() === 0);
   const [meaningfulOpenId, setMeaningfulOpenId] = useState(0); // bump → reset ephemeral expansion
   const coldStartRef = useRef(true);

--- a/src/components/home/hooks/use-activity-feed.ts
+++ b/src/components/home/hooks/use-activity-feed.ts
@@ -110,6 +110,10 @@ export function useActivityFeed({
   const lists = listsQuery.data?.data ?? EMPTY_LISTS;
 
   const [feed, setFeed] = useState<Feed>(EMPTY_FEED);
+  // getLastSeen() is 0 only when the marker was never written, i.e. a true first
+  // open. It reads localStorage, so it is unaffected by IndexedDB availability —
+  // unlike loadState(), which returns null for both "never opened" and "no store".
+  const [isFirstRun] = useState(() => io.getLastSeen() === 0);
   const [meaningfulOpenId, setMeaningfulOpenId] = useState(0); // bump → reset ephemeral expansion
   const coldStartRef = useRef(true);
   // Mutex: every cycle (cold start, data change, return-to-visible) is chained
@@ -306,5 +310,5 @@ export function useActivityFeed({
 
   // `events` is the unfiltered 28-day source the feed is built from; the dashboard
   // narrows it to the openable horizon (selectOpenableEvents) for deep-linking.
-  return { feed, meaningfulOpenId, events };
+  return { feed, meaningfulOpenId, events, isFirstRun };
 }

--- a/src/components/home/mobile-home-dashboard.tsx
+++ b/src/components/home/mobile-home-dashboard.tsx
@@ -96,7 +96,7 @@ function ActivityFeedSection({
   now: Date;
   onOpenEvent: (e: CalendarEvent) => void;
 }) {
-  const { feed, meaningfulOpenId, events } = useActivityFeed({
+  const { feed, meaningfulOpenId, events, isFirstRun } = useActivityFeed({
     nowProvider: () => now.getTime(),
   });
   const memberMap = useFamilyMemberMap();
@@ -125,6 +125,7 @@ function ActivityFeedSection({
       onSelectRow={handleSelect}
       memberColorOf={memberColorOf}
       meaningfulOpenId={meaningfulOpenId}
+      isFirstRun={isFirstRun}
     />
   );
 }

--- a/src/components/lists/build-list-sections.test.ts
+++ b/src/components/lists/build-list-sections.test.ts
@@ -295,4 +295,58 @@ describe("buildListSections", () => {
       "No cat item",
     ]);
   });
+
+  it("omits the Uncategorized title when it is the only section", () => {
+    const sections = buildListSections({
+      list: {
+        ...baseList,
+        items: [
+          {
+            id: "1",
+            text: "Milk",
+            completed: false,
+            completedAt: null,
+            categoryId: null,
+            createdAt: "2026-01-01T00:00:00",
+            updatedAt: "2026-01-01T00:00:00",
+          },
+        ],
+      },
+      showCompleted: true,
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].title).toBeNull();
+  });
+
+  it("keeps the Uncategorized title when other sections exist", () => {
+    const sections = buildListSections({
+      list: {
+        ...baseList,
+        items: [
+          {
+            id: "1",
+            text: "Milk",
+            completed: false,
+            completedAt: null,
+            categoryId: null,
+            createdAt: "2026-01-01T00:00:00",
+            updatedAt: "2026-01-01T00:00:00",
+          },
+          {
+            id: "2",
+            text: "Bread",
+            completed: false,
+            completedAt: null,
+            categoryId: "produce",
+            createdAt: "2026-01-02T00:00:00",
+            updatedAt: "2026-01-02T00:00:00",
+          },
+        ],
+      },
+      showCompleted: true,
+    });
+
+    expect(sections.find((s) => s.title === "Uncategorized")).toBeDefined();
+  });
 });

--- a/src/components/lists/build-list-sections.ts
+++ b/src/components/lists/build-list-sections.ts
@@ -50,7 +50,9 @@ export function buildListSections({
       ? [
           {
             id: "uncategorized",
-            title: "Uncategorized",
+            // A lone "Uncategorized" header labels nothing — there is no other
+            // section to distinguish it from. The call site already skips nulls.
+            title: categorizedSections.length > 0 ? "Uncategorized" : null,
             items: uncategorizedItems,
           },
         ]

--- a/src/components/lists/list-card.test.tsx
+++ b/src/components/lists/list-card.test.tsx
@@ -1,0 +1,30 @@
+import type { ListSummary } from "@/lib/types";
+import { render, screen } from "@/test/test-utils";
+import { ListCard } from "./list-card";
+
+const baseList: ListSummary = {
+  id: "l1",
+  name: "Groceries",
+  kind: "grocery",
+  totalItems: 3,
+  completedItems: 0,
+};
+
+describe("ListCard progress", () => {
+  it("states progress once, not twice", () => {
+    render(<ListCard list={baseList} onOpen={() => {}} />);
+    expect(screen.getByText("0 of 3 done")).toBeInTheDocument();
+    expect(screen.queryByText(/items? left/i)).toBeNull();
+  });
+
+  it("keeps the empty-state copy", () => {
+    render(
+      <ListCard
+        list={{ ...baseList, totalItems: 0, completedItems: 0 }}
+        onOpen={() => {}}
+      />,
+    );
+    expect(screen.getByText("No items yet")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to fill")).toBeNull();
+  });
+});

--- a/src/components/lists/list-card.tsx
+++ b/src/components/lists/list-card.tsx
@@ -12,15 +12,10 @@ export function ListCard({ list, onOpen }: ListCardProps) {
   const pressable = usePressable();
   const meta = kindMeta[list.kind];
   const Icon = meta.icon;
-  const remainingItems = list.totalItems - list.completedItems;
   const progressLabel =
     list.totalItems === 0
       ? "No items yet"
       : `${list.completedItems} of ${list.totalItems} done`;
-  const remainingLabel =
-    list.totalItems === 0
-      ? "Ready to fill"
-      : `${remainingItems} ${remainingItems === 1 ? "item" : "items"} left`;
 
   return (
     <button
@@ -48,12 +43,9 @@ export function ListCard({ list, onOpen }: ListCardProps) {
       <h3 className="mt-4 line-clamp-2 text-[17px] font-semibold leading-6 text-foreground">
         {list.name}
       </h3>
-      <div className="mt-2 space-y-1">
+      <div className="mt-2">
         <p className="text-sm leading-5 text-muted-foreground">
           {progressLabel}
-        </p>
-        <p className="text-xs font-semibold leading-4 text-muted-foreground">
-          {remainingLabel}
         </p>
       </div>
     </button>

--- a/src/components/lists/list-rail-row.test.tsx
+++ b/src/components/lists/list-rail-row.test.tsx
@@ -11,12 +11,12 @@ const list: ListSummary = {
 };
 
 describe("ListRailRow", () => {
-  it("identifies the selected row and its remaining item count", () => {
+  it("identifies the selected row and its progress", () => {
     render(<ListRailRow list={list} selected onSelect={vi.fn()} />);
 
     expect(
       screen.getByRole("button", {
-        name: /groceries, selected, 4 items remaining/i,
+        name: /groceries, selected, 2 of 6 done/i,
       }),
     ).toHaveAttribute("aria-current", "true");
   });
@@ -27,7 +27,7 @@ describe("ListRailRow", () => {
       <ListRailRow list={list} selected={false} onSelect={onSelect} />,
     );
     const row = screen.getByRole("button", {
-      name: /groceries, 4 items remaining/i,
+      name: /groceries, 2 of 6 done/i,
     });
 
     expect(row).not.toHaveAttribute("aria-current");
@@ -39,7 +39,7 @@ describe("ListRailRow", () => {
     render(<ListRailRow list={list} selected={false} onSelect={vi.fn()} />);
 
     expect(
-      screen.getByRole("button", { name: /groceries, 4 items remaining/i }),
+      screen.getByRole("button", { name: /groceries, 2 of 6 done/i }),
     ).toHaveClass("min-h-[44px]");
   });
 });

--- a/src/components/lists/list-rail-row.tsx
+++ b/src/components/lists/list-rail-row.tsx
@@ -13,15 +13,13 @@ export function ListRailRow({ list, selected, onSelect }: ListRailRowProps) {
   const pressable = usePressable();
   const meta = kindMeta[list.kind];
   const Icon = meta.icon;
-  const remaining = list.totalItems - list.completedItems;
-  const remainingLabel =
+  // One phrasing for progress everywhere (list card, rail row, chore columns and
+  // assignee groups) so the same list never reads two different ways.
+  const progressLabel =
     list.totalItems === 0
-      ? "Ready to fill"
-      : `${remaining} ${remaining === 1 ? "item" : "items"} left`;
-  const ariaLabel =
-    list.totalItems === 0
-      ? `${list.name}${selected ? ", selected" : ""}, no items yet`
-      : `${list.name}${selected ? ", selected" : ""}, ${remaining} ${remaining === 1 ? "item" : "items"} remaining`;
+      ? "No items yet"
+      : `${list.completedItems} of ${list.totalItems} done`;
+  const ariaLabel = `${list.name}${selected ? ", selected" : ""}, ${progressLabel.toLowerCase()}`;
 
   return (
     <button
@@ -51,7 +49,7 @@ export function ListRailRow({ list, selected, onSelect }: ListRailRowProps) {
           {list.name}
         </span>
         <span className="block text-xs leading-4 text-muted-foreground">
-          {remainingLabel}
+          {progressLabel}
         </span>
       </span>
     </button>

--- a/src/components/lists/lists-rail.test.tsx
+++ b/src/components/lists/lists-rail.test.tsx
@@ -35,7 +35,7 @@ describe("ListsRail", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
-        name: /chores, selected, 2 items remaining/i,
+        name: /chores, selected, 0 of 2 done/i,
       }),
     ).toHaveAttribute("aria-current", "true");
     expect(

--- a/src/components/meals-view.tsx
+++ b/src/components/meals-view.tsx
@@ -133,6 +133,8 @@ export function MealsView() {
   const [selectedSlot, setSelectedSlot] = useState<MealSlotSelection | null>(
     null,
   );
+  const todayCardRef = useRef<HTMLDivElement | null>(null);
+  const didScrollToTodayRef = useRef(false);
   const [editingSlotId, setEditingSlotId] = useState<MealSlotId | null>(null);
   const [placementDraft, setPlacementDraft] =
     useState<MealPlacementDraft | null>(null);
@@ -201,6 +203,20 @@ export function MealsView() {
     onSuccess: () => resetPlanningSession(),
     onError: handlePlanningSaveError,
   });
+
+  // Land on today within the Sunday-anchored week. The week boundary itself is a
+  // cross-stack contract with the Meals/Chores backend and must not move.
+  useEffect(() => {
+    if (didScrollToTodayRef.current) return;
+    if (isLargeScreen) return; // MealGrid already marks today at lg+
+    // The board query is still loading on mount, so no day card exists yet and
+    // the ref is null; this re-runs once displayBoard lands.
+    if (!displayBoard) return;
+    const node = todayCardRef.current;
+    if (!node) return;
+    didScrollToTodayRef.current = true;
+    node.scrollIntoView({ block: "start", behavior: "auto" });
+  }, [isLargeScreen, displayBoard]);
 
   useEffect(() => {
     if (!pendingPlacementDraft) return;
@@ -606,15 +622,23 @@ export function MealsView() {
         {displayBoard && !isLargeScreen ? (
           <div className="space-y-4">
             {displayBoard.days.map((day) => (
-              <MealDayCard
+              <div
                 key={day.date}
-                day={day}
-                readOnly={readOnly}
-                pendingRecipeId={pendingRecipeId}
-                planningDrafts={planningActive ? planningDrafts : []}
-                planningTarget={currentPlanningTarget}
-                onSelectSlot={selectSlot}
-              />
+                ref={
+                  day.date === formatLocalDate(new Date())
+                    ? todayCardRef
+                    : undefined
+                }
+              >
+                <MealDayCard
+                  day={day}
+                  readOnly={readOnly}
+                  pendingRecipeId={pendingRecipeId}
+                  planningDrafts={planningActive ? planningDrafts : []}
+                  planningTarget={currentPlanningTarget}
+                  onSelectSlot={selectSlot}
+                />
+              </div>
             ))}
           </div>
         ) : null}

--- a/src/components/meals/meal-day-card.test.tsx
+++ b/src/components/meals/meal-day-card.test.tsx
@@ -1,0 +1,29 @@
+import { formatLocalDate } from "@/lib/time-utils";
+import { render, screen } from "@/test/test-utils";
+import { MealDayCard } from "./meal-day-card";
+
+const dayWith = (date: string, dayIndex = 0) => ({ date, dayIndex, slots: [] });
+
+describe("MealDayCard today affordance", () => {
+  it("marks today with aria-current", () => {
+    render(
+      <MealDayCard
+        day={dayWith(formatLocalDate(new Date()))}
+        readOnly={false}
+        onSelectSlot={() => {}}
+      />,
+    );
+    expect(screen.getByRole("region")).toHaveAttribute("aria-current", "date");
+  });
+
+  it("does not mark a non-today day", () => {
+    render(
+      <MealDayCard
+        day={dayWith("2020-01-02")}
+        readOnly={false}
+        onSelectSlot={() => {}}
+      />,
+    );
+    expect(screen.getByRole("region")).not.toHaveAttribute("aria-current");
+  });
+});

--- a/src/components/meals/meal-day-card.tsx
+++ b/src/components/meals/meal-day-card.tsx
@@ -1,5 +1,6 @@
-import { parseLocalDate } from "@/lib/time-utils";
+import { formatLocalDate, parseLocalDate } from "@/lib/time-utils";
 import type { MealDay, MealSlot } from "@/lib/types";
+import { cn } from "@/lib/utils";
 import type {
   MealPlanningDraft,
   MealPlanningTarget,
@@ -31,9 +32,19 @@ export function MealDayCard({
   planningTarget = null,
   onSelectSlot,
 }: MealDayCardProps) {
+  const isToday = day.date === formatLocalDate(new Date());
+  const headingId = `meal-day-${day.date}`;
+
   return (
-    <section className="space-y-3 rounded-lg border border-border bg-card/60 p-3">
-      <h2 className="text-base font-semibold text-foreground">
+    <section
+      aria-labelledby={headingId}
+      aria-current={isToday ? "date" : undefined}
+      className={cn(
+        "space-y-3 rounded-lg border p-3",
+        isToday ? "border-primary/40 bg-primary/5" : "border-border bg-card/60",
+      )}
+    >
+      <h2 id={headingId} className="text-base font-semibold text-foreground">
         {formatDayLabel(day.date)}
       </h2>
       <div className="space-y-2">

--- a/src/components/settings/family-settings-modal.test.tsx
+++ b/src/components/settings/family-settings-modal.test.tsx
@@ -115,6 +115,20 @@ describe("FamilySettingsModal — pending member controls", () => {
     expect(screen.getByRole("button", { name: "Edit Bob" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Remove Bob" })).toBeDisabled();
   });
+
+  it("uses plain language instead of 'Danger Zone'", () => {
+    const client = createClient();
+    client.setQueryData<FamilyApiResponse>(familyKeys.family(), {
+      data: baseFamily(),
+    });
+
+    render(<FamilySettingsModal open onOpenChange={noop} />, {
+      queryClient: client,
+    });
+
+    expect(screen.queryByText(/danger zone/i)).toBeNull();
+    expect(screen.getByText(/reset this family/i)).toBeInTheDocument();
+  });
 });
 
 // ============================================================================

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -213,10 +213,11 @@ export function FamilySettingsModal({
             )}
           </section>
 
-          {/* Danger Zone */}
+          {/* Reset — the only action here, so the heading names it rather than
+              using a jargon warning label. The consequence copy sits below. */}
           <section className="space-y-4 pt-4 border-t border-border">
             <h3 className="text-sm font-semibold text-destructive uppercase tracking-wider">
-              Danger Zone
+              Reset this family
             </h3>
             <div className="p-4 rounded-lg border border-destructive/30 bg-destructive/5">
               <div className="flex items-start gap-3">

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -67,7 +67,11 @@ export function AppHeader() {
 
     return (
       <header className="shrink-0 border-b border-border bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/85 flex items-center justify-between gap-3 min-h-16 px-4 py-3">
-        <h1 className="min-w-0 truncate text-[22px] leading-7 font-semibold text-foreground">
+        <h1
+          data-testid="app-header-context"
+          data-module={activeModule ?? "home"}
+          className="min-w-0 truncate text-[22px] leading-7 font-semibold text-foreground"
+        >
           {mobileTitle}
         </h1>
         <div className="flex shrink-0 items-center gap-2">

--- a/src/lib/validations/family.test.ts
+++ b/src/lib/validations/family.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createMemberFormSchema,
+  createMemberProfileSchema,
   familyDataSchema,
   familyMemberSchema,
   familyNameSchema,
@@ -697,6 +698,41 @@ describe("family validations", () => {
       expect(result).not.toBeNull();
       expect(result?.members[0].email).toBeUndefined();
       expect(result?.members[0].avatarUrl).toBeUndefined();
+    });
+  });
+
+  describe("member color validation message", () => {
+    it("gives a human message when no color is selected", () => {
+      const result = createMemberFormSchema([]).safeParse({ name: "Alice" });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.find((i) => i.path[0] === "color")?.message,
+        ).toBe("Please select a color");
+      }
+    });
+
+    it("gives the same message on the profile schema", () => {
+      const result = createMemberProfileSchema([]).safeParse({ name: "Alice" });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.find((i) => i.path[0] === "color")?.message,
+        ).toBe("Please select a color");
+      }
+    });
+
+    it("never leaks Zod's default enum text", () => {
+      const result = createMemberFormSchema([]).safeParse({
+        name: "Alice",
+        color: "chartreuse",
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.find((i) => i.path[0] === "color")?.message,
+        ).not.toMatch(/expected one of/i);
+      }
     });
   });
 });

--- a/src/lib/validations/family.ts
+++ b/src/lib/validations/family.ts
@@ -25,17 +25,15 @@ export const familyNameSchema = z.object({
 export type FamilyNameFormData = z.infer<typeof familyNameSchema>;
 
 /**
- * Valid family colors.
+ * Valid family colors. The message lives here rather than at the call sites: a
+ * missing or invalid color fails this base schema first, so a wrapping
+ * `.refine()` never runs and Zod's raw enum text would reach the UI. Both member
+ * surfaces inherit this message.
  */
-const familyColorSchema = z.enum([
-  "coral",
-  "teal",
-  "green",
-  "purple",
-  "yellow",
-  "pink",
-  "orange",
-]);
+const familyColorSchema = z.enum(
+  ["coral", "teal", "green", "purple", "yellow", "pink", "orange"],
+  { message: "Please select a color" },
+);
 
 /**
  * Schema for family member form validation.
@@ -51,9 +49,7 @@ export const memberFormSchema = z.object({
         .min(1, "Name is required")
         .max(30, "Name must be 30 characters or less"),
     ),
-  color: familyColorSchema.refine((val) => val !== undefined, {
-    message: "Please select a color",
-  }),
+  color: familyColorSchema,
 });
 
 export type MemberFormData = z.infer<typeof memberFormSchema>;
@@ -84,9 +80,7 @@ export const createMemberFormSchema = (
             message: "A member with this name already exists",
           }),
       ),
-    color: familyColorSchema.refine((val) => val !== undefined, {
-      message: "Please select a color",
-    }),
+    color: familyColorSchema,
   });
 };
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -42,6 +42,11 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
 Element.prototype.scrollTo = vi.fn();
 window.scrollTo = vi.fn();
 
+// Mock scrollIntoView (used by the mobile Meals stack to land on today; jsdom
+// lacks it entirely, unlike scrollTo, so calling it unstubbed throws and takes
+// the whole component tree down). The real scroll is proven in Playwright.
+Element.prototype.scrollIntoView = vi.fn();
+
 // Mock pointer capture APIs (used by vaul's drag handling; missing in jsdom)
 Element.prototype.setPointerCapture = vi.fn();
 Element.prototype.releasePointerCapture = vi.fn();


### PR DESCRIPTION
Implements Unit A of the [mobile daily-use polish spec](https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/specs/2026-07-27-mobile-daily-use-polish-design.md) — wayfinding (§1) and microcopy (§2), following the [plan](https://github.com/joe-bor/family-hub/blob/main/docs/superpowers/plans/2026-07-27-mobile-wayfinding-and-microcopy.md) task by task. No control is resized here; touch ergonomics is Unit B (#310).

Closes #309.

## What changed

**Wayfinding**
- Mobile Calendar toolbar gains Previous/Next (44px from the outset so Unit B need not revisit the file). Today is untouched — it stays in `AppHeader`.
- Schedule's context label now reflects its visible 14-day window (`Jun 1 – 14`) instead of the constant `"Upcoming"`, so paging the swipe-less default view is visible.
- Mobile Meals scrolls today's day card into view on open and gives it a today affordance matching `MealGrid`'s.

**Microcopy** — all seven items
- Colour validation message moved onto the `familyColorSchema` enum; both dead `.refine()` calls deleted.
- Activity feed no longer claims "Since you last opened" on a genuine first open, in either branch.
- "Danger Zone" → "Reset this family" (the actual action; the existing consequence copy is unchanged).
- List and chore progress standardised on `{completed} of {total} done` across five sites.
- Cadence labels the active scope already implies are suppressed.
- A lone `Uncategorized` header is omitted.
- Finished events under a cleared hero are marked `· done` (plus reduced opacity); the large-screen hero's `REST_OF_DAY_CLEAR` title now matches the mobile one.

## Execution contract → code and tests

| # | Contract | Where it landed |
|---|---|---|
| 1 | Meals week anchor unchanged | `getWeekStartSunday` at [meals-view.tsx:131](src/components/meals-view.tsx#L131) untouched; the diff for that file is a ref + effect + wrapper `div` only, so no `weekStartDate` payload can change. Asserted in [e2e/meals-today.spec.ts](e2e/meals-today.spec.ts) (first card still Sunday). |
| 2 | No second Today button | Only prev/next added to `mobile-toolbar.tsx`; guarded by `does not render a second Today control (AppHeader owns it)` in `mobile-toolbar.test.tsx`. |
| 3 | Schedule gets prev/next **and** a real label | `context-label.ts` schedule branch + 3 tests in `context-label.test.ts`. Desktop label verified non-regressed: `calendar-module.test.tsx`'s desktop schedule test updated to the windowed label and the full 32-file calendar suite passes. |
| 4 | Fix colour validation at the enum | `z.enum(..., { message })` in `family.ts`; **both** dead refines removed (`memberFormSchema` and `createMemberFormSchema`). 3 tests cover both member surfaces plus a "never leaks Zod's default enum text" guard. |
| 5 | First-run detection via `getLastSeen()` | `const [isFirstRun] = useState(() => io.getLastSeen() === 0)` in `use-activity-feed.ts`. No `saveState` probe added. |
| 6 | First-run state covers both branches | Single `heading` const used by the empty *and* non-empty branch of `activity-feed.tsx`; both covered by tests. |
| 7 | Real enums | `IMPLIED_BY: Record<ChoreCadence, ChoreScope>` with `DAILY/WEEKLY/MONTHLY` → `TODAY/THIS_WEEK/THIS_MONTH`. Proven non-no-op by a test that asserts the label *is* shown for a non-implying scope. (Same trap avoided in `list-card.test.tsx`: `ListKind` is lowercase `"grocery"`.) |
| 8 | Thread `activeScope` through `ChoreAssigneeGroup` | `chores-scope-column.tsx` → `chore-assignee-group.tsx` → `chore-row.tsx`. |
| 9 | Target `REST_OF_DAY_CLEAR`, not `ALL_CLEAR_TODAY` | Real fix in `today-list.tsx` (`data-past` + `· done`); `large-now-hero.tsx` `titleFor` mirrors the mobile `getTitle`. `ALL_CLEAR_TODAY` deliberately left alone. |
| 10 | E2E setup is a fixed pattern | `registerFamily(request, options)`, auth seeded after the first `goto`, then reload — copied from `mobile-calendar.spec.ts:18-35` in both new specs. |
| 11 | No duplicated import headers | Only `it(...)`/`describe(...)` blocks added to the existing `mobile-toolbar.test.tsx`, `activity-feed.test.tsx`, `chore-row.test.tsx`, `family.test.ts`, `today-list.test.tsx`, `build-list-sections.test.ts`. |
| 12 | Resize nothing | `list-item-row.tsx`, `category-manager-list.tsx`, `chores-scope-switcher.tsx` are **not in the diff**. `chore-row.tsx` changes are the cadence label only. The only sizing tokens anywhere in the diff are the two *new* toolbar buttons (`h-11 w-11`) and `min-h-12`, which moved into `cn()` unchanged. The `lg:`-asserting tests in `chore-row.test.tsx` / `list-item-row.test.tsx` are left for Unit B to rewrite per spec §3.3.4. |

## Verification

- `npm run lint` → exit 0 (1 pre-existing `useOptionalChain` warning in `month-event-chip.test.tsx`, untouched by this branch)
- `npm test -- --run` → **177 files, 1764 tests passed**
- `npm run build` → clean; `npm run check:bundle` → 90.7 kB / 96.0 kB entry budget
- `npm run test:e2e -- --workers=1` against BE release `1.9.0` → **207 passed, 268 skipped, 0 failed** (10.1m). The two new specs contribute 5 executed tests in `Mobile Chrome` (4 navigation views + Meals) and 15 `test.skip(!isMobile)` skips in the desktop projects.

The new Meals E2E guard was negative-controlled: with the `scrollIntoView` call disabled it fails on `toBeInViewport()`, so it is not vacuous.

## Notes for review

- `src/test/setup.ts` gains an `Element.prototype.scrollIntoView` stub beside the existing `scrollTo` one. jsdom implements `scrollTo` but **not** `scrollIntoView`, so calling it unstubbed threw and took the whole `MealsView` tree down (44 failures with an empty DOM). Production code is unchanged by this; the real scroll is proven in Playwright.
- `home-dashboard.test.tsx`'s "renders the activity feed region on mobile" now asserts the region rather than the heading text — the heading is legitimately first-run dependent, and the test is about the feed rendering at all.
- `mobile-chores.spec.ts` needed scoping (`region.locator("> p")`): standardising progress copy means the scope column and its assignee group now say the same thing, so a bare `getByText` was strict-mode ambiguous.
