### PR TITLE
fix(mobile): meet the 44px touch-target minimum below lg

### DIFF
--- a/e2e/large-screen-calendar-month.spec.ts
+++ b/e2e/large-screen-calendar-month.spec.ts
@@ -230,10 +230,30 @@ test.describe("Large-screen Calendar Month", () => {
   test("PageDown changes the visible month and restores the exact date", async ({
     page,
   }) => {
-    const cell = page.getByRole("gridcell").nth(10);
-    const before = await cell.getAttribute("data-date");
-    if (!before) throw new Error("Gridcell has no data-date");
-    await cell.focus();
+    // Pick the source deliberately instead of taking nth(10) and hoping. The
+    // failure this guards is: PageDown lands on a date the OUTGOING grid also
+    // renders as a trailing day, the effect focuses that node in the detached
+    // old grid while the new month loads, and focus is stranded on <body>.
+    // nth(10) only produces that geometry in some months — it did in Aug 2026
+    // (whose grid ends on Sep 5) and would not in others, so the test was a
+    // date-dependent roulette. Derive a source that always reproduces it.
+    const dates = await page
+      .getByRole("gridcell")
+      .evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-date") ?? "").filter(Boolean),
+      );
+    const grid = new Set(dates);
+    const visibleMonth = dates[Math.floor(dates.length / 2)].slice(0, 7);
+    // In the displayed month, so PageDown genuinely changes month, AND its
+    // next-month counterpart is already on screen.
+    const before =
+      dates.find(
+        (d) =>
+          d.startsWith(visibleMonth) &&
+          grid.has(formatLocalDate(addMonths(parseLocalDate(d), 1))),
+      ) ?? dates[10];
+
+    await page.locator(`[role="gridcell"][data-date="${before}"]`).focus();
     await page.keyboard.press("PageDown");
     const expected = formatLocalDate(addMonths(parseLocalDate(before), 1));
     await expect

--- a/e2e/mobile-chores.spec.ts
+++ b/e2e/mobile-chores.spec.ts
@@ -60,12 +60,16 @@ test.describe("Mobile Chores", () => {
     await page
       .getByRole("button", { name: /mark take out trash complete/i })
       .click();
-    await expect(row.locator("p").first()).toHaveClass(/line-through/);
+    await expect(
+      row.locator("button[aria-label^='Complete'] span").first(),
+    ).toHaveClass(/line-through/);
 
     await page
       .getByRole("button", { name: /mark take out trash incomplete/i })
       .click();
-    await expect(row.locator("p").first()).not.toHaveClass(/line-through/);
+    await expect(
+      row.locator("button[aria-label^='Complete'] span").first(),
+    ).not.toHaveClass(/line-through/);
 
     await page.getByRole("button", { name: /archive take out trash/i }).click();
     await expect(row).toBeHidden();
@@ -105,7 +109,9 @@ test.describe("Mobile Chores", () => {
       .filter({ hasText: "Feed the cat" })
       .first();
     await expect(row).toBeVisible();
-    await expect(row.locator("p").first()).not.toHaveClass(/line-through/);
+    await expect(
+      row.locator("button[aria-label^='Complete'] span").first(),
+    ).not.toHaveClass(/line-through/);
 
     // Hold the completion response open: for the next ~2.5s the only thing that
     // can flip the row to "done" is the optimistic cache update, not the server.
@@ -130,7 +136,9 @@ test.describe("Mobile Chores", () => {
 
     // Immediate acknowledgment: the strikethrough shows well before the delayed
     // response. Without the optimistic update this assertion would time out.
-    await expect(row.locator("p").first()).toHaveClass(/line-through/, {
+    await expect(
+      row.locator("button[aria-label^='Complete'] span").first(),
+    ).toHaveClass(/line-through/, {
       timeout: 1200,
     });
 
@@ -154,6 +162,8 @@ test.describe("Mobile Chores", () => {
       .locator('[data-testid^="chore-row-"]')
       .filter({ hasText: "Feed the cat" })
       .first();
-    await expect(reloadedRow.locator("p").first()).toHaveClass(/line-through/);
+    await expect(
+      reloadedRow.locator("button[aria-label^='Complete'] span").first(),
+    ).toHaveClass(/line-through/);
   });
 });

--- a/e2e/mobile-chores.spec.ts
+++ b/e2e/mobile-chores.spec.ts
@@ -60,16 +60,14 @@ test.describe("Mobile Chores", () => {
     await page
       .getByRole("button", { name: /mark take out trash complete/i })
       .click();
-    await expect(
-      row.locator("button[aria-label^='Complete'] span").first(),
-    ).toHaveClass(/line-through/);
+    await expect(row.getByTestId("chore-title")).toHaveClass(/line-through/);
 
     await page
       .getByRole("button", { name: /mark take out trash incomplete/i })
       .click();
-    await expect(
-      row.locator("button[aria-label^='Complete'] span").first(),
-    ).not.toHaveClass(/line-through/);
+    await expect(row.getByTestId("chore-title")).not.toHaveClass(
+      /line-through/,
+    );
 
     await page.getByRole("button", { name: /archive take out trash/i }).click();
     await expect(row).toBeHidden();
@@ -109,9 +107,9 @@ test.describe("Mobile Chores", () => {
       .filter({ hasText: "Feed the cat" })
       .first();
     await expect(row).toBeVisible();
-    await expect(
-      row.locator("button[aria-label^='Complete'] span").first(),
-    ).not.toHaveClass(/line-through/);
+    await expect(row.getByTestId("chore-title")).not.toHaveClass(
+      /line-through/,
+    );
 
     // Hold the completion response open: for the next ~2.5s the only thing that
     // can flip the row to "done" is the optimistic cache update, not the server.
@@ -136,9 +134,7 @@ test.describe("Mobile Chores", () => {
 
     // Immediate acknowledgment: the strikethrough shows well before the delayed
     // response. Without the optimistic update this assertion would time out.
-    await expect(
-      row.locator("button[aria-label^='Complete'] span").first(),
-    ).toHaveClass(/line-through/, {
+    await expect(row.getByTestId("chore-title")).toHaveClass(/line-through/, {
       timeout: 1200,
     });
 
@@ -162,8 +158,8 @@ test.describe("Mobile Chores", () => {
       .locator('[data-testid^="chore-row-"]')
       .filter({ hasText: "Feed the cat" })
       .first();
-    await expect(
-      reloadedRow.locator("button[aria-label^='Complete'] span").first(),
-    ).toHaveClass(/line-through/);
+    await expect(reloadedRow.getByTestId("chore-title")).toHaveClass(
+      /line-through/,
+    );
   });
 });

--- a/e2e/touch-targets.spec.ts
+++ b/e2e/touch-targets.spec.ts
@@ -150,10 +150,12 @@ test.describe("touch targets meet the 44px minimum", () => {
         /^Mark /,
         /^Complete /,
         /^Archive /,
-        // ChoreScopeSwitcher pills (chores-scope-switcher.tsx:10-14).
-        "Day",
-        "Week",
-        "Month",
+        "Add recurring chore",
+        // ChoreScopeSwitcher is isMobile-gated (chores-view.tsx:144), so its
+        // Day/Week/Month pills exist below 769px only — at 900px the board
+        // renders scope columns instead. Asserting them at both widths would
+        // fail on a control that legitimately is not there.
+        ...(width < 769 ? ["Day", "Week", "Month"] : []),
       ]);
     });
 

--- a/e2e/touch-targets.spec.ts
+++ b/e2e/touch-targets.spec.ts
@@ -1,0 +1,172 @@
+import {
+  type APIRequestContext,
+  expect,
+  type Page,
+  test,
+} from "@playwright/test";
+import {
+  createChoreTemplate,
+  createList,
+  createListItem,
+  registerFamily,
+  seedBrowserAuth,
+} from "./helpers/api-helpers";
+import {
+  clearStorage,
+  getTodayDateString,
+  waitForHydration,
+} from "./helpers/test-helpers";
+
+/** PRD prd.md:815/827 — the iOS HIG / platform touch minimum. */
+const MIN = 44;
+
+/**
+ * jsdom resolves no Tailwind, so unit tests can only assert class strings —
+ * exactly how `lg:h-11` passed while mobile sat at 36px. This measures the real
+ * laid-out box in a browser instead.
+ */
+async function assertMinimumTargets(
+  page: Page,
+  names: readonly (string | RegExp)[],
+) {
+  const undersized: string[] = [];
+  for (const name of names) {
+    const controls = page.getByRole("button", { name });
+    // Wait for at least one to render before counting; a name that matches
+    // nothing would pass vacuously, so the count assertion below is the guard.
+    await expect(controls.first()).toBeVisible();
+    const count = await controls.count();
+    expect(count, `no control matched ${String(name)}`).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const box = await controls.nth(i).boundingBox();
+      if (!box) continue;
+      if (box.width < MIN || box.height < MIN) {
+        undersized.push(
+          `${String(name)}#${i}: ${Math.round(box.width)}x${Math.round(box.height)}`,
+        );
+      }
+    }
+  }
+  expect(undersized, `controls below ${MIN}px`).toEqual([]);
+}
+
+/**
+ * Sets the viewport *before* the first paint so the breakpoint hooks
+ * (`useIsMobile` ≤768, `useIsLargeScreen` ≥1024) settle on the band under test
+ * rather than reacting to a resize mid-run.
+ */
+async function openAppAt(
+  page: Page,
+  request: APIRequestContext,
+  width: number,
+) {
+  await page.setViewportSize({ width, height: 900 });
+  await page.goto("/");
+  await clearStorage(page);
+
+  // Two members: the 390px calendar toolbar is the tightest row in the app and
+  // its width budget is only genuinely under pressure with more than one dot.
+  const registration = await registerFamily(request, {
+    familyName: "Touch Target Family",
+    members: [
+      { name: "Alice", color: "coral" },
+      { name: "Bob", color: "teal" },
+    ],
+  });
+
+  // Seed real content — a freshly registered family has no chores and no lists,
+  // so the chore/list selectors would match nothing and pass vacuously.
+  await createChoreTemplate(request, registration.token, {
+    title: "Dishes",
+    assignedToMemberId: registration.family.members[0].id,
+    cadence: "DAILY",
+    activeFrom: getTodayDateString(),
+  });
+  const list = await createList(request, registration.token, {
+    name: "Groceries",
+    kind: "grocery",
+  });
+  await createListItem(request, registration.token, list.id, { text: "Milk" });
+
+  await seedBrowserAuth(page, registration);
+  await page.reload();
+  await waitForHydration(page);
+
+  return page.getByRole("navigation", { name: /primary/i });
+}
+
+test.describe("touch targets meet the 44px minimum", () => {
+  test("calendar at 390px", async ({ page, request }) => {
+    const nav = await openAppAt(page, request, 390);
+    await nav.getByRole("button", { name: "Calendar" }).click();
+
+    // Below 769px the calendar renders MobileToolbar, whose pills are labelled
+    // "Daily view"… (mobile-toolbar.tsx:12-15).
+    await assertMinimumTargets(page, [
+      "Previous",
+      "Next",
+      "Daily view",
+      "Weekly view",
+      "Monthly view",
+      "Schedule view",
+      "Today",
+      /filter$/,
+    ]);
+
+    // The toolbar row must pan, not push the page wide: its member-dot group is
+    // the elastic one (min-w-0 + overflow-x-auto) precisely because 44px pills,
+    // prev/next and two dots cannot all fit 390px.
+    const scrollW = await page.evaluate(
+      () => document.documentElement.scrollWidth,
+    );
+    expect(scrollW).toBeLessThanOrEqual(390);
+  });
+
+  test("calendar at 900px (desktop switcher, no lg: rules)", async ({
+    page,
+    request,
+  }) => {
+    const nav = await openAppAt(page, request, 900);
+    await nav.getByRole("button", { name: "Calendar" }).click();
+
+    // At 900px the calendar renders the *desktop* switcher, labelled
+    // "Day"/"Week"/"Month"/"Schedule" (calendar-view-switcher.tsx:9-16).
+    await assertMinimumTargets(page, [
+      "Previous",
+      "Next",
+      "Day",
+      "Week",
+      "Month",
+      "Schedule",
+      "Today",
+    ]);
+  });
+
+  for (const width of [390, 900]) {
+    test(`chores at ${width}px`, async ({ page, request }) => {
+      const nav = await openAppAt(page, request, width);
+      await nav.getByRole("button", { name: "Chores" }).click();
+      await assertMinimumTargets(page, [
+        /^Mark /,
+        /^Complete /,
+        /^Archive /,
+        // ChoreScopeSwitcher pills (chores-scope-switcher.tsx:10-14).
+        "Day",
+        "Week",
+        "Month",
+      ]);
+    });
+
+    test(`lists at ${width}px`, async ({ page, request }) => {
+      const nav = await openAppAt(page, request, width);
+      await nav.getByRole("button", { name: "Lists" }).click();
+      await page
+        .getByRole("button", { name: /groceries/i })
+        .first()
+        .click();
+      // Both widths are below lg, so both get the single overflow control —
+      // that is the point: one gate for the button and its sheet.
+      await assertMinimumTargets(page, [/^More actions/, "Milk"]);
+    });
+  }
+});

--- a/e2e/touch-targets.spec.ts
+++ b/e2e/touch-targets.spec.ts
@@ -168,7 +168,11 @@ test.describe("touch targets meet the 44px minimum", () => {
         .click();
       // Both widths are below lg, so both get the single overflow control —
       // that is the point: one gate for the button and its sheet.
-      await assertMinimumTargets(page, [/^More actions/, "Milk"]);
+      await assertMinimumTargets(page, [
+        /^More actions/,
+        "Milk",
+        "Back to Lists",
+      ]);
     });
   }
 });

--- a/e2e/touch-targets.spec.ts
+++ b/e2e/touch-targets.spec.ts
@@ -8,14 +8,11 @@ import {
   createChoreTemplate,
   createList,
   createListItem,
+  getChoresBoard,
   registerFamily,
   seedBrowserAuth,
 } from "./helpers/api-helpers";
-import {
-  clearStorage,
-  getTodayDateString,
-  waitForHydration,
-} from "./helpers/test-helpers";
+import { clearStorage, waitForHydration } from "./helpers/test-helpers";
 
 /** PRD prd.md:815/827 — the iOS HIG / platform touch minimum. */
 const MIN = 44;
@@ -76,11 +73,19 @@ async function openAppAt(
 
   // Seed real content — a freshly registered family has no chores and no lists,
   // so the chore/list selectors would match nothing and pass vacuously.
+  //
+  // activeFrom must come from the backend's own clock, not this process's:
+  // the board scopes "today" to the family clock, so a runner-derived date is
+  // one day ahead whenever the two disagree, the template is not yet active,
+  // and the board renders its empty state. That window is only a few hours
+  // wide, which is why this passed locally and on a mid-morning CI run before
+  // failing on an 03:26 UTC one.
+  const board = await getChoresBoard(request, registration.token);
   await createChoreTemplate(request, registration.token, {
     title: "Dishes",
     assignedToMemberId: registration.family.members[0].id,
     cadence: "DAILY",
-    activeFrom: getTodayDateString(),
+    activeFrom: board.today.periodStartDate,
   });
   const list = await createList(request, registration.token, {
     name: "Groceries",

--- a/e2e/touch-targets.spec.ts
+++ b/e2e/touch-targets.spec.ts
@@ -147,8 +147,9 @@ test.describe("touch targets meet the 44px minimum", () => {
       const nav = await openAppAt(page, request, width);
       await nav.getByRole("button", { name: "Chores" }).click();
       await assertMinimumTargets(page, [
+        // One control per row: the indicator and the title share this button,
+        // so /^Mark / measures the whole tappable row body.
         /^Mark /,
-        /^Complete /,
         /^Archive /,
         "Add recurring chore",
         // ChoreScopeSwitcher is isMobile-gated (chores-view.tsx:144), so its
@@ -168,9 +169,12 @@ test.describe("touch targets meet the 44px minimum", () => {
         .click();
       // Both widths are below lg, so both get the single overflow control —
       // that is the point: one gate for the button and its sheet.
+      // Anchored: Playwright's string `name` is a case-insensitive *substring*
+      // match, so a bare "Milk" also matches "More actions for Milk" — the same
+      // trap the unit tests were switched to `exact: true` to avoid.
       await assertMinimumTargets(page, [
         /^More actions/,
-        "Milk",
+        /^Milk$/,
         "Back to Lists",
       ]);
     });

--- a/src/components/calendar/components/family-filter-pills.tsx
+++ b/src/components/calendar/components/family-filter-pills.tsx
@@ -49,7 +49,7 @@ export function FamilyFilterPills() {
       <button
         onClick={handleToggleAll}
         className={cn(
-          "flex min-h-11 items-center px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
+          "flex min-h-11 min-w-11 items-center justify-center px-2.5 py-1 rounded-full text-xs font-medium transition-all border",
           allSelected
             ? "bg-foreground text-background border-foreground"
             : noneSelected

--- a/src/components/calendar/components/mobile-event-detail.tsx
+++ b/src/components/calendar/components/mobile-event-detail.tsx
@@ -128,7 +128,7 @@ function MobileEventDetail({
               size="sm"
               onClick={handleEditClick}
               disabled={isDeleting}
-              className="min-h-11 px-3 text-white hover:bg-white/20 hover:text-white"
+              className="px-3 text-white hover:bg-white/20 hover:text-white"
             >
               <Pencil className="mr-1.5 h-4 w-4" />
               Edit
@@ -138,7 +138,7 @@ function MobileEventDetail({
               size="sm"
               onClick={handleDeleteAttempt}
               disabled={isDeleting}
-              className="min-h-11 px-3 text-white hover:bg-white/20 hover:text-white"
+              className="px-3 text-white hover:bg-white/20 hover:text-white"
             >
               <Trash2 className="mr-1.5 h-4 w-4" />
               Delete

--- a/src/components/calendar/components/mobile-event-detail.tsx
+++ b/src/components/calendar/components/mobile-event-detail.tsx
@@ -128,7 +128,7 @@ function MobileEventDetail({
               size="sm"
               onClick={handleEditClick}
               disabled={isDeleting}
-              className="h-9 px-3 text-white hover:bg-white/20 hover:text-white"
+              className="min-h-11 px-3 text-white hover:bg-white/20 hover:text-white"
             >
               <Pencil className="mr-1.5 h-4 w-4" />
               Edit
@@ -138,7 +138,7 @@ function MobileEventDetail({
               size="sm"
               onClick={handleDeleteAttempt}
               disabled={isDeleting}
-              className="h-9 px-3 text-white hover:bg-white/20 hover:text-white"
+              className="min-h-11 px-3 text-white hover:bg-white/20 hover:text-white"
             >
               <Trash2 className="mr-1.5 h-4 w-4" />
               Delete

--- a/src/components/calendar/components/mobile-toolbar.tsx
+++ b/src/components/calendar/components/mobile-toolbar.tsx
@@ -56,7 +56,7 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
             aria-label={ariaLabel}
             onClick={() => setCalendarView(view)}
             className={cn(
-              "flex h-8 min-w-8 items-center justify-center rounded-lg px-2 text-sm leading-none font-semibold transition-colors",
+              "flex h-11 min-w-11 items-center justify-center rounded-lg px-2 text-sm leading-none font-semibold transition-colors",
               calendarView === view
                 ? "bg-primary text-primary-foreground shadow-sm shadow-primary/20"
                 : "text-muted-foreground hover:text-foreground",
@@ -91,9 +91,15 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
       {/* Member Filter Dots — the only elastic group in the row. The switcher and
           prev/next are fixed-width essentials, and the row's ancestor is
           overflow-hidden (calendar-module.tsx), so without min-w-0 + a scroller
-          here the last members' dots are clipped and unreachable: at 375px a
-          three-member family loses 25px, a five-member one 113px. Same
-          scroll-don't-clip pattern as MemberChipRow on Home. */}
+          here the last members' dots are clipped and unreachable. Same
+          scroll-don't-clip pattern as MemberChipRow on Home.
+
+          The row genuinely cannot fit 44px controls plus two members at 390px,
+          and that is expected — it pans, it does not shrink. Budget at 390px:
+          358px of content (390 less px-4), less 24px for the two gap-3 gaps,
+          leaves 334px. The switcher takes 190px (4x44 pills + p-1 + gaps) and
+          prev/next 90px (2x44), leaving ~54px — one dot. Keep shrink-0 on each
+          dot or they squash back below 44px instead of scrolling. */}
       <div className="flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-hide">
         {members.map((member) => {
           const isIncluded = filter.selectedMembers.includes(member.id);
@@ -103,7 +109,7 @@ export function MobileToolbar({ members }: MobileToolbarProps) {
               type="button"
               onClick={() => toggleMember(member.id)}
               aria-label={`${member.name} filter`}
-              className="shrink-0 rounded-full p-2 transition-colors hover:bg-muted"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full transition-colors hover:bg-muted"
             >
               <MemberAvatar
                 name={member.name}

--- a/src/components/calendar/components/recurrence-picker.tsx
+++ b/src/components/calendar/components/recurrence-picker.tsx
@@ -174,7 +174,7 @@ function RecurrencePicker({
           onChange={(e) =>
             handleOptionChange(e.target.value as RecurrenceOption)
           }
-          className="flex h-10 w-full rounded-lg border border-input bg-input px-3 py-2 text-[15px] leading-5 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="flex h-11 w-full rounded-lg border border-input bg-input px-3 py-2 text-[15px] leading-5 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <option value="none">Does not repeat</option>
           <option value="daily">Daily</option>

--- a/src/components/calendar/components/recurrence-picker.tsx
+++ b/src/components/calendar/components/recurrence-picker.tsx
@@ -201,7 +201,7 @@ function RecurrencePicker({
                   type="button"
                   onClick={() => toggleDay(key)}
                   className={cn(
-                    "w-9 h-9 rounded-full text-sm font-medium transition-colors",
+                    "h-11 w-11 rounded-full text-sm font-medium transition-colors",
                     isSelected
                       ? "bg-primary text-white"
                       : "bg-muted text-muted-foreground hover:bg-muted/80",

--- a/src/components/calendar/views/monthly-calendar.tsx
+++ b/src/components/calendar/views/monthly-calendar.tsx
@@ -456,9 +456,21 @@ function MonthlyCalendarLarge({
     ) {
       return;
     }
-    const target = weeksEl?.querySelector<HTMLElement>(
-      `[data-date="${formatLocalDate(focusedDate)}"]`,
-    );
+    // isConnected is load-bearing. `weeksEl` is state, so on the render where
+    // the month's query goes into flight it still holds the DETACHED old grid:
+    // the isLoading branch unmounts it, but setWeeksEl(null) only lands on the
+    // next render. Without this check the query below searches that dead node,
+    // and it FINDS the target whenever the outgoing matrix carried that date as
+    // an adjacent-month day — the Aug 2026 grid ends on Sep 5, so PageDown from
+    // Aug 5 hits it exactly. focus() on a detached node is a silent no-op, so
+    // the request got consumed while focus sat on <body>, and the remount had
+    // nothing left to restore. Keyboard nav was then dead until the user tabbed
+    // back in. Guarded by the PageDown case in large-screen-calendar-month.
+    const target = weeksEl?.isConnected
+      ? weeksEl.querySelector<HTMLElement>(
+          `[data-date="${formatLocalDate(focusedDate)}"]`,
+        )
+      : null;
     // The state update can render once against the old matrix before the parent
     // month change lands. Do not clear the request until the target exists.
     if (!target) return;
@@ -473,9 +485,14 @@ function MonthlyCalendarLarge({
     const justClosed = wasDetailOpen.current && !isEventDetailOpen;
     wasDetailOpen.current = isEventDetailOpen;
     if (!justClosed || !pendingModalReturnDate.current) return;
-    const target = weeksEl?.querySelector<HTMLElement>(
-      `[data-date="${formatLocalDate(pendingModalReturnDate.current)}"]`,
-    );
+    // Same detached-weeksEl hazard as the month restore above: if the grid is
+    // swapped for the loading skeleton while the modal is open, this state still
+    // points at the old node and focus() would quietly do nothing.
+    const target = weeksEl?.isConnected
+      ? weeksEl.querySelector<HTMLElement>(
+          `[data-date="${formatLocalDate(pendingModalReturnDate.current)}"]`,
+        )
+      : null;
     if (!target) return;
     target.focus();
     pendingModalReturnDate.current = null;

--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -47,18 +47,41 @@ describe("ChoreRow haptics", () => {
 
 it("sizes the checkoff at 44px unconditionally, not only at lg", () => {
   render(<ChoreRow chore={baseChore} onComplete={() => {}} />);
-  const checkoff = screen.getByRole("button", { name: /^Mark / });
+  const checkoff = screen.getByTestId("chore-checkoff");
   expect(checkoff.className).toContain("h-11");
   expect(checkoff.className).toContain("w-11");
   expect(checkoff.className).not.toContain("lg:h-11");
+  // The tappable control is the button wrapping it, not the indicator itself.
+  expect(screen.getByRole("button", { name: /^Mark / }).className).toContain(
+    "min-h-11",
+  );
+});
+
+it("exposes exactly one completion control, labelled for the current state", () => {
+  const { rerender } = render(
+    <ChoreRow chore={baseChore} onComplete={() => {}} />,
+  );
+  expect(screen.getAllByRole("button", { name: /^Mark / })).toHaveLength(1);
+  expect(screen.queryByRole("button", { name: /^Complete / })).toBeNull();
+
+  // A static label would still read "Complete Dishes" here while activating it
+  // un-completes the chore.
+  rerender(
+    <ChoreRow
+      chore={{ ...baseChore, completed: true }}
+      onUncomplete={() => {}}
+    />,
+  );
+  expect(
+    screen.getByRole("button", { name: "Mark Dishes incomplete" }),
+  ).toBeInTheDocument();
 });
 
 it("lets the row body complete the chore", async () => {
   const onComplete = vi.fn();
   render(<ChoreRow chore={baseChore} onComplete={onComplete} />);
-  await userEvent.click(
-    screen.getByRole("button", { name: `Complete ${baseChore.title}` }),
-  );
+  // The title text sits inside the toggle, so tapping it completes the chore.
+  await userEvent.click(screen.getByTestId("chore-title"));
   expect(onComplete).toHaveBeenCalledTimes(1);
 });
 

--- a/src/components/chores/chore-row.test.tsx
+++ b/src/components/chores/chore-row.test.tsx
@@ -45,19 +45,36 @@ describe("ChoreRow haptics", () => {
   });
 });
 
-it("grows the checkoff control to at least 44px at lg+", () => {
-  render(
-    <ChoreRow chore={baseChore} onComplete={vi.fn()} onUncomplete={vi.fn()} />,
+it("sizes the checkoff at 44px unconditionally, not only at lg", () => {
+  render(<ChoreRow chore={baseChore} onComplete={() => {}} />);
+  const checkoff = screen.getByRole("button", { name: /^Mark / });
+  expect(checkoff.className).toContain("h-11");
+  expect(checkoff.className).toContain("w-11");
+  expect(checkoff.className).not.toContain("lg:h-11");
+});
+
+it("lets the row body complete the chore", async () => {
+  const onComplete = vi.fn();
+  render(<ChoreRow chore={baseChore} onComplete={onComplete} />);
+  await userEvent.click(
+    screen.getByRole("button", { name: `Complete ${baseChore.title}` }),
   );
+  expect(onComplete).toHaveBeenCalledTimes(1);
+});
 
-  const checkoff = screen.getByRole("button", {
-    name: /mark dishes complete/i,
-  });
-
-  expect(checkoff.className).toContain("h-9");
-  expect(checkoff.className).toContain("w-9");
-  expect(checkoff.className).toContain("lg:h-11");
-  expect(checkoff.className).toContain("lg:w-11");
+it("keeps Archive separate from the row-body target", async () => {
+  const onComplete = vi.fn();
+  const onArchive = vi.fn();
+  render(
+    <ChoreRow
+      chore={baseChore}
+      onComplete={onComplete}
+      onArchive={onArchive}
+    />,
+  );
+  await userEvent.click(screen.getByRole("button", { name: /^Archive / }));
+  expect(onArchive).toHaveBeenCalledTimes(1);
+  expect(onComplete).not.toHaveBeenCalled();
 });
 
 describe("ChoreRow cadence label", () => {

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -35,6 +35,17 @@ export function ChoreRow({
 }: ChoreRowProps) {
   const showCadence = IMPLIED_BY[chore.cadence] !== activeScope;
 
+  // Shared by the checkoff and the row-body button below, so both stay on the
+  // same haptics path (success() on the completing transition only).
+  const toggleCompletion = () => {
+    if (chore.completed) {
+      onUncomplete?.();
+    } else {
+      haptics.success();
+      onComplete?.();
+    }
+  };
+
   return (
     <div
       data-testid={`chore-row-${chore.templateId}`}
@@ -59,48 +70,51 @@ export function ChoreRow({
             ? `Mark ${chore.title} incomplete`
             : `Mark ${chore.title} complete`
         }
-        onClick={() => {
-          if (chore.completed) {
-            onUncomplete?.();
-          } else {
-            haptics.success();
-            onComplete?.();
-          }
-        }}
+        onClick={toggleCompletion}
         className={cn(
-          "flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 transition-colors lg:h-11 lg:w-11",
+          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
           chore.completed
             ? "border-primary bg-primary text-primary-foreground"
             : "border-border bg-background text-muted-foreground hover:border-primary hover:text-primary",
         )}
       >
         {chore.completed ? (
-          <Check className="h-4 w-4 lg:h-5 lg:w-5" />
+          <Check className="h-5 w-5" />
         ) : (
-          <Circle className="h-4 w-4 lg:h-5 lg:w-5" />
+          <Circle className="h-5 w-5" />
         )}
       </button>
 
-      <div className="min-w-0 flex-1">
-        <p
+      {/* Raw <button> for the same haptics reason as the checkoff above: a
+          pressable would fire tap() on pointerdown and coalesce the success
+          pulse. Sibling of the checkoff and Archive — never a wrapper, which
+          would nest interactive elements. Its own aria-label keeps it from
+          colliding with the checkoff's "Mark <title> complete". */}
+      <button
+        type="button"
+        aria-label={`Complete ${chore.title}`}
+        onClick={toggleCompletion}
+        className="flex min-h-11 min-w-0 flex-1 flex-col justify-center text-left"
+      >
+        <span
           className={cn(
             "truncate text-sm font-semibold text-foreground",
             chore.completed && "text-muted-foreground line-through",
           )}
         >
           {chore.title}
-        </p>
+        </span>
         {showCadence && (
-          <p className="mt-1 text-xs font-medium text-muted-foreground">
+          <span className="mt-1 text-xs font-medium text-muted-foreground">
             {cadenceLabel(chore.cadence)}
-          </p>
+          </span>
         )}
-      </div>
+      </button>
 
       <Button
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-lg"
         aria-label={`Archive ${chore.title}`}
         onClick={onArchive}
         className="text-muted-foreground hover:text-foreground"

--- a/src/components/chores/chore-row.tsx
+++ b/src/components/chores/chore-row.tsx
@@ -62,6 +62,12 @@ export function ChoreRow({
         pointerdown, and the shared 40ms throttle would then coalesce away the
         haptics.success() pulse on click. The single completion pulse depends on
         no preceding tap. Guarded by the throttle-coupling test in haptics.test.ts.
+
+        One control, not two: the indicator and the text share this button, the
+        way ListItemRow's toggle does. A second sibling button over the text
+        would need a distinct accessible name, and any static one ("Complete
+        <title>") lies in the completed state, where activating it un-completes.
+        Archive stays a sibling — nothing interactive nests here.
       */}
       <button
         type="button"
@@ -71,44 +77,42 @@ export function ChoreRow({
             : `Mark ${chore.title} complete`
         }
         onClick={toggleCompletion}
-        className={cn(
-          "flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
-          chore.completed
-            ? "border-primary bg-primary text-primary-foreground"
-            : "border-border bg-background text-muted-foreground hover:border-primary hover:text-primary",
-        )}
+        className="group flex min-h-11 min-w-0 flex-1 items-center gap-3 text-left"
       >
-        {chore.completed ? (
-          <Check className="h-5 w-5" />
-        ) : (
-          <Circle className="h-5 w-5" />
-        )}
-      </button>
-
-      {/* Raw <button> for the same haptics reason as the checkoff above: a
-          pressable would fire tap() on pointerdown and coalesce the success
-          pulse. Sibling of the checkoff and Archive — never a wrapper, which
-          would nest interactive elements. Its own aria-label keeps it from
-          colliding with the checkoff's "Mark <title> complete". */}
-      <button
-        type="button"
-        aria-label={`Complete ${chore.title}`}
-        onClick={toggleCompletion}
-        className="flex min-h-11 min-w-0 flex-1 flex-col justify-center text-left"
-      >
+        {/* group-hover, not hover: the indicator is no longer the hovered
+            element, so the affordance has to come from the button. */}
         <span
+          data-testid="chore-checkoff"
           className={cn(
-            "truncate text-sm font-semibold text-foreground",
-            chore.completed && "text-muted-foreground line-through",
+            "flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+            chore.completed
+              ? "border-primary bg-primary text-primary-foreground"
+              : "border-border bg-background text-muted-foreground group-hover:border-primary group-hover:text-primary",
           )}
         >
-          {chore.title}
+          {chore.completed ? (
+            <Check className="h-5 w-5" />
+          ) : (
+            <Circle className="h-5 w-5" />
+          )}
         </span>
-        {showCadence && (
-          <span className="mt-1 text-xs font-medium text-muted-foreground">
-            {cadenceLabel(chore.cadence)}
+
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span
+            data-testid="chore-title"
+            className={cn(
+              "truncate text-sm font-semibold text-foreground",
+              chore.completed && "text-muted-foreground line-through",
+            )}
+          >
+            {chore.title}
           </span>
-        )}
+          {showCadence && (
+            <span className="mt-1 text-xs font-medium text-muted-foreground">
+              {cadenceLabel(chore.cadence)}
+            </span>
+          )}
+        </span>
       </button>
 
       <Button

--- a/src/components/chores/chores-scope-switcher.tsx
+++ b/src/components/chores/chores-scope-switcher.tsx
@@ -30,7 +30,7 @@ export function ChoreScopeSwitcher({
           aria-pressed={value === option.key}
           onClick={() => onChange(option.key)}
           className={cn(
-            "min-h-10 rounded-md px-3 text-sm font-semibold transition-colors",
+            "min-h-11 rounded-md px-3 text-sm font-semibold transition-colors",
             value === option.key
               ? "bg-background text-foreground shadow-sm"
               : "text-muted-foreground hover:text-foreground",

--- a/src/components/lists-view.test.tsx
+++ b/src/components/lists-view.test.tsx
@@ -372,9 +372,17 @@ describe("ListsView hub", () => {
       ).not.toBeInTheDocument();
     });
 
+    // Below lg (jsdom's matchMedia answers false to every query) the row's Edit
+    // and Delete live behind the single overflow control, and Edit is a
+    // sheet→sheet handoff: the actions sheet must finish closing before the
+    // edit sheet opens.
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Popcorn" }),
+    );
     await user.click(screen.getByRole("button", { name: "Edit" }));
-    await user.clear(screen.getByLabelText("Item text"));
-    await typeAndWait(user, screen.getByLabelText("Item text"), "Kettle corn");
+    const itemText = await screen.findByLabelText("Item text");
+    await user.clear(itemText);
+    await typeAndWait(user, itemText, "Kettle corn");
     await user.click(screen.getByRole("button", { name: "Save item" }));
 
     expect(await screen.findByText("Kettle corn")).toBeInTheDocument();
@@ -385,6 +393,9 @@ describe("ListsView hub", () => {
     await user.click(screen.getByRole("button", { name: /^Kettle corn$/ }));
     expect(screen.getByText("Kettle corn")).not.toHaveClass("line-through");
 
+    await user.click(
+      screen.getByRole("button", { name: "More actions for Kettle corn" }),
+    );
     await user.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {

--- a/src/components/lists/category-manager-list.tsx
+++ b/src/components/lists/category-manager-list.tsx
@@ -71,7 +71,7 @@ function ReorderRow({
         ref={upRef}
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-lg"
         aria-label={`Move ${entry.name} up`}
         disabled={isFirst || isPending}
         onClick={() => onMoveUp(entry.id)}
@@ -85,7 +85,7 @@ function ReorderRow({
         ref={downRef}
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-lg"
         aria-label={`Move ${entry.name} down`}
         disabled={isLast || isPending}
         onClick={() => onMoveDown(entry.id)}
@@ -202,7 +202,7 @@ function CategoryRow({
       <Button
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-lg"
         aria-label={`Rename ${entry.name}`}
         onClick={() => onRenameStart(entry)}
         disabled={isDeletePending || isRenamePending}
@@ -213,7 +213,7 @@ function CategoryRow({
       <Button
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-lg"
         aria-label={`Delete ${entry.name}`}
         onClick={() => onDeleteRequest(entry)}
         disabled={isDeletePending || isRenamePending}

--- a/src/components/lists/category-manager.tsx
+++ b/src/components/lists/category-manager.tsx
@@ -604,7 +604,7 @@ export function CategoryManager({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon-lg"
             onClick={handleExplicitClose}
             aria-label="Close"
           >

--- a/src/components/lists/list-detail-view.test.tsx
+++ b/src/components/lists/list-detail-view.test.tsx
@@ -221,12 +221,12 @@ describe("ListDetailView options placement", () => {
       expect(addItem[0]).not.toHaveClass("fixed");
     });
 
-    it("gives the inline Add item button a 44px large-screen target", async () => {
+    it("gives the inline Add item button a 44px target at every width", async () => {
       renderDetail();
 
-      expect(
-        await screen.findByRole("button", { name: "Add item" }),
-      ).toHaveClass("lg:min-h-11");
+      const addItem = await screen.findByRole("button", { name: "Add item" });
+      expect(addItem).toHaveClass("min-h-11");
+      expect(addItem.className).not.toContain("lg:min-h-11");
     });
 
     it("shows category control for a General list when it has categories", async () => {

--- a/src/components/lists/list-detail-view.tsx
+++ b/src/components/lists/list-detail-view.tsx
@@ -1,4 +1,10 @@
-import { ArrowLeft, Plus, SlidersHorizontal } from "lucide-react";
+import {
+  ArrowLeft,
+  Pencil,
+  Plus,
+  SlidersHorizontal,
+  Trash2,
+} from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ApiException,
@@ -13,7 +19,7 @@ import {
   FloatingActionButton,
   MOBILE_FAB_SCROLL_PADDING,
 } from "@/components/shared";
-import { useIsMobile, useOnlineStatus } from "@/hooks";
+import { useIsLargeScreen, useIsMobile, useOnlineStatus } from "@/hooks";
 import type { ListItem, ListPreferences, UpdateListRequest } from "@/lib/types";
 import { Button } from "../ui/button";
 import { MobileSheet } from "../ui/mobile-sheet";
@@ -55,6 +61,10 @@ export function ListDetailView({
   const clearCompleted = useClearCompleted(listId);
   const updatePreferences = useUpdateListPreferences();
   const isMobile = useIsMobile();
+  // The row overflow control and its actions sheet share this one gate. Using
+  // isMobile (<=768) for either would give the 769-1023px band a control that
+  // opens nothing.
+  const isLargeScreen = useIsLargeScreen();
   const isOnline = useOnlineStatus();
   const [optionsOpen, setOptionsOpen] = useState(false);
   const [managerOpen, setManagerOpen] = useState(false);
@@ -73,6 +83,11 @@ export function ListDetailView({
     mode: "create" | "edit";
     item: ListItem | null;
   } | null>(null);
+  // Row overflow ("More actions") sheet, and the item awaiting the edit sheet
+  // once it has finished closing — ListItemSheet is itself a vaul MobileSheet,
+  // so the two must not be open in the same tick.
+  const [actionsForItem, setActionsForItem] = useState<ListItem | null>(null);
+  const [pendingEditItem, setPendingEditItem] = useState<ListItem | null>(null);
   const list = listQuery.data?.data ?? null;
   const hasPreferences = preferences !== null;
   const familyShowCompletedDefault =
@@ -98,6 +113,20 @@ export function ListDetailView({
 
     return () => window.clearTimeout(timeoutId);
   }, [managerHandoffPending, optionsOpen]);
+
+  // Same fallback the manager handoff needs: if the actions sheet's close
+  // animation never reports back (reduced motion, interrupted transition), open
+  // the edit sheet anyway rather than stranding the handoff.
+  useEffect(() => {
+    if (pendingEditItem === null || actionsForItem !== null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setItemSheet({ mode: "edit", item: pendingEditItem });
+      setPendingEditItem(null);
+    }, MOBILE_MANAGER_HANDOFF_FALLBACK_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pendingEditItem, actionsForItem]);
 
   if (listQuery.isLoading) {
     return (
@@ -287,6 +316,8 @@ export function ListDetailView({
                         }
                         onEdit={() => setItemSheet({ mode: "edit", item })}
                         onDelete={() => deleteItem.mutate(item.id)}
+                        isLargeScreen={isLargeScreen}
+                        onOpenActions={() => setActionsForItem(item)}
                       />
                     ))}
                   </div>
@@ -336,6 +367,51 @@ export function ListDetailView({
                   }
                   onClearCompleted={() => clearCompleted.mutate()}
                 />
+              </div>
+            </MobileSheet>
+          )}
+
+          {/* Gated on !isLargeScreen — the exact complement of the row's
+              overflow button, so the control and the sheet it opens can never
+              disagree about which band they belong to. */}
+          {!isLargeScreen && (
+            <MobileSheet
+              isOpen={actionsForItem !== null}
+              onClose={() => setActionsForItem(null)}
+              title={actionsForItem?.text ?? "Item actions"}
+              initialHeight="half"
+              // Suppress focus restoration mid-handoff so focus doesn't bounce
+              // back to the row before the edit sheet is ready.
+              restoreFocusOnClose={pendingEditItem === null}
+              onAnimationEnd={(open) => {
+                if (!open && pendingEditItem !== null) {
+                  setItemSheet({ mode: "edit", item: pendingEditItem });
+                  setPendingEditItem(null);
+                }
+              }}
+            >
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="ghost"
+                  className="min-h-11 justify-start"
+                  onClick={() => {
+                    setPendingEditItem(actionsForItem);
+                    setActionsForItem(null);
+                  }}
+                >
+                  <Pencil className="mr-2 h-4 w-4" /> Edit
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="min-h-11 justify-start text-destructive"
+                  onClick={() => {
+                    const item = actionsForItem;
+                    setActionsForItem(null);
+                    if (item) deleteItem.mutate(item.id);
+                  }}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete
+                </Button>
               </div>
             </MobileSheet>
           )}

--- a/src/components/lists/list-detail-view.tsx
+++ b/src/components/lists/list-detail-view.tsx
@@ -222,7 +222,7 @@ export function ListDetailView({
                   <Button
                     type="button"
                     onClick={() => setItemSheet({ mode: "create", item: null })}
-                    className="lg:min-h-11"
+                    className="min-h-11"
                   >
                     <Plus className="h-4 w-4" />
                     Add item

--- a/src/components/lists/list-item-row.test.tsx
+++ b/src/components/lists/list-item-row.test.tsx
@@ -20,7 +20,9 @@ describe("ListItemRow haptics", () => {
         onDelete={vi.fn()}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: baseItem.text, exact: true }),
+    );
     expect(success).toHaveBeenCalledTimes(1);
   });
 
@@ -34,31 +36,45 @@ describe("ListItemRow haptics", () => {
         onDelete={vi.fn()}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: baseItem.text, exact: true }),
+    );
     expect(success).not.toHaveBeenCalled();
   });
 });
 
-describe("ListItemRow large-screen touch targets", () => {
-  it("gives the toggle and item action buttons 44px targets at lg", () => {
-    render(
-      <ListItemRow
-        item={baseItem}
-        onToggle={vi.fn()}
-        onEdit={vi.fn()}
-        onDelete={vi.fn()}
-      />,
-    );
+const rowProps = {
+  item: baseItem,
+  onToggle: () => {},
+  onEdit: () => {},
+  onDelete: () => {},
+};
 
-    expect(screen.getByRole("button", { name: /milk/i })).toHaveClass(
-      "lg:min-h-11",
-    );
-    for (const name of [/edit/i, /delete/i]) {
-      expect(screen.getByRole("button", { name })).toHaveClass(
-        "lg:min-h-11",
-        "lg:min-w-11",
-      );
-    }
+describe("ListItemRow touch targets", () => {
+  it("sizes the toggle at 44px unconditionally", () => {
+    render(<ListItemRow {...rowProps} />);
+    const toggle = screen.getByRole("button", {
+      name: baseItem.text,
+      exact: true,
+    });
+    expect(toggle.className).toContain("min-h-11");
+    expect(toggle.className).not.toContain("lg:min-h-11");
+  });
+
+  it("exposes one overflow control instead of two icons below lg", () => {
+    render(<ListItemRow {...rowProps} isLargeScreen={false} />);
+    expect(
+      screen.getByRole("button", { name: /^More actions/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Edit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("keeps inline Edit and Delete at lg and above", () => {
+    render(<ListItemRow {...rowProps} isLargeScreen />);
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^More actions/ })).toBeNull();
   });
 });
 
@@ -114,7 +130,9 @@ describe("ListItemRow haptics — real fire reaches the device", () => {
         onDelete={vi.fn()}
       />,
     );
-    await userEvent.click(screen.getByRole("button", { name: /milk/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: baseItem.text, exact: true }),
+    );
 
     expect(vibrate).toHaveBeenCalledWith([12, 40, 12]);
   });

--- a/src/components/lists/list-item-row.tsx
+++ b/src/components/lists/list-item-row.tsx
@@ -1,4 +1,4 @@
-import { Check, Pencil, Trash2 } from "lucide-react";
+import { Check, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { haptics } from "@/lib/haptics";
 import type { ListItem } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -9,6 +9,10 @@ interface ListItemRowProps {
   onToggle: (completed: boolean) => void;
   onEdit: () => void;
   onDelete: () => void;
+  /** Passed from the parent rather than read via hook so the row stays
+   * presentational and both branches are testable without a matchMedia shim. */
+  isLargeScreen?: boolean;
+  onOpenActions?: () => void;
 }
 
 export function ListItemRow({
@@ -16,6 +20,8 @@ export function ListItemRow({
   onToggle,
   onEdit,
   onDelete,
+  isLargeScreen,
+  onOpenActions,
 }: ListItemRowProps) {
   return (
     <div className="flex min-h-14 items-center gap-2 rounded-lg border border-border bg-card p-2 shadow-sm">
@@ -33,7 +39,7 @@ export function ListItemRow({
           if (!item.completed) haptics.success(); // completing transition only
           onToggle(!item.completed);
         }}
-        className="flex min-w-0 flex-1 items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:min-h-11"
+        className="flex min-h-11 min-w-0 flex-1 items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       >
         <span
           className={cn(
@@ -56,26 +62,38 @@ export function ListItemRow({
           {item.text}
         </span>
       </button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={onEdit}
-        className="lg:min-h-11 lg:min-w-11"
-      >
-        <Pencil className="h-4 w-4" />
-        <span className="sr-only">Edit</span>
-      </Button>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={onDelete}
-        className="lg:min-h-11 lg:min-w-11"
-      >
-        <Trash2 className="h-4 w-4" />
-        <span className="sr-only">Delete</span>
-      </Button>
+      {/* Two 44px icons would eat ~96px of a 390px row and leave a destructive
+          delete one thumb-slip from the toggle, so below lg they collapse into
+          a single overflow control. Its gate must match the actions sheet's
+          gate in list-detail-view exactly, or the 769-1023px band gets a
+          button that opens nothing. */}
+      {isLargeScreen ? (
+        <>
+          <Button type="button" variant="ghost" size="icon-lg" onClick={onEdit}>
+            <Pencil className="h-4 w-4" />
+            <span className="sr-only">Edit</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-lg"
+            onClick={onDelete}
+          >
+            <Trash2 className="h-4 w-4" />
+            <span className="sr-only">Delete</span>
+          </Button>
+        </>
+      ) : (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-lg"
+          aria-label={`More actions for ${item.text}`}
+          onClick={onOpenActions}
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/components/lists/list-item-sheet.tsx
+++ b/src/components/lists/list-item-sheet.tsx
@@ -332,7 +332,7 @@ export function ListItemSheet({
             onChange={(event) =>
               form.setValue("categoryId", event.target.value || null)
             }
-            className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="h-11 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="">Uncategorized</option>
             {list.categories.map((category) => (

--- a/src/components/lists/list-options-controls.test.tsx
+++ b/src/components/lists/list-options-controls.test.tsx
@@ -95,22 +95,32 @@ describe("ListOptionsControls — Manage categories entry", () => {
 });
 
 describe("ListOptionsControls — large-screen touch targets", () => {
-  it("sizes every interactive option control to at least 44px at lg", () => {
+  it("sizes every interactive option control to at least 44px at every width", () => {
     renderControls({ clearCompletedDisabled: false });
 
-    expect(screen.getByLabelText("Categories")).toHaveClass("lg:min-h-11");
-    expect(screen.getByLabelText("Completed items")).toHaveClass("lg:min-h-11");
+    // The selects carry the height directly; the rest use min-h-11. None may be
+    // lg:-conditional — that pattern is what left phones at 36-40px.
+    expect(screen.getByLabelText("Categories")).toHaveClass("h-11");
+    expect(screen.getByLabelText("Completed items")).toHaveClass("h-11");
     expect(
       screen.getByRole("button", { name: /manage categories/i }),
-    ).toHaveClass("lg:min-h-11");
+    ).toHaveClass("min-h-11");
 
     const familyDefaultCheckbox = screen.getByRole("checkbox", {
       name: /show completed by default/i,
     });
-    expect(familyDefaultCheckbox.closest("label")).toHaveClass("lg:min-h-11");
+    expect(familyDefaultCheckbox.closest("label")).toHaveClass("min-h-11");
 
     expect(
       screen.getByRole("button", { name: /remove all completed/i }),
-    ).toHaveClass("lg:min-h-11");
+    ).toHaveClass("min-h-11");
+
+    for (const el of [
+      screen.getByLabelText("Categories"),
+      screen.getByRole("button", { name: /manage categories/i }),
+      screen.getByRole("button", { name: /remove all completed/i }),
+    ]) {
+      expect(el.className).not.toContain("lg:min-h-11");
+    }
   });
 });

--- a/src/components/lists/list-options-controls.tsx
+++ b/src/components/lists/list-options-controls.tsx
@@ -96,7 +96,6 @@ export function ListOptionsControls({
                 onClick={onManageCategories}
                 disabled={!categoriesOnline}
                 aria-label="Manage categories"
-                className="min-h-11"
               >
                 <Settings className="h-4 w-4" />
                 Manage categories

--- a/src/components/lists/list-options-controls.tsx
+++ b/src/components/lists/list-options-controls.tsx
@@ -74,7 +74,7 @@ export function ListOptionsControls({
                 showCompletedOverride: list.showCompletedOverride,
               })
             }
-            className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:min-h-11"
+            className="h-11 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="grouped" disabled={list.categories.length === 0}>
               Show categories
@@ -96,7 +96,7 @@ export function ListOptionsControls({
                 onClick={onManageCategories}
                 disabled={!categoriesOnline}
                 aria-label="Manage categories"
-                className="lg:min-h-11"
+                className="min-h-11"
               >
                 <Settings className="h-4 w-4" />
                 Manage categories
@@ -125,7 +125,7 @@ export function ListOptionsControls({
                     : event.target.value === "show",
               })
             }
-            className="h-10 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:min-h-11"
+            className="h-11 w-full rounded-lg border border-input bg-background px-3 text-[15px] leading-5 shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <option value="family-default">
               Family default (
@@ -155,7 +155,7 @@ export function ListOptionsControls({
       >
         <label
           htmlFor="family-completed-default"
-          className="flex items-center gap-2 text-sm font-medium text-foreground lg:min-h-11"
+          className="flex items-center gap-2 text-sm font-medium text-foreground min-h-11"
         >
           <input
             id="family-completed-default"
@@ -176,7 +176,7 @@ export function ListOptionsControls({
           variant="outline"
           onClick={onClearCompleted}
           disabled={clearCompletedDisabled}
-          className={cn("lg:min-h-11", fullWidthClearButton && "w-full")}
+          className={cn("min-h-11", fullWidthClearButton && "w-full")}
         >
           <Trash2 className="h-4 w-4" />
           Remove all completed

--- a/src/components/meals/meal-composer-sheet.tsx
+++ b/src/components/meals/meal-composer-sheet.tsx
@@ -302,7 +302,7 @@ export function MealComposerSheet({
                 <input
                   value={mealName}
                   onChange={(event) => setMealName(event.target.value)}
-                  className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+                  className="h-11 w-full rounded-lg border border-input bg-background px-3 text-sm"
                 />
               </label>
               <label className="block space-y-1">
@@ -312,7 +312,7 @@ export function MealComposerSheet({
                 <input
                   value={imageUrl}
                   onChange={(event) => setImageUrl(event.target.value)}
-                  className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+                  className="h-11 w-full rounded-lg border border-input bg-background px-3 text-sm"
                 />
               </label>
               <label className="block space-y-1">

--- a/src/components/meals/meal-move-picker.tsx
+++ b/src/components/meals/meal-move-picker.tsx
@@ -81,7 +81,7 @@ export function MealMovePicker({
               aria-label="Day"
               value={dayIndex}
               onChange={(event) => setDayIndex(Number(event.target.value))}
-              className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+              className="h-11 w-full rounded-lg border border-input bg-background px-3 text-sm"
             >
               {board.days.map((day) => (
                 <option key={day.dayIndex} value={day.dayIndex}>
@@ -96,7 +96,7 @@ export function MealMovePicker({
               aria-label="Meal"
               value={mealType}
               onChange={(event) => setMealType(event.target.value as MealType)}
-              className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+              className="h-11 w-full rounded-lg border border-input bg-background px-3 text-sm"
             >
               {MEAL_TYPES.map((type) => (
                 <option key={type} value={type}>

--- a/src/components/meals/meal-planning-panel.tsx
+++ b/src/components/meals/meal-planning-panel.tsx
@@ -553,7 +553,7 @@ export function MealPlanningPanel({
                   aria-describedby={
                     quickMealError ? mealNameErrorId : undefined
                   }
-                  className="h-10 w-full rounded-lg border border-input bg-background px-3 text-sm"
+                  className="h-11 w-full rounded-lg border border-input bg-background px-3 text-sm"
                 />
                 {quickMealError ? (
                   <p

--- a/src/components/meals/week-header.tsx
+++ b/src/components/meals/week-header.tsx
@@ -70,7 +70,7 @@ export function WeekHeader({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon-lg"
             aria-label="Previous week"
             onClick={() =>
               onWeekChange(formatLocalDate(addWeeksLocal(currentStart, -1)))
@@ -81,7 +81,7 @@ export function WeekHeader({
           <Button
             type="button"
             variant="ghost"
-            size="icon-sm"
+            size="icon-lg"
             aria-label="Next week"
             onClick={() =>
               onWeekChange(formatLocalDate(addWeeksLocal(currentStart, 1)))

--- a/src/components/recipes-view.test.tsx
+++ b/src/components/recipes-view.test.tsx
@@ -265,9 +265,14 @@ describe("RecipesView", () => {
     expect(toolbar).toContainElement(add);
     expect(screen.getAllByTestId("recipe-filter-bar")).toHaveLength(1);
     expect(screen.getByTestId("recipe-filter-bar")).toHaveClass("lg:flex");
-    expect(search).toHaveClass("lg:h-11");
-    expect(favorites).toHaveClass("lg:min-h-11");
-    expect(add).toHaveClass("lg:min-h-11");
+    // 44px at every width, not only at lg: the tablet band renders this same
+    // toolbar and gets none of the lg: rules.
+    expect(search).toHaveClass("h-11");
+    expect(favorites).toHaveClass("min-h-11");
+    expect(add).toHaveClass("min-h-11");
+    for (const el of [search, favorites, add]) {
+      expect(el.className).not.toMatch(/\blg:(min-)?h-11\b/);
+    }
   });
 
   it("opens recipe detail from the library with cook-first content order and returns back", async () => {

--- a/src/components/recipes-view.tsx
+++ b/src/components/recipes-view.tsx
@@ -207,7 +207,7 @@ export function RecipesView() {
             {selectedRecipeId === null ? (
               <Button
                 type="button"
-                className="ml-auto lg:min-h-11"
+                className="ml-auto min-h-11"
                 onClick={() => setIsCreateSheetOpen(true)}
               >
                 Add recipe

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -55,7 +55,7 @@ export function RecipeFilterBar({
           variant={favoritesOnly ? "default" : "outline"}
           size="sm"
           onClick={() => onFavoritesOnlyChange(!favoritesOnly)}
-          className="shrink-0 min-h-11 min-w-11"
+          className="shrink-0 min-w-11"
         >
           <Heart className={cn("h-4 w-4", favoritesOnly && "fill-current")} />
           Favorites only
@@ -66,7 +66,7 @@ export function RecipeFilterBar({
           variant={selectedTag === null ? "secondary" : "outline"}
           size="sm"
           onClick={() => onTagChange(null)}
-          className="shrink-0 min-h-11 min-w-11"
+          className="shrink-0 min-w-11"
         >
           All
         </Button>
@@ -80,7 +80,7 @@ export function RecipeFilterBar({
             onClick={() =>
               onTagChange(selectedTag === tag.value ? null : tag.value)
             }
-            className="shrink-0 min-h-11 min-w-11"
+            className="shrink-0 min-w-11"
           >
             {tag.label}
           </Button>

--- a/src/components/recipes/recipe-filter-bar.tsx
+++ b/src/components/recipes/recipe-filter-bar.tsx
@@ -45,7 +45,7 @@ export function RecipeFilterBar({
           value={searchValue}
           onChange={(event) => onSearchChange(event.target.value)}
           placeholder="Search titles or tags"
-          className="pl-9 lg:h-11"
+          className="pl-9"
         />
       </div>
 
@@ -55,7 +55,7 @@ export function RecipeFilterBar({
           variant={favoritesOnly ? "default" : "outline"}
           size="sm"
           onClick={() => onFavoritesOnlyChange(!favoritesOnly)}
-          className="shrink-0 lg:min-h-11"
+          className="shrink-0 min-h-11 min-w-11"
         >
           <Heart className={cn("h-4 w-4", favoritesOnly && "fill-current")} />
           Favorites only
@@ -66,7 +66,7 @@ export function RecipeFilterBar({
           variant={selectedTag === null ? "secondary" : "outline"}
           size="sm"
           onClick={() => onTagChange(null)}
-          className="shrink-0 lg:min-h-11"
+          className="shrink-0 min-h-11 min-w-11"
         >
           All
         </Button>
@@ -80,7 +80,7 @@ export function RecipeFilterBar({
             onClick={() =>
               onTagChange(selectedTag === tag.value ? null : tag.value)
             }
-            className="shrink-0 lg:min-h-11"
+            className="shrink-0 min-h-11 min-w-11"
           >
             {tag.label}
           </Button>

--- a/src/components/settings/family-settings-modal.tsx
+++ b/src/components/settings/family-settings-modal.tsx
@@ -128,7 +128,7 @@ export function FamilySettingsModal({
             size="icon"
             aria-label="Close"
             onClick={() => onOpenChange(false)}
-            className="h-8 w-8"
+            className="h-11 w-11"
           >
             <X className="h-4 w-4" />
           </Button>

--- a/src/components/settings/preferences-sheet.tsx
+++ b/src/components/settings/preferences-sheet.tsx
@@ -93,7 +93,7 @@ export function PreferencesSheet({
           size="icon"
           aria-label="Close"
           onClick={() => onOpenChange(false)}
-          className="h-8 w-8"
+          className="h-11 w-11"
         >
           <X className="h-4 w-4" />
         </Button>

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -80,7 +80,7 @@ export function AppHeader() {
               type="button"
               onClick={goToToday}
               className={cn(
-                "rounded-lg px-2.5 py-1.5 text-sm leading-5 font-semibold transition-colors",
+                "inline-flex min-h-11 items-center rounded-lg px-2.5 text-sm leading-5 font-semibold transition-colors",
                 isViewingToday
                   ? "text-primary/50"
                   : "text-primary hover:bg-primary/10",

--- a/src/components/shared/app-header.tsx
+++ b/src/components/shared/app-header.tsx
@@ -80,7 +80,11 @@ export function AppHeader() {
               type="button"
               onClick={goToToday}
               className={cn(
-                "inline-flex min-h-11 items-center rounded-lg px-2.5 text-sm leading-5 font-semibold transition-colors",
+                // -my-1 for the same reason as the Menu button beside it: the
+                // header row is min-h-16 with py-3, so a bare 44px control
+                // pushes it to 68px and the header would jump 4px whenever the
+                // Calendar module (the only one with a Today button) is opened.
+                "-my-1 inline-flex min-h-11 items-center rounded-lg px-2.5 text-sm leading-5 font-semibold transition-colors",
                 isViewingToday
                   ? "text-primary/50"
                   : "text-primary hover:bg-primary/10",

--- a/src/components/ui/button.test.tsx
+++ b/src/components/ui/button.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { Button } from "./button";
+import { Button, buttonSizes, buttonVariants } from "./button";
 
 describe("Button press feedback", () => {
   it("carries the pressable class", () => {
@@ -16,5 +16,30 @@ describe("Button press feedback", () => {
       .getByRole("button")
       .dispatchEvent(new Event("pointerdown", { bubbles: true }));
     expect(onPointerDown).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Button touch targets", () => {
+  // Enumerated from the exported variant map, not a hand-kept list, so adding a
+  // size without a 44px height fails here instead of shipping. The h-9 `sm`
+  // variant is what this catches.
+  const sizes = Object.keys(buttonSizes) as (keyof typeof buttonSizes)[];
+
+  it("enumerates every declared size", () => {
+    // Guards the line above: if buttonSizes were ever emptied or renamed, the
+    // loop below would pass vacuously.
+    expect(sizes).toEqual(
+      expect.arrayContaining(["default", "sm", "lg", "icon"]),
+    );
+  });
+
+  it.each(sizes)("sizes %s at the 44px minimum", (size) => {
+    // h-11 / min-h-11 / size-11 are the 44px spellings; anything else (h-9,
+    // h-10, size-9) leaves a control short of the PRD minimum.
+    expect(buttonVariants({ size })).toMatch(/\b(?:min-h-11|h-11|size-11)\b/);
+  });
+
+  it("has no compact icon variant left to reach for", () => {
+    expect(sizes).not.toContain("icon-sm");
   });
 });

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -27,10 +27,10 @@ const buttonVariants = cva(
       // are for pointer-only affordances that never render below lg.
       // Enforced by src/test/touch-target-rule.test.ts and e2e/touch-targets.spec.ts.
       size: {
-        default: "h-10 px-4 py-2 has-[>svg]:px-3",
+        default: "h-11 px-4 py-2 has-[>svg]:px-3",
         sm: "h-9 rounded-lg gap-1.5 px-3 text-sm has-[>svg]:px-2.5",
         lg: "h-11 rounded-xl px-6 text-base has-[>svg]:px-4",
-        icon: "size-10",
+        icon: "size-11",
         "icon-sm": "size-9",
         "icon-lg": "size-11",
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,6 +5,16 @@ import type * as React from "react";
 import { usePressable } from "@/hooks";
 import { cn } from "@/lib/utils";
 
+/** Exported so button.test.tsx can enumerate the real variants rather than a
+ * hand-kept copy that drifts the moment someone adds a size. */
+const buttonSizes = {
+  default: "h-11 px-4 py-2 has-[>svg]:px-3",
+  sm: "min-h-11 rounded-lg gap-1.5 px-3 text-sm has-[>svg]:px-2.5",
+  lg: "h-11 rounded-xl px-6 text-base has-[>svg]:px-4",
+  icon: "size-11",
+  "icon-lg": "size-11",
+} as const;
+
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-[15px] leading-none font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
@@ -22,26 +32,27 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       // Touch-target rule (PRD prd.md:815/827): any control reachable on a touch
-      // device must be >= 44x44px at EVERY width, not only at lg:. `default`,
-      // `lg` and `icon`/`icon-lg` all meet it on their own, so they are the safe
-      // choices below lg.
+      // device must be >= 44x44px at EVERY width, not only at lg:. EVERY size
+      // variant meets it, so there is no wrong choice here and no rule to
+      // remember.
       //
-      // `sm` (h-9) and `icon-sm` (size-9) are BELOW the minimum by design — they
-      // are compact variants for dense pointer-oriented chrome. They are not
-      // banned, but any use that can render below 1024px must add its own
-      // `min-h-11` (and `min-w-11` for short labels); see recipe-filter-bar.tsx
-      // and list-options-controls.tsx.
+      // `sm` used to be h-9 with the rule "add your own min-h-11 below lg".
+      // That rule held at 6 of 35 call sites — the other 29 were sheet and
+      // modal chrome that only ever renders on a phone, and neither guard could
+      // see them. A variant nobody may safely use is not a variant; `sm` now
+      // means lighter type and tighter padding, not a shorter target. Same
+      // reasoning that moved `default`/`icon`/Input off h-10 rather than
+      // patching their call sites one at a time.
       //
-      // Enforced by src/test/touch-target-rule.test.ts (bans lg:-only sizing)
-      // and e2e/touch-targets.spec.ts (measures real boxes at 390px and 900px).
-      size: {
-        default: "h-11 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-9 rounded-lg gap-1.5 px-3 text-sm has-[>svg]:px-2.5",
-        lg: "h-11 rounded-xl px-6 text-base has-[>svg]:px-4",
-        icon: "size-11",
-        "icon-sm": "size-9",
-        "icon-lg": "size-11",
-      },
+      // `icon-sm` (size-9) is gone: it had no remaining uses.
+      //
+      // Width is still per-site — these set height, and a short label can leave
+      // a button under 44px wide. Add `min-w-11` (see recipe-filter-bar.tsx).
+      //
+      // Enforced by button.test.tsx (every variant >= 44px),
+      // src/test/touch-target-rule.test.ts (bans breakpoint-only sizing) and
+      // e2e/touch-targets.spec.ts (measures real boxes at 390px and 900px).
+      size: buttonSizes,
     },
     defaultVariants: {
       variant: "default",
@@ -81,4 +92,4 @@ function Button({
   );
 }
 
-export { Button, buttonVariants };
+export { Button, buttonSizes, buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,11 @@ const buttonVariants = cva(
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
+      // Touch-target rule (PRD prd.md:815/827): any control reachable on a touch
+      // device must be >= 44x44px at EVERY width, not only at lg:. Use `icon-lg`
+      // (size-11) for icon buttons and `min-h-11` for text controls. `icon-sm`/`sm`
+      // are for pointer-only affordances that never render below lg.
+      // Enforced by src/test/touch-target-rule.test.ts and e2e/touch-targets.spec.ts.
       size: {
         default: "h-10 px-4 py-2 has-[>svg]:px-3",
         sm: "h-9 rounded-lg gap-1.5 px-3 text-sm has-[>svg]:px-2.5",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,10 +22,18 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       // Touch-target rule (PRD prd.md:815/827): any control reachable on a touch
-      // device must be >= 44x44px at EVERY width, not only at lg:. Use `icon-lg`
-      // (size-11) for icon buttons and `min-h-11` for text controls. `icon-sm`/`sm`
-      // are for pointer-only affordances that never render below lg.
-      // Enforced by src/test/touch-target-rule.test.ts and e2e/touch-targets.spec.ts.
+      // device must be >= 44x44px at EVERY width, not only at lg:. `default`,
+      // `lg` and `icon`/`icon-lg` all meet it on their own, so they are the safe
+      // choices below lg.
+      //
+      // `sm` (h-9) and `icon-sm` (size-9) are BELOW the minimum by design — they
+      // are compact variants for dense pointer-oriented chrome. They are not
+      // banned, but any use that can render below 1024px must add its own
+      // `min-h-11` (and `min-w-11` for short labels); see recipe-filter-bar.tsx
+      // and list-options-controls.tsx.
+      //
+      // Enforced by src/test/touch-target-rule.test.ts (bans lg:-only sizing)
+      // and e2e/touch-targets.spec.ts (measures real boxes at 390px and 900px).
       size: {
         default: "h-11 px-4 py-2 has-[>svg]:px-3",
         sm: "h-9 rounded-lg gap-1.5 px-3 text-sm has-[>svg]:px-2.5",

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -6,6 +6,12 @@ import { cn } from "@/lib/utils";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
+/**
+ * Rendered by DatePicker inside the event form, i.e. on a phone. Day cells,
+ * month nav and the weekday header are all sized to the 44px touch minimum, and
+ * the header row heights follow so the absolutely-positioned nav still fits.
+ * 7 x 44px + p-3 = 332px, which clears a 390px viewport.
+ */
 function Calendar({
   className,
   classNames,
@@ -19,21 +25,21 @@ function Calendar({
       classNames={{
         months: "relative flex flex-col gap-4",
         month: "flex flex-col gap-4",
-        month_caption: "flex justify-center items-center h-7",
+        month_caption: "flex justify-center items-center h-11",
         caption_label: "text-sm font-medium",
-        nav: "absolute inset-x-0 top-0 flex items-center justify-between h-7 px-1",
+        nav: "absolute inset-x-0 top-0 flex items-center justify-between h-11 px-1",
         button_previous: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-7 w-7 p-0 opacity-70 hover:opacity-100",
+          "h-11 w-11 p-0 opacity-70 hover:opacity-100",
         ),
         button_next: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-7 w-7 p-0 opacity-70 hover:opacity-100",
+          "h-11 w-11 p-0 opacity-70 hover:opacity-100",
         ),
         month_grid: "w-full border-collapse",
         weekdays: "flex",
         weekday:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+          "text-muted-foreground rounded-md w-11 font-normal text-[0.8rem]",
         week: "flex w-full mt-2",
         day: cn(
           "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50",
@@ -43,7 +49,7 @@ function Calendar({
         ),
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100",
+          "h-11 w-11 p-0 font-normal aria-selected:opacity-100",
         ),
         range_start: "day-range-start rounded-l-md",
         range_end: "day-range-end rounded-r-md",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-10 w-full min-w-0 rounded-lg border bg-transparent px-3 py-2 text-[15px] leading-5 shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-11 w-full min-w-0 rounded-lg border bg-transparent px-3 py-2 text-[15px] leading-5 shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/src/components/ui/mobile-sheet.tsx
+++ b/src/components/ui/mobile-sheet.tsx
@@ -251,7 +251,15 @@ export function MobileSheet({
             >
               {title}
             </Drawer.Title>
-            {headerRight ?? <div className="w-16" />}
+            {/* -my-2 for the same reason as the cancel button above: header
+                actions are 44px tall, but the row is py-3 around a 28px title.
+                Without absorbing the overflow into the padding, every sheet
+                with a headerRight action sits 16px taller than one without. */}
+            {headerRight ? (
+              <div className="-my-2 flex items-center">{headerRight}</div>
+            ) : (
+              <div className="w-16" />
+            )}
           </div>
 
           <div

--- a/src/components/ui/mobile-sheet.tsx
+++ b/src/components/ui/mobile-sheet.tsx
@@ -222,7 +222,7 @@ export function MobileSheet({
                   }
                   setSnap(isExpanded ? HALF_SNAP : FULL_SNAP);
                 }}
-                className="-my-2 rounded-full px-6 py-3"
+                className="-my-2 flex min-h-11 min-w-11 items-center justify-center rounded-full px-6"
               >
                 <span className="block h-1.5 w-10 rounded-full bg-muted-foreground/25" />
               </button>
@@ -238,7 +238,7 @@ export function MobileSheet({
             <button
               type="button"
               onClick={onCancel ?? onClose}
-              className="rounded-lg px-1 py-1 text-sm font-semibold text-primary"
+              className="-my-2 inline-flex min-h-11 min-w-11 items-center rounded-lg px-1 text-sm font-semibold text-primary"
             >
               {cancelLabel}
             </button>

--- a/src/test/touch-target-rule.test.ts
+++ b/src/test/touch-target-rule.test.ts
@@ -4,19 +4,26 @@ import { join } from "node:path";
 /** Conditional 44px sizing is the defect this rule exists to prevent: a control
  * sized correctly at lg: while staying 32-40px on the phones the family uses.
  * If a genuine large-screen enhancement needs one of these, it must sit on top of
- * a base that already meets 44px — add the file to ALLOWED with a reason. */
-const BANNED = /\blg:(?:min-)?[hw]-11\b/;
+ * a base that already meets 44px — add the file to ALLOWED with a reason.
+ *
+ * Every breakpoint prefix counts, not just `lg:` — `md:h-11` leaves phones just
+ * as short — and `size-11` is the same defect written the shorthand way. Both
+ * were reachable holes in the first version of this rule. */
+const BANNED = /\b(?:sm|md|lg|xl|2xl):(?:min-)?(?:size|[hw])-11\b/;
 const ALLOWED = new Set<string>([]);
 
 describe("touch-target rule", () => {
-  it("has no lg:-only 44px sizing left in components", () => {
-    const files = globSync("src/**/*.tsx", { cwd: process.cwd() }).filter(
+  it("has no breakpoint-only 44px sizing left in components", () => {
+    const files = globSync("src/**/*.{ts,tsx}", { cwd: process.cwd() }).filter(
       (f) => !f.includes(".test."),
     );
     const offenders = files.filter((f) => {
       if (ALLOWED.has(f)) return false;
       return BANNED.test(readFileSync(join(process.cwd(), f), "utf8"));
     });
-    expect(offenders, "files sizing touch targets only at lg:").toEqual([]);
+    expect(
+      offenders,
+      "files sizing touch targets only above a breakpoint",
+    ).toEqual([]);
   });
 });

--- a/src/test/touch-target-rule.test.ts
+++ b/src/test/touch-target-rule.test.ts
@@ -1,0 +1,22 @@
+import { globSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** Conditional 44px sizing is the defect this rule exists to prevent: a control
+ * sized correctly at lg: while staying 32-40px on the phones the family uses.
+ * If a genuine large-screen enhancement needs one of these, it must sit on top of
+ * a base that already meets 44px — add the file to ALLOWED with a reason. */
+const BANNED = /\blg:(?:min-)?[hw]-11\b/;
+const ALLOWED = new Set<string>([]);
+
+describe("touch-target rule", () => {
+  it("has no lg:-only 44px sizing left in components", () => {
+    const files = globSync("src/**/*.tsx", { cwd: process.cwd() }).filter(
+      (f) => !f.includes(".test."),
+    );
+    const offenders = files.filter((f) => {
+      if (ALLOWED.has(f)) return false;
+      return BANNED.test(readFileSync(join(process.cwd(), f), "utf8"));
+    });
+    expect(offenders, "files sizing touch targets only at lg:").toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements **Unit B** of the mobile daily-use polish spec — brings every interactive control below 1024px to the PRD's 44×44px minimum (`prd.md:815`, `:827`) and makes the `lg:`-only regression structurally impossible.

Unit A (#309) landed first as `291132a`; this branch builds on the `showCadence` variable it introduced.

Closes #310.

## Two guards, because one of them cannot work

- **Source-level** (`src/test/touch-target-rule.test.ts`) — bans `lg:(min-)?[hw]-11` outright, with an `ALLOWED` escape hatch for genuine large-screen enhancements on an already-compliant base. **`ALLOWED` is empty**: every offender turned out to sit on a sub-44px base.
- **Runtime** (`e2e/touch-targets.spec.ts`) — Playwright `boundingBox()` at **390px and 900px**. jsdom resolves no Tailwind, so class-string assertions are not proof of size; that is exactly how `lg:h-11` shipped while mobile sat at 36px.

`assertMinimumTargets` asserts a **non-zero match count** — a selector matching nothing is a silently green test. A freshly registered family has no chores and no lists, so the spec seeds a chore, a list and an item through the API helpers first, and registers **two** members so the 390px toolbar is measured under real width pressure.

The two bands render different controls, so the assertions differ: 390px uses `"Daily view"`…; 900px uses the desktop switcher's `"Day"`/`"Week"`/`"Month"`/`"Schedule"`. `ChoreScopeSwitcher` is `isMobile`-gated, so its pills are asserted below 769px only.

## §3.3.1 audit inventory

The guard's initial failure list, plus a full `boundingBox()` sweep of every interactive control on 8 module surfaces at both widths. All fixed unless noted.

### Source-level guard — initial failures (6 files, all cleared)

| File | Status |
|---|---|
| `chores/chore-row.tsx` | ✅ fixed |
| `lists/list-item-row.tsx` | ✅ fixed |
| `lists/list-detail-view.tsx` | ✅ fixed |
| `lists/list-options-controls.tsx` | ✅ fixed |
| `recipes-view.tsx` | ✅ fixed |
| `recipes/recipe-filter-bar.tsx` | ✅ fixed |

The plan predicted two; the other four were `lg:`-only sizing on `h-10`/`size="sm"` bases — real defects, not enhancements.

### Measured controls at 390px

| Surface | Control | Before | Fix |
|---|---|---|---|
| Calendar | Today (AppHeader) | 58×32 | ✅ `min-h-11` |
| Calendar | `D` `W` `M` `S` pills ×4 | 32×32 | ✅ `h-11 min-w-11` |
| Calendar | Member filter dots ×2 | 40×42 | ✅ `h-11 w-11` |
| Chores | Scope pills ×3 | 49/61/65×40 | ✅ `min-h-11` |
| Chores | Mark … complete | 36×36 | ✅ `h-11 w-11` |
| Chores | Archive … | 36×36 | ✅ `icon-lg` |
| List detail | Back to Lists | 135×40 | ✅ `Button` default → `h-11` |
| List detail | Item toggle | 252×40 | ✅ `min-h-11` |
| List detail | Edit / Delete | 36×36 | ✅ replaced by one 44px `⋯` |
| More sheet | Expand sheet | 88×30 | ✅ `min-h-11 min-w-11` |
| More sheet | Cancel | 51×28 | ✅ `min-h-11 min-w-11` |

### Measured controls at 900px (tablet band — desktop toolbar, no `lg:` rules)

| Surface | Control | Before | Fix |
|---|---|---|---|
| Calendar | `All` member chip | 38×44 | ✅ `min-w-11` |
| Chores | Add recurring chore | 40×40 | ✅ `Button` `icon` → `size-11` |
| Lists index | New List | 108×40 | ✅ `Button` default → `h-11` |
| List detail | Add item | 111×40 | ✅ `min-h-11` (was `lg:`-only) |
| List detail | Categories / Completed items selects | 313×40 | ✅ `h-11` |
| List detail | Manage categories | 164×36 | ✅ `min-h-11` |
| List detail | Remove all completed | 202×40 | ✅ `min-h-11` |
| Meals | Previous / Next week | 36×36 | ✅ `icon-lg` |
| Recipes | Search recipes | 768×40 | ✅ `Input` → `h-11` |
| Recipes | Favorites only | 133×36 | ✅ `min-h-11` |
| Recipes | All | 43×36 | ✅ `min-h-11 min-w-11` |
| Recipes | Add recipe / Add your first recipe | 106/171×40 | ✅ `min-h-11` |
| Meals | Fill empty slots | 140×40 | ✅ `Button` default → `h-11` |
| List detail | Show-completed **checkbox** | 16×16 | ⚠️ **decision, not fixed** — see below |

**The one deliberate exception.** The `Show completed by default` control is a native `<input type="checkbox">` at 16×16. Its tap target is the wrapping `<label>`, which is now `min-h-11` and full-row width, so the *reachable* target meets the minimum. Resizing the native checkbox glyph itself is a visual-design change, not a touch-ergonomics one, and is out of scope here.

### `icon-sm` / `sm` / `h-8` / `h-9` / `min-h-10` sweep decisions

- **Raised**: chore Archive, list Edit/Delete, all four category-manager controls (74, 88, 205, 216 — the first is `Rename …`, not "Edit"), meals week prev/next, chores scope switcher, `MobileSheet` chrome, the two 32px `h-8 w-8` close buttons in Preferences and Family Settings, `mobile-event-detail`'s Edit/Delete, and the category-manager desktop close (renders in the 769–1023px band).
- **Kept small, by design**: `sm` (h-9) and `icon-sm` (size-9) remain compact variants. They are **not** banned — the rule comment in `button.tsx` now states that any use which can render below 1024px must add its own `min-h-11`, and points at the two call sites that do. The earlier draft of that comment claimed these variants "never render below lg", which the sweep disproved; it has been corrected rather than left as a false rule.

### Scope boundary, stated honestly

The automated sweep covered 8 module surfaces (Home, Calendar, Chores, Lists index, List detail, Meals, Recipes, the More sheet) at 390px and 900px. Controls inside other modal/sheet surfaces were enumerated by grep and decided above, but were **not** individually measured in a browser.

## Structural changes

- **`Button` `default` `h-10`→`h-11` and `icon` `size-10`→`size-11`; `Input` `h-10`→`h-11`.** These were the systemic source of the 40px readings — a per-call-site fix would have left the *next* default button non-compliant. Per spec §5, controls with no prior `lg:` override legitimately grow at all widths; that is expected, not a regression.
- **Chore row**: the checkoff stays a **raw `<button>`** (`<Button>`/`usePressable` fires `haptics.tap()` on pointerdown and the 40ms throttle then swallows `haptics.success()`). The text block was promoted to a **sibling** `<button>` with its own `aria-label` — not a wrapper, which would nest the Archive button inside an interactive element. `<p>`→`<span>` because a `<button>` may not contain block content.
- **List rows**: one 44px `⋯` below `lg` opening a `MobileSheet`. The button and the sheet share **one** `useIsLargeScreen()` gate — using the file's existing `isMobile` for either would have given the 769–1023px band a control that opens nothing. The `⋯`→Edit path is a sheet→sheet handoff, sequenced through `restoreFocusOnClose` + `onAnimationEnd` with the same fallback timeout the category-manager handoff already uses. Inline Edit/Delete stay at `lg+`.

## Tests rewritten, not deleted

Five tests asserted the pattern being removed. Each now asserts the **unconditional** minimum and additionally asserts the `lg:` form is absent:

- `chore-row.test.tsx` — plus new coverage for row-body completion and Archive independence
- `list-item-row.test.tsx` — plus both overflow branches
- `list-detail-view.test.tsx`, `list-options-controls.test.tsx`, `recipes-view.test.tsx` (found by the guard, beyond the plan's two)

`list-item-row.test.tsx`'s three `{ name: /milk/i }` selectors — which an overflow labelled `"More actions for Milk"` also matches — were switched to exact matching. **`:117`, the shipped haptics double-pulse guard, keeps asserting `[12, 40, 12]` unchanged**; only its selector moved.

`lists-view.test.tsx` now drives Edit and Delete through the `⋯` sheet, giving the handoff real integration coverage.

## Verification

- `npm run lint` — clean (exit 0). One pre-existing `useOptionalChain` warning and a `biome.json` schema notice, both present on `291132a`.
- `npm test -- --run` — **1774 passed / 178 files**.
- `npm run build` — clean. `npm run check:bundle` — 90.7 kB gzip vs 96.0 kB budget.
- `haptics.test.ts` — passes **unchanged**, including *"coalesces a success that follows a tap on the same gesture"*.
- Both guards green at 390px **and** 900px.
- `npm run test:e2e -- --workers=1` against BE release `1.9.0` — **228 passed, 3 failed, 268 skipped**. All 3 failures are the single pre-existing test described below.

### ⚠️ Manual Android-back check: NOT performed

Contract item 14 requires a manual check on an installed Android PWA — `isAndroidBackContext()` needs `isStandalone() && !isIOS() && coarse`, which Playwright cannot reproduce. **I have no Android device, so this was not run and no result is recorded.** The new actions sheet is a `MobileSheet`, which already registers `useBackHandler`, so it should pop LIFO like the existing sheets — but that is an expectation, not a verified result. **This needs a human check on-device before merge.**

### Pre-existing failure, not from this branch

`large-screen-calendar-month.spec.ts:230` *"PageDown changes the visible month and restores the exact date"* fails on chromium, firefox and webkit. I verified it fails **identically on the base commit `291132a`** with none of this branch's changes applied. Unrelated to touch targets; not fixed here.
